### PR TITLE
Fix project ID typo in supabase config.toml

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,6 +1,6 @@
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
-project_id = "nounpsace"
+project_id = "nounspace"
 
 [api]
 enabled = true


### PR DESCRIPTION
"nounpsace" -> "nounspace"

(reminder to test before merging!)