### PR TITLE
feat: add useWindowSize hook to track window size

### DIFF
--- a/src/common/lib/hooks/useWindowSize.ts
+++ b/src/common/lib/hooks/useWindowSize.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from "react";
+
+// Adapted from 
+// https://stackoverflow.com/questions/63406435/how-to-detect-window-size-in-next-js-ssr-using-react-hook
+
+type WindowSize = {
+  width: number;
+  height: number;
+}
+
+export default function useWindowSize() {
+  // Initialize state with undefined width/height so server and client renders match
+  // Learn more here: https://joshwcomeau.com/react/the-perils-of-rehydration/
+  const [windowSize, setWindowSize] = useState<WindowSize>();
+
+  useEffect(() => {
+    // only execute all the code below in client side
+    // Handler to call on window resize
+    function handleResize() {
+      // Set window width/height to state
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+    
+    // Add event listener
+    window.addEventListener("resize", handleResize);
+     
+    // Call handler right away so state gets updated with initial window size
+    handleResize();
+    
+    // Remove event listener on cleanup
+    return () => window.removeEventListener("resize", handleResize);
+  }, []); // Empty array ensures that effect is only run on mount
+  
+  return windowSize;
+}

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -38,9 +38,11 @@ export interface GridLayout extends LayoutFidgetConfig {
   items: number;
   isResizable: boolean;
   isDraggable: boolean;
+  isBounded?: boolean;
   rowHeight: number;
   compactType?: string | null;
   preventCollision?: boolean;
+  margin?: [number, number];
   onLayoutChange: (layout: PlacedGridItem[]) => unknown;
   onDrop: (layout: PlacedGridItem[], item: PlacedGridItem) => unknown;
 }

--- a/src/pages/homebase/index.tsx
+++ b/src/pages/homebase/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Space, { SpaceConfig } from "@/common/ui/templates/Space";
 import { useState } from "react";
 import { RiPencilFill } from "react-icons/ri";
@@ -8,9 +8,12 @@ import {
 } from "@/fidgets/layout/Grid";
 import { LayoutFidgetDetails } from "@/common/fidgets";
 import { NextPageWithLayout } from "../_app";
+import useWindowSize from "@/common/lib/hooks/useWindowSize";
+import { round } from "lodash";
 
 const Homebase: NextPageWithLayout = () => {
   const [editMode, setMode] = useState(false);
+  const windowSize = useWindowSize();
 
   const availableHandles = [
     "s",
@@ -30,10 +33,10 @@ const Homebase: NextPageWithLayout = () => {
       y: 0,
       w: 6,
       minW: 1,
-      maxW: 12,
-      h: 10,
+      maxW: 9,
+      h: 8,
       minH: 1,
-      maxH: 12,
+      maxH: 9,
     },
     {
       i: "frame",
@@ -45,7 +48,7 @@ const Homebase: NextPageWithLayout = () => {
       maxW: 4,
       h: 6,
       minH: 3,
-      maxH: 12,
+      maxH: 9,
     },
   ];
 
@@ -90,6 +93,8 @@ const Homebase: NextPageWithLayout = () => {
     preventCollision: true,
     maxRows: 9,
     layout: defaultLayoutData,
+    margin: [0, 0],
+    isBounded: true,
   };
   const layoutID = "";
   const layoutDetails: LayoutFidgetDetails = {
@@ -102,6 +107,19 @@ const Homebase: NextPageWithLayout = () => {
     layoutDetails,
     fidgetConfigs: fidgets,
   });
+
+  useEffect(() => {
+    setSpaceConfig({
+      ...spaceConfig,
+      layoutDetails: {
+        layoutFidget: "grid",
+        layoutConfig: {
+          ...gridDetails,
+          rowHeight: windowSize ? round(windowSize.height / 9) : 70,
+        },
+      },
+    });
+  }, [windowSize])
 
   async function saveConfig(config: SpaceConfig) {
     setSpaceConfig(config);


### PR DESCRIPTION
Added a basic hook to track window size. This does make the grid layout a bit better.

Some notes though:
- The current set up with the cards in FidgetWrapper makes it so that items cannot be resize because the resize handle is hidden on the DOM. We need to set a way to set the z-index of the handles to a high number to make them accessible
- The window height tracking helps some, but doesn't solve the underlying issue with the package we are using being buggy
- The package we are using is not made for React 18 (which we are using). Combined with its bugginess, we might want to consider a different package that is better maintained, here are some options
        1. [konva-js](https://konvajs.org/) (this doesn't have built in grid support, but does [have ways to support it](https://medium.com/@pierrebleroux/snap-to-grid-with-konvajs-c41eae97c13f))
        2. [gridstack.js](https://github.com/gridstack/gridstack.js) (less flexible than konva, but seems to be a very similar set up to the package we are currently using)