### PR TITLE
AuthernticatorManagerProvider

### DIFF
--- a/src/authenticators/AuthenticatorManager.tsx
+++ b/src/authenticators/AuthenticatorManager.tsx
@@ -1,0 +1,244 @@
+import React, { createContext, useContext, useRef } from "react";
+import { AuthenticatorComponent, AuthenticatorData, AuthenticatorMethod, AuthenticatorMethods, AuthenticatorRef } from ".";
+import { get, includes, isNull, isUndefined, map, mapValues, pickBy } from "lodash";
+import authenticators from "./authenticators";
+
+type AuthenticatorPermissions = {
+  [fidgetId: string]: string[];
+};
+
+type AuthenticatorConfig = {
+  [authenticatorName: string]: {
+    data: AuthenticatorData;
+    permissions: AuthenticatorPermissions;
+  };
+};
+
+type AuthenticatorManagerProviderProps = {
+  children: React.ReactNode;
+  authenticatorConfig: AuthenticatorConfig;
+  saveAuthenticatorConfig: (newConfig: AuthenticatorConfig) => Promise<void>;
+};
+
+type AuthenticatorManagerAllowedResponse<R = unknown> = {
+  result: "success";
+  value: R;
+};
+type AuthenticatorManagerDeniedResponse = {
+  result: "error";
+  reason: "denied";
+};
+type AuthenticatorManagerFailedResponse = {
+  result: "error";
+  reason: "failed";
+  value: unknown; // Place the error that the method resulted in here
+};
+type AuthenticatorManagerUnknownMethodResponse = {
+  result: "error";
+  reason: "unknownMethod";
+};
+
+type AuthenticatorManagerResponse = AuthenticatorManagerAllowedResponse 
+  | AuthenticatorManagerFailedResponse 
+  | AuthenticatorManagerDeniedResponse
+  | AuthenticatorManagerUnknownMethodResponse;
+
+type AuthenticatorPermissionRequest = {
+  authenticatorName: string;
+  methods: {
+    required: boolean;
+    name: string;
+    description?: string;
+  }[];
+};
+
+type AuthenticatorPermissionResponse = {
+  authenticatorName: string;
+  methods: string[];
+};
+
+// TO DO: Define FidgetId Type (with information about UUID + Space is installed in + Fidget Name)
+
+type AuthenticatorManager = {
+  // If Authenticator is not initialized, will always return denied
+  callMethod: (
+    requestingFidgetId: string,
+    authenticatorName: string,
+    methodName: string,
+    ...args: any[]
+  ) => Promise<AuthenticatorManagerResponse>;
+  // If Authenticator is not initialized, it will initialize it before asking
+  // the user to grant the permission to the Fidget
+  requestPermissions: (requestingFidgetId: string, permissionsRequested: AuthenticatorPermissionRequest[]) => 
+    Promise<AuthenticatorPermissionResponse[]>;
+  // If Authenticator is not initialized, returns an empty array
+  grantedPermissions: (requestingFidgetId: string) => Promise<AuthenticatorPermissionResponse[]>;
+  openManagementPanel: () => void;
+};
+
+// type InitializerRecord<D> = {
+//   Initalizer: AuthenticatorInitializer<D>;
+//   authenticatorName: string;
+// };
+
+const AuthenticatorContext = createContext<AuthenticatorManager | null>(null);
+
+function authenticatorForName(name: string): AuthenticatorComponent<
+  AuthenticatorData,
+  AuthenticatorMethods<AuthenticatorData>
+> | undefined {
+  const lookups = name.replace(":", ".");
+  return get(authenticators, lookups);
+}
+
+export const AuthenticatorManagerProvider: React.FC<AuthenticatorManagerProviderProps> = ({
+  authenticatorConfig,
+  saveAuthenticatorConfig,
+  children
+}) => {
+  const installedAuthenticators = mapValues(
+    authenticatorConfig,
+    (config, authenticatorName) => {
+      const component = authenticatorForName(authenticatorName);
+      if (isUndefined(component)) return {
+        component: null,
+        ref: null,
+        config,
+      };
+      type ComponentMethods<X> = X extends AuthenticatorComponent<any, infer M> ? M : never;
+      return {
+        component,
+        ref: useRef<AuthenticatorRef<
+          typeof config.data,
+          ComponentMethods<typeof component>
+        >>(null),
+        config,
+      };
+    }
+  );
+
+  // const [currentInitializer, setCurrentInitializer] = useState<InitializerRecord<unknown>>();
+  // const [showModal, setShowModal] = useState(false);
+  const authenticatorManager = useRef<AuthenticatorManager>();
+
+  if (isUndefined(authenticatorManager.current)) {
+    authenticatorManager.current = {
+      callMethod: async (
+        requestingFidgetId: string,
+        authenticatorName: string,
+        methodName: string,
+        ...args: any[]
+      ) => {
+        const authenticator = installedAuthenticators[authenticatorName];
+        if (isUndefined(authenticator) || isNull(authenticator.ref)) {
+          return {
+            result: "error",
+            reason: "denied"
+          };
+        }
+        const allowedMethods = authenticator.config.permissions[requestingFidgetId] || [];
+        if (!includes(allowedMethods, methodName)) {
+          return {
+            result: "error",
+            reason: "denied"
+          };
+        }
+        try {
+          const method = authenticator.ref[methodName] as AuthenticatorMethod;
+          if (isUndefined(method)) {
+            return {
+              result: "error",
+              reason: "unknownMethod",
+            };
+          }
+          return {
+            result: "success",
+            value: await method(...args),
+          };
+        } catch (e) {
+          return {
+            result: "error",
+            reason: "failed",
+            value: e,
+          };
+        }
+      },
+      requestPermissions: async (requestingFidgetId, permissionsRequested) => {
+        return [];
+      },
+      grantedPermissions: async (requestingFidgetId) => {
+        // TO DO: Change this to support permission grants to spaces or Fidget types, not just single instances
+        return map(
+          // Get all of the auth configs that contain the figet ID
+          pickBy(authenticatorConfig, conf => includes(conf.permissions, [requestingFidgetId])),
+          // Map these configs into the return type
+          (config, authenticatorName) => {
+            return {
+              authenticatorName,
+              methods: config.permissions[requestingFidgetId],
+            };
+          },
+        );
+      },
+      openManagementPanel: () => undefined,
+    };
+  }
+
+  function saveSingleAuthenticatorData(authenticatorName, config) {
+    return (data) => saveAuthenticatorConfig({
+      ...authenticatorConfig,
+      [authenticatorName]: {
+        permissions: config.permissions,
+        data,
+      },
+    });
+  }
+
+  // function initializationCompleted() {
+  //   setCurrentInitializer(undefined);
+  //   setShowModal(false);
+  // }
+
+  return (
+    <AuthenticatorContext.Provider value={authenticatorManager.current}>
+      {
+        map(
+          installedAuthenticators,
+          ({ component, ref, config }, authenticatorName) => component ? React.createElement(
+            component,
+            {
+              ref,
+              data: config.data,
+              saveData: saveSingleAuthenticatorData(authenticatorName, config),
+            }
+          ) : null
+        )
+      }
+      {/* <Modal open={showModal} setOpen={setShowModal}>
+        {
+          !isUndefined(currentInitializer) ?
+          <currentInitializer.Initalizer
+            data={authenticatorConfig[currentInitializer.authenticatorName]}
+            saveData={saveSingleAuthenticatorData(
+              currentInitializer.authenticatorName,
+              authenticatorConfig[currentInitializer.authenticatorName]
+            )}
+            done={initializationCompleted}
+          /> :
+          null
+        }
+      </Modal> */}
+      { children }
+    </AuthenticatorContext.Provider>
+  );
+};
+
+export function useAuthenticatorManager() {
+  const context = useContext(AuthenticatorContext);
+
+  if (!context) {
+    throw new Error(`useAuthenticatorManager must be use within AuthenticatorManagerProvider`)
+  }
+
+  return context;
+}

