### PR TITLE
Add builder Dao proposals to Governance Fidget 2 

### DIFF
--- a/src/common/lib/utils/queries.ts
+++ b/src/common/lib/utils/queries.ts
@@ -1,0 +1,103 @@
+export const NOUNS_PROPOSALS_QUERY = `  query ProposalsQuery {    _meta {      block {        number        timestamp      }    }    proposals(orderBy: startBlock, orderDirection: desc) {      id      title      status      startBlock      endBlock
+    }
+  }
+`;
+
+export const NOUNSBUILD_PROPOSALS_QUERY = `
+query proposals(
+  $where: Proposal_filter,
+  $first: Int! = 100,
+  $skip: Int = 0
+) {
+  proposals(
+    where: $where
+    first: $first
+    skip: $skip
+    orderBy: timeCreated
+    orderDirection: desc
+  ) {
+    ...Proposal
+    votes {
+      ...ProposalVote
+    }
+  }
+}
+
+fragment Proposal on Proposal {
+  abstainVotes
+  againstVotes
+  calldatas
+  description
+  descriptionHash
+  executableFrom
+  expiresAt
+  forVotes
+  proposalId
+  proposalNumber
+  proposalThreshold
+  proposer
+  quorumVotes
+  targets
+  timeCreated
+  title
+  values
+  voteEnd
+  voteStart
+  snapshotBlockNumber
+  transactionHash
+  dao {
+    governorAddress
+    tokenAddress
+  }
+}
+
+fragment ProposalVote on ProposalVote {
+  voter
+  support
+  weight
+  reason
+}
+`;
+
+export const NOUNS_PROPOSAL_DETAIL_QUERY = `
+  query ProposalDetailQuery($id: ID = "") {
+    _meta {
+      block {
+        number
+        timestamp
+      }
+    }
+    proposal(id: $id) {
+      id
+      title
+      status
+      startBlock
+      endBlock
+      forVotes
+      againstVotes
+      abstainVotes
+      quorumVotes
+      createdTimestamp
+      voteSnapshotBlock
+      proposer {
+        id
+        nounsRepresented {
+          id
+        }
+      }
+      signers {
+        id
+        nounsRepresented {
+          id
+        }
+      }
+    }
+    proposalVersions(
+      where: {proposal_: {id: $id}}
+      orderBy: createdAt
+      orderDirection: desc
+    ) {
+      createdAt
+    }
+  }
+`;

--- a/src/fidgets/community/nouns-dao/components/BuilderProposalDetailView.tsx
+++ b/src/fidgets/community/nouns-dao/components/BuilderProposalDetailView.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Button } from "@/common/components/atoms/button";
 import { Progress } from "@/common/components/atoms/progress";
 import Spinner from "@/common/components/atoms/spinner";
@@ -10,7 +9,7 @@ import { RiExternalLinkLine } from "react-icons/ri";
 import { useEnsName } from "wagmi";
 import { mainnet } from "wagmi/chains";
 import { StatusBadge } from "./BuilderProposalItem";
