### PR TITLE
fix: debounce needs a number to actually do its job

### DIFF
--- a/src/common/data/stores/accounts/spaceStore.ts
+++ b/src/common/data/stores/accounts/spaceStore.ts
@@ -198,7 +198,7 @@ export const spaceStore = (
           },
         );
       }
-    })();
+    }, 1000)();
   },
   saveSpace: async (config) => {
     set((draft) => {

--- a/src/common/data/stores/homebase/index.ts
+++ b/src/common/data/stores/homebase/index.ts
@@ -67,7 +67,7 @@ export const createHomeBaseStoreFunc = (
         // TO DO: Error handling
         await axiosBackend.post(`/api/space/homebase/`, file);
       }
-    })();
+    }, 1000)();
   },
   saveHomebaseConfig: async (config) => {
     set((draft) => {


### PR DESCRIPTION
Forgot the second arg to `debounce` that makes it delay calls until after a time window