--- a/src/authenticators/authenticators.ts
+++ b/src/authenticators/authenticators.ts
@@ -1,0 +1,5 @@
+import farcaster from "./farcaster/signers";
+
+export default {
+  farcaster,
+};

--- a/src/authenticators/farcaster/signers/NounspaceManagedSignerAuthenticator.tsx
+++ b/src/authenticators/farcaster/signers/NounspaceManagedSignerAuthenticator.tsx
@@ -52,6 +52,9 @@ const retrieveSignerData = (data) => {
 }
 
 const methods: FarcasterSignerAuthenticatorMethods<NounspaceDeveloperManagedSignerData> = {
+  isReady: (data) => {
+    return async () => data.status === "completed" && !isUndefined(data.publicKeyHex) && !isUndefined(data.privateKeyHex);
+  },
   signMessage: (data) => {
     return async (messageHash: Uint8Array) => {
       if (isUndefined(data.publicKeyHex) || isUndefined(data.privateKeyHex)) {
@@ -185,7 +188,7 @@ const initializer: AuthenticatorInitializer<NounspaceDeveloperManagedSignerData>
   );
 };
 
-export default createAuthenticator<
+const auth = createAuthenticator<
   NounspaceDeveloperManagedSignerData,
   FarcasterSignerAuthenticatorMethods<NounspaceDeveloperManagedSignerData>
 >(
@@ -193,3 +196,5 @@ export default createAuthenticator<
   methods,
   initializer
 );
+
+export default auth;

--- a/src/authenticators/index.tsx
+++ b/src/authenticators/index.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef, useImperativeHandle } from "react";
 
 type SaveDataFunction<D> = (data: D) => Promise<void>;
 
-type AuthenticatorMethod = (...args: any[]) => Promise<unknown>;
+export type AuthenticatorMethod = (...args: any[]) => Promise<unknown>;
 
 export type AuthenticatorMethodWrapper<
   F extends AuthenticatorMethod,
@@ -15,6 +15,7 @@ type AuthenticatorMethodsWithData<M> = {
 };
 
 export interface AuthenticatorMethods<D extends AuthenticatorData> {
+  isReady: AuthenticatorMethodWrapper<() => Promise<boolean>, D>;
   [key: string]: AuthenticatorMethodWrapper<AuthenticatorMethod, D>;
 }
 
@@ -42,12 +43,20 @@ export type AuthenticatorRef<D extends AuthenticatorData, M extends Authenticato
   AuthenticatorMethodsWithData<M> & { initializer: AuthenticatorInitializer<D> }
 );
 