-import { estimateBlockTime } from "./ProposalListRowItem";
+import React from "react";
 const VoteStat = ({ label, value, total, progressColor, labelColor }) => {
   const percentage = Math.round((100.0 * value) / total);
   return (
@@ -84,37 +83,23 @@ const AddressInfo = ({ label, address }) => {
   );
 };
 
-export const ProposalDetailView = ({
+export const BuilderProposalDetailView = ({
   proposal,
-  versions,
   goBack,
-  currentBlock,
   loading,
 }: {
   proposal: ProposalData;
-  versions: any[];
   goBack: () => void;
-  currentBlock: any;
   loading: boolean;
 }) => {
   const proposer = proposal?.proposer?.id;
-  const sponsor = proposal?.signers?.length
-    ? proposal.signers[0].id
-    : undefined;
-  const version = versions?.length;
 
   const { data: proposerEnsName } = useEnsName({
     address: proposer,
     chainId: mainnet.id,
   });
 
-  const { data: sponsorEnsName } = useEnsName({
-    address: sponsor,
-    chainId: mainnet.id,
-  });
-
   const proposerEnsOrAddress = proposerEnsName ?? proposer;
-  const sponsorEnsOrAddress = sponsorEnsName ?? sponsor;
 
   if (loading) {
     return (
@@ -136,16 +121,12 @@ export const ProposalDetailView = ({
   };
 
   const totalVotes = votes.for + votes.against + votes.abstain;
-  const lastUpdated = moment(Number(versions[0].createdAt) * 1000).fromNow();
-  const lastUpdatedText =
-    version == 1 ? `Created ${lastUpdated}` : `Updated ${lastUpdated}`;
-  const endDate = estimateBlockTime(
-    Number(proposal.endBlock),
-    currentBlock.number,
-    currentBlock.timestamp,
-  );
-  const formattedEndDate = moment(endDate).format("MMM D, YYYY");
-  const formattedEndTime = moment(endDate).format("h:mm A");
+  const formattedEndDate = proposal.expiresAt
+    ? moment.unix(Number(proposal.expiresAt)).format("MMM D, YYYY")
+    : "N/A";
+  const formattedEndTime = proposal.expiresAt
+    ? moment.unix(Number(proposal.expiresAt)).format("h:mm A")
+    : "N/A";
 
   return (
     <div className="flex flex-col size-full">
@@ -182,35 +163,18 @@ export const ProposalDetailView = ({
                 </span>
                 <StatusBadge
                   status={proposal.status}
-                  className="px-[8px] rounded-[6px]  text-[10px]/[1.25] font-medium"
+                  className="px-[8px] rounded-[6px] text-[10px]/[1.25] font-medium"
                 />
               </div>
               <p className="font-medium text-base/[1.25]">{proposal.title}</p>
-              {(proposer || sponsor) && (
+              {proposer && (
                 <div className="flex gap-4">
                   <AddressInfo
                     label="Proposed by"
                     address={proposerEnsOrAddress}
                   />
-                  <AddressInfo
-                    label="Sponsored by"
-                    address={sponsorEnsOrAddress}
-                  />
                 </div>
               )}
-            </div>
-            <div className="flex gap-2 items-center">
-              <StatusBadge
-                className={mergeClasses(
-                  "px-[8px] rounded-[6px] bg-gray-100",
-                  "hover:bg-gray-100 text-[10px]/[1.25] font-semibold",
-                )}
-              >
-                Version {version}
-              </StatusBadge>
-              <span className="text-[10px]/[1.25] text-gray-500">
-                {lastUpdatedText}
-              </span>
             </div>
           </div>
           <div className="flex flex-col gap-2">
@@ -261,4 +225,4 @@ export const ProposalDetailView = ({
   );
 };
 
-export default ProposalDetailView;
+export default BuilderProposalDetailView;

--- a/src/fidgets/community/nouns-dao/components/BuilderProposalItem.tsx
+++ b/src/fidgets/community/nouns-dao/components/BuilderProposalItem.tsx
@@ -1,0 +1,96 @@
+import { Badge } from "@/common/components/atoms/badge";
+import { mergeClasses } from "@/common/lib/utils/mergeClasses";
+import moment from "moment";
+import React from "react";
+import { MdAccessTimeFilled } from "react-icons/md";
+
+const baseBadgeClassNames =
+  "rounded-lg shadow-none font-semibold text-[11px] gap-1";
+
+const statusBadgeClassNames = {
+  ACTIVE: "bg-[#0E9F6E]",
+  EXECUTED: "bg-blue-600",
+  CANCELLED: "bg-gray-500",
+  DEFEATED: "bg-red-600",
+  QUEUED: "bg-gray-500",
+  PENDING: "bg-white border border-orange-600 text-orange-600",
+  "": "text-gray-600 bg-gray-200",
+};
+
+const statusTextOverrides = {
+  ACTIVE: "Active",
+  EXECUTED: "Executed",
+  CANCELLED: "Cancelled",
+  DEFEATED: "Defeated",
+  QUEUED: "Queued",
+  PENDING: "Updatable",
+};
+
+export const StatusBadge = ({
+  status,
+  className,
+  children,
+}: {
+  status?: string;
+  className?: string | null;
+  children?: React.ReactNode | null;
+}) => {
+  return (
+    <Badge
+      className={mergeClasses(
+        baseBadgeClassNames,
+        statusBadgeClassNames[status ?? ""],
+        className,
+      )}
+      variant="default"
+    >
+      {children ?? statusTextOverrides[status ?? ""] ?? status}
+    </Badge>
+  );
+};
+
+const BuilderProposalItem = ({
+  proposal,
+  setProposal,
+}: {
+  proposal: any;
+  setProposal: (proposalId: string) => void;
+}) => {
+  const handleProposalClick = () => {
+    setProposal(proposal.proposalId);
+  };
+  console.log(proposal);
+  return (
+    <div
+      onClick={handleProposalClick}
+      className={mergeClasses(
+        "flex overflow-hidden border border-gray-200 bg-gray-50 rounded-[8px]",
+        "p-3 py-2.5 gap-3 cursor-pointer hover:bg-white items-center",
+      )}
+    >
+      <div className="flex flex-col md:flex flex-auto flex-nowrap gap-1.5">
+        <p className="flex-auto font-medium text-sm/[1.25] mb-0">
+          <span className="flex-none mr-2 text-gray-400 font-bold">
+            {proposal.proposalNumber}
+          </span>
+          {proposal.title}
+        </p>
+        <div>
+          <Badge
+            className={mergeClasses(
+              baseBadgeClassNames,
+              "text-gray-600 bg-gray-200",
+            )}
+            variant="secondary"
+          >
+            <MdAccessTimeFilled size={12} className="text-gray-500" />
+            {"Created " + moment.unix(proposal.timeCreated).fromNow()}
+          </Badge>
+        </div>
+      </div>
+      {/* <StatusBadge status={proposal.status} /> */}
+    </div>
+  );
+};
+
+export default BuilderProposalItem;

--- a/src/fidgets/community/nouns-dao/components/ProposalListRowItem.tsx
+++ b/src/fidgets/community/nouns-dao/components/ProposalListRowItem.tsx
@@ -1,0 +1,134 @@
+import { Badge } from "@/common/components/atoms/badge";
+import { mergeClasses } from "@/common/lib/utils/mergeClasses";
+import moment from "moment";
+import React from "react";
+import { MdAccessTimeFilled } from "react-icons/md";
+
+const baseBadgeClassNames =
+  "rounded-lg shadow-none font-semibold text-[11px] gap-1";
+
+const statusBadgeClassNames = {
+  ACTIVE: "bg-[#0E9F6E]",
+  EXECUTED: "bg-blue-600",
+  CANCELLED: "bg-gray-500",
+  DEFEATED: "bg-red-600",
+  QUEUED: "bg-gray-500",
+  PENDING: "bg-white border border-orange-600 text-orange-600",
+  "": "text-gray-600 bg-gray-200",
+};
+
+const statusTextOverrides = {
+  ACTIVE: "Active",
+  EXECUTED: "Executed",
+  CANCELLED: "Cancelled",
+  DEFEATED: "Defeated",
+  QUEUED: "Queued",
+  PENDING: "Updatable",
+};
+
+export const StatusBadge = ({
+  status,
+  className,
+  children,
+}: {
+  status?: string;
+  className?: string | null;
+  children?: React.ReactNode | null;
+}) => {
+  return (
+    <Badge
+      className={mergeClasses(
+        baseBadgeClassNames,
+        statusBadgeClassNames[status ?? ""],
+        className,
+      )}
+      variant="default"
+    >
+      {children ?? statusTextOverrides[status ?? ""] ?? status}
+    </Badge>
+  );
+};
+
+export const estimateBlockTime = (
+  blockNumber: number,
+  currentBlockNumber: number,
+  currentBlockTimestamp: number,
+  secondsPerBlock: number = 12,
+) => {
+  const blocksDelta = blockNumber - currentBlockNumber;
+  const secondsDelta = blocksDelta * secondsPerBlock;
+  const estimatedUnix = (currentBlockTimestamp + secondsDelta) * 1000;
+  return new Date(estimatedUnix);
+};
+
+const ProposalListRowItem = ({
+  proposal,
+  setProposal,
+  currentBlock,
+}: {
+  proposal: any;
+  setProposal: (proposalId: string) => void;
+  currentBlock: any;
+}) => {
+  const getDateBadgeText = () => {
+    if (!["ACTIVE", "PENDING"].includes(proposal.status)) {
+      return null;
+    }
+    const startBlock = Number(proposal.startBlock);
+    const endBlock = Number(proposal.endBlock);
+
+    if (currentBlock.number < startBlock) {
+      const startDate = estimateBlockTime(
+        startBlock,
+        currentBlock.number,
+        currentBlock.timestamp,
+      );
+      return "Starts " + moment(startDate).fromNow();
+    } else if (currentBlock.number < endBlock) {
+      const endDate = estimateBlockTime(
+        endBlock,
+        currentBlock.number,
+        currentBlock.timestamp,
+      );
+      return "Ends " + moment(endDate).fromNow();
+    }
+    return null;
+  };
+  const dateBadgeText = getDateBadgeText();
+
+  return (
+    <div
+      onClick={() => setProposal(proposal.id)}
+      className={mergeClasses(
+        "flex overflow-hidden border border-gray-200 bg-gray-50 rounded-[8px]",
+        "p-3 py-2.5 gap-3 cursor-pointer hover:bg-white items-center",
+      )}
+    >
+      <div className="flex flex-col md:flex flex-auto flex-nowrap gap-1.5">
+        <p className="flex-auto font-medium text-sm/[1.25] mb-0">
+          <span className="flex-none mr-2 text-gray-400 font-bold">
+            {proposal.id}
+          </span>
+          {proposal.title}
+        </p>
+        {dateBadgeText && (
+          <div>
+            <Badge
+              className={mergeClasses(
+                baseBadgeClassNames,
+                "text-gray-600 bg-gray-200",
+              )}
+              variant="secondary"
+            >
+              <MdAccessTimeFilled size={12} className="text-gray-500" />
+              {dateBadgeText}
+            </Badge>
+          </div>
+        )}
+      </div>
+      <StatusBadge status={proposal.status} />
+    </div>
+  );
+};
+
+export default ProposalListRowItem;

--- a/src/fidgets/community/nouns-dao/components/ProposalListView.tsx
+++ b/src/fidgets/community/nouns-dao/components/ProposalListView.tsx
@@ -1,174 +1,79 @@
-import React from "react";
-import { Badge } from "@/common/components/atoms/badge";
-import type { ProposalData } from "@/fidgets/community/nouns-dao";
-import { mergeClasses } from "@/common/lib/utils/mergeClasses";
 import {
+  CardDescription,
   CardHeader,
   CardTitle,
-  CardDescription,
 } from "@/common/components/atoms/card";
-import moment from "moment";
-import { MdAccessTimeFilled } from "react-icons/md";
-
-const baseBadgeClassNames =
-  "rounded-lg shadow-none font-semibold text-[11px] gap-1";
-
-const statusBadgeClassNames = {
-  ACTIVE: "bg-[#0E9F6E]",
-  EXECUTED: "bg-blue-600",
-  CANCELLED: "bg-gray-500",
-  DEFEATED: "bg-red-600",
-  QUEUED: "bg-gray-500",
-  PENDING: "bg-white border border-orange-600 text-orange-600",
-  "": "text-gray-600 bg-gray-200",
-};
-
-const statusTextOverrides = {
-  ACTIVE: "Active",
-  EXECUTED: "Executed",
-  CANCELLED: "Cancelled",
-  DEFEATED: "Defeated",
-  QUEUED: "Queued",
-  PENDING: "Updatable",
-};
-
-export const StatusBadge = ({
-  status,
-  className,
-  children,
-}: {
-  status?: string;
-  className?: string | null;
-  children?: React.ReactNode | null;
-}) => {
-  return (
-    <Badge
-      className={mergeClasses(
-        baseBadgeClassNames,
-        statusBadgeClassNames[status ?? ""],
-        className,
-      )}
-      variant="default"
-    >
-      {children ?? statusTextOverrides[status ?? ""] ?? status}
-    </Badge>
-  );
-};
-
-export const estimateBlockTime = (
-  blockNumber: number,
-  currentBlockNumber: number,
-  currentBlockTimestamp: number,
-  secondsPerBlock: number = 12,
-) => {
-  const blocksDelta = blockNumber - currentBlockNumber;
-  const secondsDelta = blocksDelta * secondsPerBlock;
-  const estimatedUnix = (currentBlockTimestamp + secondsDelta) * 1000;
-  return new Date(estimatedUnix);
-};
-
-const ProposalListRowItem = ({
-  proposal,
-  setProposal,
-  currentBlock,
-}: {
-  proposal: ProposalData;
-  setProposal: (proposal: ProposalData) => void;
-  currentBlock: any;
-}) => {
-  const getDateBadgeText = () => {
-    if (!["ACTIVE", "PENDING"].includes(proposal.status)) {
-      return null;
-    }
-    const startBlock = Number(proposal.startBlock);
-    const endBlock = Number(proposal.endBlock);
-
-    if (currentBlock.number < startBlock) {
-      const startDate = estimateBlockTime(
-        startBlock,
-        currentBlock.number,
-        currentBlock.timestamp,
-      );
-      return "Starts " + moment(startDate).fromNow();
-    } else if (currentBlock.number < endBlock) {
-      const endDate = estimateBlockTime(
-        endBlock,
-        currentBlock.number,
-        currentBlock.timestamp,
-      );
-      return "Ends " + moment(endDate).fromNow();
-    }
-    return null;
-  };
-  const dateBadgeText = getDateBadgeText();
-
-  return (
-    <div
-      onClick={() => setProposal(proposal.id)}
-      className={mergeClasses(
-        "flex overflow-hidden border border-gray-200 bg-gray-50 rounded-[8px]",
-        "p-3 py-2.5 gap-3 cursor-pointer hover:bg-white items-center",
-      )}
-    >
-      <div className="flex flex-col md:flex flex-auto flex-nowrap gap-1.5">
-        <p className="flex-auto font-medium text-sm/[1.25] mb-0">
-          <span className="flex-none mr-2 text-gray-400 font-bold">
-            {proposal.id}
-          </span>
-          {proposal.title}
-        </p>
-        {dateBadgeText && (
-          <div>
-            <Badge
-              className={mergeClasses(
-                baseBadgeClassNames,
-                "text-gray-600 bg-gray-200",
-              )}
-              variant="secondary"
-            >
-              <MdAccessTimeFilled size={12} className="text-gray-500" />
-              {dateBadgeText}
-            </Badge>
-          </div>
-        )}
-      </div>
-      <StatusBadge status={proposal.status} />
-    </div>
-  );
-};
-
+import BuilderProposalDetailView from "./BuilderProposalDetailView";
+import ProposalDetailView from "./ProposalDetailView";
+import BuilderProposalItem from "./BuilderProposalItem";
+import ProposalListRowItem from "./ProposalListRowItem";
+import React from "react";
 export const ProposalListView = ({
   proposals,
   setProposal,
   currentBlock,
   loading,
+  isBuilderSubgraph,
+  selectedProposal,
+  goBack,
+  proposalLoading,
 }: {
-  proposals: ProposalData[];
-  setProposal: (proposal: ProposalData) => void;
+  proposals: any[];
+  setProposal: (proposalId: string) => void;
   currentBlock: any;
   loading: boolean;
+  isBuilderSubgraph: boolean;
+  selectedProposal: any;
+  goBack: () => void;
+  proposalLoading: boolean;
 }) => {
   if (loading) {
     return <div>Fetching data...</div>;
+  }
+
+  if (selectedProposal) {
+    return isBuilderSubgraph ? (
+      <BuilderProposalDetailView
+        proposal={selectedProposal}
+        goBack={goBack}
+        loading={proposalLoading}
+      />
+    ) : (
+      <ProposalDetailView
+        proposal={selectedProposal}
+        versions={[]}
+        goBack={goBack}
+        currentBlock={currentBlock}
+        loading={proposalLoading}
+      />
+    );
   }
 
   return (
     <>
       <CardHeader className="px-0 pt-2 pb-4">
         <CardDescription className="font-semibold text-sm/[1.0]">
-          Nouns DAO
+          {isBuilderSubgraph ? "Builder DAO" : "Nouns DAO"}
         </CardDescription>
         <CardTitle className="text-xl">Proposals</CardTitle>
       </CardHeader>
       <div className="grid gap-2">
-        {proposals.map((proposal, i) => (
-          <ProposalListRowItem
-            key={i}
-            proposal={proposal}
-            setProposal={setProposal}
-            currentBlock={currentBlock}
-          />
-        ))}
+        {proposals.map((proposal, i) =>
+          isBuilderSubgraph ? (
+            <BuilderProposalItem
+              key={i}
+              proposal={proposal}
+              setProposal={setProposal}
+            />
+          ) : (
+            <ProposalListRowItem
+              key={i}
+              proposal={proposal}
+              setProposal={setProposal}
+              currentBlock={currentBlock}
+            />
+          ),
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
Added a separated files for proposal queries
Created a couple of components under community fidgets
- ProposalItem and ProposalView for Builder Daos
Adapted NounishGovernance to differentiate different query types, currently:
- Nouns ETH dao
- Base Builder dao

