### PR TITLE
Redirect root page based on login state 

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,20 +1,21 @@
-import React from "react";
-// import { useRouter } from "next/router";
-// import { createClient } from "@/common/data/database/supabase/clients/component";
+import React, { useEffect } from "react";
+import { useRouter } from "next/router";
+import { useAccountStore } from "@/common/data/stores/accounts";
+import { isUndefined } from "lodash";
 
 const Index = () => {
-  // const router = useRouter();
-  // const supabaseClient = createClient();
+  const router = useRouter();
+  const { currentSpaceIdentityPublicKey } = useAccountStore((state) => ({
+    currentSpaceIdentityPublicKey: state.currentSpaceIdentityPublicKey,
+  }));
 
-  // useEffect(() => {
-  //   supabaseClient.auth.getSession().then(({ data: { session } }) => {
-  //     if (!session) {
-  //       router.push("/login");
-  //     } else {
-  //       router.push("/homebase");
-  //     }
-  //   });
-  // }, []);
+  // TO DO: Update redirect to "setup" if the account is logged in
+  // sign up is not completed (i.e. hasn't finished adding Farcaster Auth)
+  useEffect(() => {
+    isUndefined(currentSpaceIdentityPublicKey)
+      ? router.replace("/login")
+      : router.replace("/homebase");
+  });
 
   return <p className="m-4 text-gray-200 text-md">Redirecting...</p>;
 };


### PR DESCRIPTION
Fixes this
<img width="847" alt="Screenshot 2024-06-08 at 8 45 54 AM" src="https://github.com/Nounspace/nounspace.ts/assets/7180740/ba016046-ddfb-47ef-983f-32fbc9eab898">


NOTE:
Current redirect is a little basic and we need better ways of checking where in the sign up flow the user is and send them to the correct page if they are logged in

This PR is currently built on top of #56 (and it's whole merge chain). Only merge this PR after #56 has been merged