### PR TITLE
Disable custom background interaction

### DIFF
--- a/src/common/components/molecules/CustomHTMLBackground.tsx
+++ b/src/common/components/molecules/CustomHTMLBackground.tsx
@@ -1,17 +1,5 @@
 import React, { useMemo } from "react";
-import styled from "@emotion/styled";
 import DOMPurify from "isomorphic-dompurify";
-
-const StyledIframe = styled.iframe`
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 0;
-  width: 100%;
-  height: 100vh;
-`;
 
 type CustomHTMLBackgroundProps = {
   html: string;
@@ -29,9 +17,10 @@ const CustomHTMLBackground: React.FC<CustomHTMLBackgroundProps> = ({
   }, [html]);
 
   return sanitizedHtml ? (
-    <StyledIframe
+    <iframe
       title="Custom Background"
       srcDoc={sanitizedHtml}
+      className="fixed size-full pointer-events-none"
       sandbox="" // disallows scripts
     />
   ) : null;


### PR DESCRIPTION
- Fixes an issue where fidgets can't be dragged to the grid when a custom html background is enabled. This is fixed by disabling pointer events on the background component.
- Refactor CustomHTMLBackground