### PR TITLE
Fix initial homebase state

### DIFF
--- a/src/common/data/stores/app/index.ts
+++ b/src/common/data/stores/app/index.ts
@@ -27,6 +27,7 @@ export type AppStore = {
   space: SpaceStore;
   logout: () => void;
   getIsAccountReady: () => boolean;
+  getIsInitializing: () => boolean;
 };
 
 const makeStoreFunc = (set, get, state): AppStore => ({
@@ -46,6 +47,12 @@ const makeStoreFunc = (set, get, state): AppStore => ({
     return (
       get().setup.currentStep === SetupStep.DONE &&
       !isUndefined(get().account.getCurrentIdentity())
+    );
+  },
+  getIsInitializing: () => {
+    const currentStep = get().setup.currentStep;
+    return (
+      currentStep !== SetupStep.NOT_SIGNED_IN && currentStep !== SetupStep.DONE
     );
   },
 });

--- a/src/common/data/stores/app/setup/index.ts
+++ b/src/common/data/stores/app/setup/index.ts
@@ -7,6 +7,7 @@ import {
 import { AppStore } from "..";
 
 export enum SetupStep {
+  UNINITIALIZED = "Uninitialized",
   NOT_SIGNED_IN = "Please Sign in with Privy",
   SIGNED_IN = "Connecting to wallet...",
   WALLET_CONNECTED = "Checking for nOGs...",
@@ -57,7 +58,7 @@ interface SetupStoreActions {
 export type SetupStore = SetupStoreState & SetupStoreActions;
 
 export const setupStoreDefaults: SetupStoreState = {
-  currentStep: SetupStep.NOT_SIGNED_IN,
+  currentStep: SetupStep.UNINITIALIZED,
   modalOpen: false,
   keepModalOpen: false,
   // nogs

--- a/src/common/providers/LoggedInStateProvider.tsx
+++ b/src/common/providers/LoggedInStateProvider.tsx
@@ -226,7 +226,10 @@ const LoggedInStateProvider: React.FC<LoggedInLayoutProps> = ({ children }) => {
 
   useEffect(() => {
     if (ready && authenticated) {
-      if (currentStep === SetupStep.NOT_SIGNED_IN) {
+      if (
+        currentStep === SetupStep.NOT_SIGNED_IN ||
+        currentStep === SetupStep.UNINITIALIZED
+      ) {
         setCurrentStep(SetupStep.SIGNED_IN);
       } else if (walletsReady) {
         if (currentStep === SetupStep.SIGNED_IN) {
@@ -245,6 +248,8 @@ const LoggedInStateProvider: React.FC<LoggedInLayoutProps> = ({ children }) => {
           setCurrentStep(SetupStep.DONE);
         }
       }
+    } else if (ready && !authenticated) {
+      setCurrentStep(SetupStep.NOT_SIGNED_IN);
     }
   }, [currentStep, walletsReady, ready, authenticated]);
 

--- a/src/pages/homebase/index.tsx
+++ b/src/pages/homebase/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect } from "react";
 import { NextPageWithLayout } from "../_app";
 import { useAppStore } from "@/common/data/stores/app";
 import SpaceWithLoader from "@/common/components/templates/SpaceWithLoader";
@@ -12,6 +12,7 @@ const Homebase: NextPageWithLayout = () => {
     commitConfig,
     resetConfig,
     getIsLoggedIn,
+    getIsInitializing,
   } = useAppStore((state) => ({
     homebaseConfig: state.homebase.homebaseConfig,
     saveConfig: state.homebase.saveHomebaseConfig,
@@ -19,27 +20,35 @@ const Homebase: NextPageWithLayout = () => {
     commitConfig: state.homebase.commitHomebaseToDatabase,
     resetConfig: state.homebase.resetHomebaseConfig,
     getIsLoggedIn: state.getIsAccountReady,
+    getIsInitializing: state.getIsInitializing,
   }));
-
   const isLoggedIn = getIsLoggedIn();
+  const isInitializing = getIsInitializing();
 
   useEffect(() => {
     isLoggedIn && loadConfig();
   }, [isLoggedIn]);
 
-  const args = isLoggedIn
+  const args = isInitializing
     ? {
-        config: homebaseConfig,
-        saveConfig,
-        commitConfig,
-        resetConfig,
+        config: homebaseConfig ?? undefined,
+        saveConfig: undefined,
+        commitConfig: undefined,
+        resetConfig: undefined,
       }
-    : {
-        config: USER_NOT_LOGGED_IN_HOMEBASE_CONFIG,
-        saveConfig: async () => {},
-        commitConfig: async () => {},
-        resetConfig: async () => {},
-      };
+    : !isLoggedIn
+      ? {
+          config: USER_NOT_LOGGED_IN_HOMEBASE_CONFIG,
+          saveConfig: async () => {},
+          commitConfig: async () => {},
+          resetConfig: async () => {},
+        }
+      : {
+          config: homebaseConfig,
+          saveConfig,
+          commitConfig,
+          resetConfig,
+        };
 
   return <SpaceWithLoader {...args} />;
 };


### PR DESCRIPTION
Fixes an issue where a user's saved layout isn't displayed on page load. This was happening because the grid's local state was being initialized with defaults before the homebaseConfig had a chance to fully load, and it wasn't updating this local state upon homebaseConfig load.

This was fixed by not rendering the grid until we know whether a user is logged in or not, so the correct config is received (and set locally) on initial render.

To do this, an "UNINITIALIZED" setup state was added to differentiate between a user who is logged out vs. a user whose auth/setup status has not yet been determined.

Additional changes:
- Updated nextjs version to fix fetchPriority console warning