### PR TITLE
fix: make sign up link clickable

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,16 +7,16 @@ const withBundleAnalyzer = bundlerAnalyzer({
 const cspHeader = `
     default-src 'self';
     script-src 'self' 'unsafe-eval' 'unsafe-inline' https://challenges.cloudflare.com https://www.youtube.com/iframe_api https://auth.privy.nounspace.com;
-    style-src 'self' 'unsafe-inline' https://i.ytimg.com;
+    style-src 'self' 'unsafe-inline' https://i.ytimg.com https://mint.highlight.xyz;
     img-src 'self' blob: data: https: https://i.ytimg.com;
     font-src 'self' https:;
-    object-src 'none';
+    object-src 'self';
     base-uri 'self';
     form-action 'self';
     frame-ancestors 'self';
     frame-src 'self' https://auth.privy.nounspace.com https://verify.walletconnect.com https://verify.walletconnect.org https://challenges.cloudflare.com https://www.youtube.com https://*;
     child-src 'self' https://auth.privy.nounspace.com https://verify.walletconnect.com https://verify.walletconnect.org https://www.youtube.com https://*;
-    connect-src 'self' ${process.env.NEXT_PUBLIC_SUPABASE_URL} https://auth.privy.nounspace.com wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org https://*.rpc.privy.systems https://auth.privy.io https://auth.privy.io/api/v1/apps/clw9qpfkl01nnpox6rcsb5wy3 wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org https://*.rpc.privy.systems;
+    connect-src 'self' ${process.env.NEXT_PUBLIC_SUPABASE_URL} https://auth.privy.nounspace.com https://privy.nounspace.com/api/v1/analytics_events wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org https://*.rpc.privy.systems https://auth.privy.io https://auth.privy.io/api/v1/apps/clw9qpfkl01nnpox6rcsb5wy3 wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org https://*.rpc.privy.systems;
     upgrade-insecure-requests;
 `;
 

--- a/src/authenticators/farcaster/signers/NounspaceManagedSignerAuthenticator.tsx
+++ b/src/authenticators/farcaster/signers/NounspaceManagedSignerAuthenticator.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/pages/api/signerRequests";
 import QRCode from "@/common/components/atoms/qr-code";
 import { SignatureScheme } from "@farcaster/core";
+import Link from "next/link";
 
 export type NounspaceDeveloperManagedSignerData =
   FarcasterSignerAuthenticatorData & {
@@ -231,7 +232,9 @@ const initializer: AuthenticatorInitializer<
       ) : loading && data.signerUrl ? (
         <>
           <QRCode value={data.signerUrl} maxWidth={256} />
-          <p>{data.signerUrl}</p>
+          <Link href={data.signerUrl}>
+            <p>On mobile? Click here</p>
+          </Link>
         </>
       ) : (
         <Spinner />

--- a/src/constants/userNotLoggedInHomebase.tsx
+++ b/src/constants/userNotLoggedInHomebase.tsx
@@ -1,5 +1,4 @@
 import { SpaceConfig } from "@/common/components/templates/Space";
-import { NOUNISH_LOWFI_URL } from "./nounishLowfi";
 
 const layoutID = "";
 
@@ -111,7 +110,7 @@ const USER_NOT_LOGGED_IN_HOMEBASE_CONFIG: SpaceConfig = {
       fontColor: "#000000",
       headingsFont: "Inter",
       headingsFontColor: "#000000",
-      musicURL: NOUNISH_LOWFI_URL,
+      musicURL: "https://www.youtube.com/watch?v=biiH_-nBfQs&list=PLRRiqw2OEIPHQe6X0qeQ6VkJUOqKKr_aM&index=1",
     },
   },
   fidgetInstanceDatums: {


### PR DESCRIPTION
The links work on Android if you copy then into a browser, but the default "search" on an Android doesn't actually resolve non-http links. Making the url clickable makes it open in a browser and redirect