+export type AuthenticatorComponent<
+  D extends AuthenticatorData,
+  M extends AuthenticatorMethods<D>
+> = React.ForwardRefExoticComponent<
+  AuthenticatorProps<D> & React.RefAttributes<AuthenticatorRef<D, M>>
+>;
+
 export function createAuthenticator<D extends AuthenticatorData, M extends AuthenticatorMethods<D>>(
   name: string,
   methods: M,
   initializerComponent: AuthenticatorInitializer<D>,
- ) {
-    /**
+ ): AuthenticatorComponent<D, M> {
+  /**
+   * This is a code factor function that takes in the methods that a specific
    * This is a code factory function that takes in the methods that a specific
    * authenticator needs to function, and turns it into a component that
    * the AuthenticatorManager can add to the DOM and reference.
@@ -58,7 +67,7 @@ export function createAuthenticator<D extends AuthenticatorData, M extends Authe
    * @param  {M} methods  The methods that a developer can call for this authenticator
    * @param  {AuthenticatorInitializer<D>} initializerComponent A component that allows the user
    * to register sensative data for the Authenticator
-   * @return {unknown}  A component that can be used 
+   * @return {AuthenticatorComponent<D, M>}  A component that can be used
    */
   const authenticator = forwardRef<
     AuthenticatorRef<D, M>,
@@ -79,16 +88,3 @@ export function createAuthenticator<D extends AuthenticatorData, M extends Authe
   authenticator.displayName = name;
   return authenticator;
 }
