### PR TITLE
fix: profile now recognizes the proper grid size

### DIFF
--- a/src/common/components/templates/Space.tsx
+++ b/src/common/components/templates/Space.tsx
@@ -11,7 +11,7 @@ import { LayoutFidgets } from "@/fidgets";
 import { UserTheme } from "@/common/lib/theme";
 import CustomHTMLBackground from "@/common/components/molecules/CustomHTMLBackground";
 import Sidebar from "../organisms/Sidebar";
-import { isUndefined } from "lodash";
+import { isNil, isUndefined } from "lodash";
 
 export type SpaceFidgetConfig = {
   instanceConfig: FidgetConfig<FidgetSettings>;
@@ -118,6 +118,7 @@ export default function Space({
               cancelExitEditMode={cancelExitEditMode}
               portalRef={portalRef}
               saveConfig={saveLocalConfig}
+              hasProfile={!isNil(profile)}
             />
           </div>
         </div>

--- a/src/common/fidgets/index.d.ts
+++ b/src/common/fidgets/index.d.ts
@@ -109,6 +109,8 @@ interface LayoutFidgetProps<C extends LayoutFidgetConfig> {
   saveExitEditMode: () => void;
   cancelExitEditMode: () => void;
   portalRef: React.RefObject<HTMLDivElement>;
+
+  hasProfile: boolean;
 }
 
 type LayoutFidgetDefaultProps = LayoutFidgetProps;


### PR DESCRIPTION
Now when you go to a profile page, we don't have the space extend beyond the window size

This fix works, but I think the most correct long term solution is to tell the Grid component how much space it has as a width and height and then let the Homebase/Space Page handle window size tracking and passing that info about how big the Grid (or other layout component) can be down