### PR TITLE
refactor: remove warnings

### DIFF
--- a/src/common/components/organisms/EditorPanel.tsx
+++ b/src/common/components/organisms/EditorPanel.tsx
@@ -3,15 +3,9 @@ import { ThemeSettings } from "@/common/lib/theme";
 import ThemeSettingsEditor from "@/common/lib/theme/ThemeSettingsEditor";
 import DEFAULT_THEME from "@/common/lib/theme/defaultTheme";
 import FidgetTray from "./FidgetTray";
-import {
-  FidgetArgs,
-  FidgetFieldConfig,
-  FidgetInstanceData,
-  FidgetModule,
-} from "@/common/fidgets";
+import { FidgetArgs, FidgetInstanceData, FidgetModule } from "@/common/fidgets";
 import FidgetPicker from "./FidgetPicker";
 import { v4 as uuidv4 } from "uuid";
-import _ from "lodash";
 import { mapValues } from "lodash";
 
 export interface EditorPanelProps {

--- a/src/common/components/organisms/FidgetPicker.tsx
+++ b/src/common/components/organisms/FidgetPicker.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { CompleteFidgets } from "@/fidgets";
-import { Button } from "../atoms/button";
-import { Card, CardContent, CardFooter } from "../atoms/card";
-import _ from "lodash";
-import { FidgetArgs, FidgetModule } from "@/common/fidgets";
+import { Card, CardContent } from "../atoms/card";
+import { map } from "lodash";
+import { FidgetModule } from "@/common/fidgets";
 
 export interface FidgetPickerProps {
   addFidgetToTray: (fidget: FidgetModule<any>) => void;
@@ -23,7 +22,7 @@ export const FidgetPicker: React.FC<FidgetPickerProps> = ({
   };
 
   function generateFidgetCards() {
-    return _.map(CompleteFidgets, (fidgetModule, fidgetName) => {
+    return map(CompleteFidgets, (fidgetModule, fidgetName) => {
       return (
         <button
           key={fidgetName}

--- a/src/common/components/organisms/FidgetTray.tsx
+++ b/src/common/components/organisms/FidgetTray.tsx
@@ -1,12 +1,7 @@
-import { FidgetConfig, FidgetSettings } from "@/common/fidgets";
-import React, { Dispatch, SetStateAction, DragEvent } from "react";
-import _ from "lodash";
-import { Responsive, WidthProvider } from "react-grid-layout";
-import { PlacedGridItem } from "@/fidgets/layout/Grid";
-import { number } from "prop-types";
+import React, { Dispatch, SetStateAction } from "react";
+import { map } from "lodash";
 import { FidgetInstanceData } from "@/common/fidgets";
 import { CompleteFidgets } from "@/fidgets";
-const ResponsiveReactGridLayout = WidthProvider(Responsive);
 
 const PlusIcon = () => {
   return (
@@ -44,11 +39,10 @@ export const FidgetTray: React.FC<FidgetTrayProps> = ({
   contents,
   setExternalDraggedItem,
   openFidgetPicker,
-  removeFidgetFromGrid,
 }) => {
   return (
     <div className="w-full h-screen flex-col justify-center items-center bg-sky-100 p-8 overflow-auto">
-      {contents.map((fidgetData: FidgetInstanceData) => {
+      {map(contents, (fidgetData: FidgetInstanceData) => {
         return (
           <div key={fidgetData.id} className="flex justify-center items-center">
             <div

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -33,9 +33,8 @@ const NavItem: React.FC<NavItemProps> = ({ label, active, Icon }) => {
 };
 
 const Navigation: React.FC<NavProps> = ({ isEditable, setEditMode }) => {
-  const { homebaseConfig, saveConfig, loadConfig } = useAppStore((state) => ({
+  const { homebaseConfig, loadConfig } = useAppStore((state) => ({
     homebaseConfig: state.homebase.homebaseConfig,
-    saveConfig: state.homebase.saveHomebaseConfig,
     loadConfig: state.homebase.loadHomebase,
   }));
 

--- a/src/common/components/organisms/Sidebar.tsx
+++ b/src/common/components/organisms/Sidebar.tsx
@@ -1,16 +1,5 @@
-import { ThemeSettings } from "@/common/lib/theme";
-import React, {
-  Dispatch,
-  ReactNode,
-  SetStateAction,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
-import EditorPanel from "./EditorPanel";
+import React from "react";
 import Navigation from "./Navigation";
-import { FidgetInstanceData } from "@/common/fidgets";
 
 export interface SidebarProps {
   editMode: boolean;
@@ -25,10 +14,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
   isEditable,
   portalRef,
 }) => {
-  function turnOnEditMode() {
-    setEditMode(true);
-  }
-
   return (
     <>
       <div ref={portalRef} className={editMode ? "w-full" : ""}></div>

--- a/src/common/components/templates/Space.tsx
+++ b/src/common/components/templates/Space.tsx
@@ -1,4 +1,4 @@
-import React, { useState, DragEvent, useEffect, useMemo, useRef } from "react";
+import React, { useState, useRef } from "react";
 import {
   FidgetConfig,
   FidgetInstanceData,
@@ -6,9 +6,7 @@ import {
   LayoutFidgetConfig,
   LayoutFidgetDetails,
 } from "@/common/fidgets";
-import { CompleteFidgets, LayoutFidgets } from "@/fidgets";
-import { mapValues } from "lodash";
-import { FidgetWrapper } from "@/common/fidgets/FidgetWrapper";
+import { LayoutFidgets } from "@/fidgets";
 import { UserTheme } from "@/common/lib/theme";
 import CustomHTMLBackground from "@/common/components/molecules/CustomHTMLBackground";
 import Sidebar from "../organisms/Sidebar";

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React from "react";
 import { Card, CardContent } from "@/common/components/atoms/card";
 import { toast } from "sonner";
 import {

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -1,19 +1,9 @@
-import React, {
-  Dispatch,
-  DragEvent,
-  ReactNode,
-  SetStateAction,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { DragEvent, useEffect, useState } from "react";
 import useWindowSize from "@/common/lib/hooks/useWindowSize";
-import RGL, { WidthProvider, DragOverEvent } from "react-grid-layout";
+import RGL, { WidthProvider } from "react-grid-layout";
 import {
   LayoutFidgetConfig,
   LayoutFidget,
-  LayoutFidgetProps,
   FidgetInstanceData,
   FidgetConfig,
   FidgetSettings,
@@ -22,8 +12,6 @@ import { CompleteFidgets } from "..";
 import { createPortal } from "react-dom";
 import EditorPanel from "@/common/components/organisms/EditorPanel";
 import { ThemeSettings } from "@/common/lib/theme";
-import { SpaceConfig } from "@/common/components/templates/Space";
-import { mapValues } from "lodash";
 import { FidgetWrapper } from "@/common/fidgets/FidgetWrapper";
 
 export const resizeDirections = ["s", "w", "e", "n", "sw", "nw", "se", "ne"];
@@ -77,28 +65,6 @@ type GridDetails = typeof gridDetails;
 type GridLayoutConfig = {
   layout: PlacedGridItem[];
 };
-
-function handleDrop(
-  layout: LayoutFidgetConfig,
-  item: PlacedGridItem,
-  e: DragEvent<HTMLDivElement>,
-) {
-  const data = JSON.parse(e.dataTransfer.getData("text/plain"));
-
-  const newItem = {
-    i: `0`,
-    x: 0,
-    y: 0,
-    w: data.width, // Use the passed width
-    h: data.height, // Use the passed height
-    minW: data.width,
-    maxW: data.width,
-    minH: data.height,
-    maxH: data.height,
-  };
-
-  //setExternalDraggedItem({ w: newItem.w, h: newItem.h });
-}
 
 const ReactGridLayout = WidthProvider(RGL);
 
@@ -193,7 +159,7 @@ const Grid: LayoutFidget<GridArgs> = ({
     portalRef.current,
   );
 
-  const { width, height } = useWindowSize();
+  const { height } = useWindowSize();
 
   const rowHeight = height
     ? Math.round((height - 200) / gridDetails.maxRows)


### PR DESCRIPTION
There are a bunch of warnings due to unused variables. This removes them, making the code cleaner and removing unused imports