-
-type AuthenticatorManagerProviderProps = {
-  children: React.ReactNode;
-};
-
-export const AuthenticatorManagerProvider: React.FC<AuthenticatorManagerProviderProps> = ({ children }) => {
-
-  return (
-    <>
-      { children }
-    </>
-  );
-};

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -1,4 +1,3 @@
-"use client"
 import React, { useState } from "react";
 import { Card, CardContent } from "../ui/atoms/card";
 import { Button } from "../ui/atoms/button";

--- a/src/common/ui/templates/Space.tsx
+++ b/src/common/ui/templates/Space.tsx
@@ -1,4 +1,4 @@
-import { FidgetConfig, FidgetSettings, LayoutFidgetDetails } from '@/common/fidgets';
+import { FidgetConfig, FidgetSettings, LayoutFidgetConfig, LayoutFidgetDetails } from '@/common/fidgets';
 import React from 'react';
 import { CompleteFidgets, LayoutFidgets } from '@/fidgets';
 import { mapValues } from 'lodash';
@@ -20,7 +20,7 @@ type SpaceArgs = {
   config: SpaceConfig;
   isEditable: boolean;
   saveConfig: (config: SpaceConfig) => Promise<boolean>;
-} 
+}
 
 export default function Space({ config, isEditable, saveConfig }: SpaceArgs){
   const LayoutFidget = LayoutFidgets[config.layoutDetails.layoutFidget];
@@ -50,7 +50,7 @@ export default function Space({ config, isEditable, saveConfig }: SpaceArgs){
     },
   }));
 
-  function saveLayout(layout) {
+  function saveLayout(layout: LayoutFidgetConfig) {
     return saveConfig({
       layoutID: config.layoutID,
       fidgetConfigs: config.fidgetConfigs,

--- a/src/pages/link-farcaster.tsx
+++ b/src/pages/link-farcaster.tsx
@@ -31,24 +31,20 @@ export default function LinkFarcaster() {
   }, [isMounted, router.query]);
 
   return (
-      <div className="w-full max-w-full min-h-screen">
-        <div
-          className="relative w-full h-screen flex-col items-center grid lg:max-w-none lg:grid-cols-2 lg:px-0"
-        >
-          <div className="relative h-full flex-col bg-muted p-10 text-foreground flex">
-            <div className="absolute inset-0 bg-gradient-to-t lg:bg-gradient-to-l from-gray-900 via-gray-700 to-stone-500" />
-            <div className="relative z-20 mt-16 lg:mt-24">
-              <NounspaceFarcasterAuthenticator ref={authenticatorRef} data={data} saveData={saveDataAsync} />
-              {
-                isMounted() ? (
-                  !done && AuthComponent ?
-                  <AuthComponent data={data} saveData={saveDataAsync} done={() => setDone(true)}/> :
-                  "SUCCESSFULLY CONNECTED FARCASTER"
-                ) : "Loading..."
-              }
-            </div>
-          </div>
+    <div className="w-full max-w-full min-h-screen">
+      <div className="absolute inset-0 bg-gradient-to-t lg:bg-gradient-to-l from-gray-900 via-gray-700 to-stone-500" />
+      <div className="flex justify-center">
+        <div className="relative z-20 mt-16 lg:mt-24">
+          <NounspaceFarcasterAuthenticator ref={authenticatorRef} data={data} saveData={saveDataAsync} />
+          {
+            isMounted() ? (
+              !done && AuthComponent ?
+              <AuthComponent data={data} saveData={saveDataAsync} done={() => setDone(true)}/> :
+              "SUCCESSFULLY CONNECTED FARCASTER"
+            ) : "Loading..."
+          }
         </div>
       </div>
+    </div>
   );
 }


### PR DESCRIPTION
Initial set up the `AuthernticatorManagerProvider`. There is a chunk of code in here that has been commented out, but not deleted because it is relevant to permission management. We are cutting all of the permission management scope out of the MVP and will add it in down the line