### PR TITLE
Hide global settings from Customize pane

### DIFF
--- a/src/common/components/molecules/BorderSelector.tsx
+++ b/src/common/components/molecules/BorderSelector.tsx
@@ -7,7 +7,7 @@ export const BorderSelector: React.FC<{
   value: string;
   className?: string;
   hideGlobalSettings?: boolean;
-}> = ({ onChange, value, className, hideGlobalSettings }) => {
+}> = ({ onChange, value, className, hideGlobalSettings = false }) => {
   const settings = BORDER_STYLES.filter((setting) => {
     if (hideGlobalSettings) {
       return !setting.global;

--- a/src/common/components/molecules/BorderSelector.tsx
+++ b/src/common/components/molecules/BorderSelector.tsx
@@ -6,12 +6,20 @@ export const BorderSelector: React.FC<{
   onChange: (value: string) => void;
   value: string;
   className?: string;
-}> = ({ onChange, value, className }) => {
+  hideGlobalSettings?: boolean;
+}> = ({ onChange, value, className, hideGlobalSettings }) => {
+  const settings = BORDER_STYLES.filter((setting) => {
+    if (hideGlobalSettings) {
+      return !setting.global;
+    }
+    return true;
+  });
+
   return (
     <SettingsSelector
       onChange={onChange}
       value={value}
-      settings={BORDER_STYLES}
+      settings={settings}
       className={className}
     />
   );

--- a/src/common/components/molecules/FontSelector.tsx
+++ b/src/common/components/molecules/FontSelector.tsx
@@ -19,14 +19,22 @@ export interface FontSelectorProps {
   onChange: (fontConfig: FontFamily) => void;
   value: string;
   className?: string;
+  hideGlobalSettings?: boolean;
 }
 
 export const FontSelector: React.FC<FontSelectorProps> = ({
   onChange,
   value,
   className,
+  hideGlobalSettings = false,
 }) => {
   const selectedFont: FontConfig = FONT_FAMILY_OPTIONS_BY_NAME[value];
+  const settings = FONT_FAMILY_OPTIONS.filter((setting) => {
+    if (hideGlobalSettings) {
+      return !setting.global;
+    }
+    return true;
+  });
 
   return (
     <Select onValueChange={onChange} value={value}>
@@ -39,7 +47,7 @@ export const FontSelector: React.FC<FontSelectorProps> = ({
         </SelectValue>
       </SelectTrigger>
       <SelectContent>
-        {FONT_FAMILY_OPTIONS.map((font, i) => {
+        {settings.map((font, i) => {
           return (
             <SelectItem style={font.config.style} value={font.name} key={i}>
               {font.name}

--- a/src/common/components/molecules/SettingsSelector.tsx
+++ b/src/common/components/molecules/SettingsSelector.tsx
@@ -10,6 +10,7 @@ import {
 type Setting = {
   name: string;
   value: string;
+  global?: boolean;
 };
 
 interface SettingsSelectorProps {

--- a/src/common/components/molecules/ShadowSelector.tsx
+++ b/src/common/components/molecules/ShadowSelector.tsx
@@ -7,7 +7,7 @@ export const ShadowSelector: React.FC<{
   value: string;
   className?: string;
   hideGlobalSettings?: boolean;
-}> = ({ onChange, value, className, hideGlobalSettings }) => {
+}> = ({ onChange, value, className, hideGlobalSettings = false }) => {
   const settings = SHADOW_STYLES.filter((setting) => {
     if (hideGlobalSettings) {
       return !setting.global;

--- a/src/common/components/molecules/ShadowSelector.tsx
+++ b/src/common/components/molecules/ShadowSelector.tsx
@@ -6,12 +6,20 @@ export const ShadowSelector: React.FC<{
   onChange: (value: string) => void;
   value: string;
   className?: string;
-}> = ({ onChange, value, className }) => {
+  hideGlobalSettings?: boolean;
+}> = ({ onChange, value, className, hideGlobalSettings }) => {
+  const settings = SHADOW_STYLES.filter((setting) => {
+    if (hideGlobalSettings) {
+      return !setting.global;
+    }
+    return true;
+  });
+
   return (
     <SettingsSelector
       onChange={onChange}
       value={value}
-      settings={SHADOW_STYLES}
+      settings={settings}
       className={className}
     />
   );

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -172,6 +172,7 @@ export function ThemeSettingsEditor({
                         className="ring-0 focus:ring-0 border-0 shadow-none"
                         value={fidgetBorderWidth as string}
                         onChange={themePropSetter<string>("fidgetBorderWidth")}
+                        hideGlobalSettings
                       />
                     </div>
                   </div>
@@ -181,6 +182,7 @@ export function ThemeSettingsEditor({
                       className="ring-0 focus:ring-0 border-0 shadow-none"
                       value={fidgetShadow as string}
                       onChange={themePropSetter<string>("fidgetShadow")}
+                      hideGlobalSettings
                     />
                   </div>
                 </div>

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -114,6 +114,7 @@ export function ThemeSettingsEditor({
                     className="ring-0 focus:ring-0 border-0 shadow-none"
                     value={headingsFont}
                     onChange={themePropSetter<FontFamily>("headingsFont")}
+                    hideGlobalSettings
                   />
                 </div>
               </div>
@@ -130,6 +131,7 @@ export function ThemeSettingsEditor({
                     className="ring-0 focus:ring-0 border-0 shadow-none"
                     value={font}
                     onChange={themePropSetter<FontFamily>("font")}
+                    hideGlobalSettings
                   />
                 </div>
               </div>

--- a/src/common/lib/theme/fonts.ts
+++ b/src/common/lib/theme/fonts.ts
@@ -21,6 +21,7 @@ import type { NextFontWithVariable } from "next/dist/compiled/@next/font";
 
 export type FontConfig = {
   name: FontFamily;
+  global?: boolean;
   config: NextFontWithVariable;
 };
 
@@ -122,6 +123,7 @@ export const work_sans = Work_Sans({
 export const FONT_FAMILY_OPTIONS: FontConfig[] = [
   {
     name: "Theme Font",
+    global: true,
     config: {
       variable: "--user-theme-font",
       className: ".user-theme-font",
@@ -132,6 +134,7 @@ export const FONT_FAMILY_OPTIONS: FontConfig[] = [
   },
   {
     name: "Theme Headings Font",
+    global: true,
     config: {
       variable: "--user-theme-headings-font",
       className: ".user-theme-headings-font",

--- a/src/common/lib/theme/helpers.ts
+++ b/src/common/lib/theme/helpers.ts
@@ -1,5 +1,9 @@
 export const BORDER_STYLES = [
-  { name: "Theme Border", value: "var(--user-theme-fidget-border-width)" },
+  {
+    name: "Theme Border",
+    value: "var(--user-theme-fidget-border-width)",
+    global: true,
+  },
   { name: "None", value: "0" },
   { name: "Small", value: "1px" },
   { name: "Medium", value: "2px" },
@@ -7,7 +11,11 @@ export const BORDER_STYLES = [
 ];
 
 export const SHADOW_STYLES = [
-  { name: "Theme Shadow", value: "var(--user-theme-fidget-shadow)" },
+  {
+    name: "Theme Shadow",
+    value: "var(--user-theme-fidget-shadow)",
+    global: true,
+  },
   { name: "None", value: "none" },
   { name: "Small", value: "0 2px 5px rgba(0,0,0,0.15)" },
   { name: "Medium", value: "0 4px 8px rgba(0,0,0,0.25)" },


### PR DESCRIPTION
Remove global settings from theme editor
![image](https://github.com/Nounspace/nounspace.ts/assets/1230158/98e08ea4-a327-45ba-ae71-dfc5a4681c27)

But leave it in fidget settings:
![image](https://github.com/Nounspace/nounspace.ts/assets/1230158/4aeb6cbc-4f46-44b2-a33b-0911b23cb4b3)
