### PR TITLE
Fix logout flow + assorted related bugs

### DIFF
--- a/src/authenticators/AuthenticatorManager.tsx
+++ b/src/authenticators/AuthenticatorManager.tsx
@@ -78,9 +78,12 @@ type AuthenticatorManagerResponse =
 export type AuthenticatorManager = {
   // If Authenticator is not initialized, will always return denied
   callMethod: (
-    requestingFidgetId: string,
-    authenticatorId: string,
-    methodName: string,
+    callSignature: {
+      requestingFidgetId: string;
+      authenticatorId: string;
+      methodName: string;
+      isLookup?: boolean;
+    },
     ...args: any[]
   ) => Promise<AuthenticatorManagerResponse>;
   initializeAuthenticators: (authenticatorIds: string[]) => void;
@@ -159,10 +162,8 @@ export const AuthenticatorManagerProvider: React.FC<
   const authenticatorManager = useMemo<AuthenticatorManager>(
     () => ({
       callMethod: async (
-        requestingFidgetId: string,
-        authenticatorId: string,
-        methodName: string,
-        ...args: any[]
+        { requestingFidgetId, authenticatorId, methodName, isLookup = false },
+        ...args
       ): Promise<AuthenticatorManagerResponse> => {
         const authenticator = installedAuthenticators[authenticatorId];
         if (isUndefined(authenticator)) {
@@ -172,7 +173,8 @@ export const AuthenticatorManagerProvider: React.FC<
           // TO DO: When adding permissioning
           // Allow client requests to not open modal
           // While Fidget requests will
-          if (!modalOpen && requestingFidgetId !== "navigation") {
+          if (!modalOpen && !isLookup) {
+            console.log("Auth Manager Calling Open Modal", requestingFidgetId);
             setModalOpen(true);
           }
           return {

--- a/src/common/components/pages/UserDefinedSpace.tsx
+++ b/src/common/components/pages/UserDefinedSpace.tsx
@@ -67,11 +67,12 @@ export default function UserDefinedSpace({
   const [currentUserFid, setCurrentUserFid] = useState<number | null>(null);
   useEffect(() => {
     if (!isSignedIntoFarcaster) return;
-    authManagerCallMethod(
-      "root",
-      FARCASTER_NOUNSPACE_AUTHENTICATOR_NAME,
-      "getAccountFid",
-    ).then((authManagerResp) => {
+    authManagerCallMethod({
+      requestingFidgetId: "root",
+      authenticatorId: FARCASTER_NOUNSPACE_AUTHENTICATOR_NAME,
+      methodName: "getAccountFid",
+      isLookup: true,
+    }).then((authManagerResp) => {
       if (authManagerResp.result === "success") {
         setCurrentUserFid(authManagerResp.value as number);
       }

--- a/src/common/data/stores/app/accounts/authenticatorStore.ts
+++ b/src/common/data/stores/app/accounts/authenticatorStore.ts
@@ -22,6 +22,7 @@ export interface AuthenticatorActions {
   commitAuthenticatorUpdatesToDatabase: () => Promise<void>;
   saveAuthenticatorConfig: (newConfig: AuthenticatorConfig) => Promise<void>;
   listInstalledAuthenticators: () => string[];
+  resetAuthenticators: () => void;
 }
 
 export type AuthenticatorStore = AuthenticatorState & AuthenticatorActions;
@@ -36,6 +37,16 @@ export const authenticatorStore = (
   get: StoreGet<AppStore>,
 ): AuthenticatorStore => ({
   ...authenticatorDefaults,
+  resetAuthenticators: () => {
+    set(
+      (draft) => {
+        draft.account.authenticatorConfig = {};
+        draft.account.authenticatorRemoteConfig = {};
+      },
+      "resetAuthenticators",
+      true,
+    );
+  },
   listInstalledAuthenticators: () => {
     return keys(get().account.authenticatorConfig);
   },

--- a/src/common/data/stores/app/accounts/identityStore.ts
+++ b/src/common/data/stores/app/accounts/identityStore.ts
@@ -76,6 +76,7 @@ interface IdentityActions {
   getCurrentIdentity: () => SpaceIdentity | undefined;
   getCurrentIdentityIndex: () => number;
   getIdentitiesForWallet: (wallet: Wallet) => IdentityRequest[];
+  resetIdenities: () => void;
 }
 
 export type IdentityStore = IdentityState & IdentityActions;
@@ -144,6 +145,17 @@ export const identityStore = (
   get: StoreGet<AppStore>,
 ): IdentityStore => ({
   ...identityDefault,
+  resetIdenities: () => {
+    set(
+      (draft) => {
+        draft.account.currentSpaceIdentityPublicKey = "";
+        draft.account.spaceIdentities = [];
+        draft.account.walletIdentities = {};
+      },
+      "resetIdenities",
+      true,
+    );
+  },
   getCurrentIdentity: () => {
     const state = get();
     return find(state.account.spaceIdentities, {

--- a/src/common/data/stores/app/accounts/index.ts
+++ b/src/common/data/stores/app/accounts/index.ts
@@ -25,7 +25,9 @@ export type AccountStore = IdentityStore &
   AuthenticatorStore &
   PreKeyStore &
   FarcasterStore &
-  PrivyStore;
+  PrivyStore & {
+    reset: () => void;
+  };
 
 export const accountStoreDefaults: Partial<AccountStore> = {
   ...privyDefault,
@@ -43,6 +45,10 @@ export const createAccountStoreFunc = (
   ...privyStore(set),
   ...authenticatorStore(set, get),
   ...farcasterStore(set, get),
+  reset: () => {
+    get().account.resetIdenities();
+    get().account.resetAuthenticators();
+  },
 });
 
 export const partializedAccountStore = (state: AppStore) => ({

--- a/src/common/data/stores/app/homebase/index.ts
+++ b/src/common/data/stores/app/homebase/index.ts
@@ -24,6 +24,7 @@ interface HomeBaseStoreActions {
   commitHomebaseToDatabase: () => Promise<void>;
   saveHomebaseConfig: (config: SpaceConfig) => Promise<void>;
   resetHomebaseConfig: () => Promise<void>;
+  clearHomebase: () => void;
 }
 
 export type HomeBaseStore = HomeBaseStoreState & HomeBaseStoreActions;
@@ -100,6 +101,16 @@ export const createHomeBaseStoreFunc = (
     set((draft) => {
       draft.homebase.homebaseConfig = draft.homebase.remoteHomebaseConfig;
     });
+  },
+  clearHomebase: () => {
+    set(
+      (draft) => {
+        draft.homebase.homebaseConfig = undefined;
+        draft.homebase.remoteHomebaseConfig = undefined;
+      },
+      "clearHomebase",
+      true,
+    );
   },
 });
 

--- a/src/common/data/stores/app/index.ts
+++ b/src/common/data/stores/app/index.ts
@@ -1,6 +1,9 @@
-import { rawReturn } from "mutative";
 import { createJSONStorage } from "zustand/middleware";
-import { createStore, createStoreBindings } from "../createStore";
+import {
+  createStore,
+  createStoreBindings,
+  MatativeConfig,
+} from "../createStore";
 import {
   AccountStore,
   createAccountStoreFunc,
@@ -32,21 +35,15 @@ export type AppStore = {
 
 const LOCAL_STORAGE_LOCATION = "nounspace-app-store";
 
-const makeStoreFunc = (set, get, state): AppStore => ({
+const makeStoreFunc: MatativeConfig<AppStore> = (set, get, state) => ({
   setup: createSetupStoreFunc(set, get),
   account: createAccountStoreFunc(set, get, state),
   homebase: createHomeBaseStoreFunc(set, get),
   space: createSpaceStoreFunc(set, get),
   logout: () => {
-    set(
-      (_draft) => {
-        return rawReturn({
-          ...makeStoreFunc(set, get, state),
-        });
-      },
-      "logout",
-      true,
-    );
+    get().account.reset();
+    get().homebase.clearHomebase();
+    get().space.clear();
     localStorage.removeItem(LOCAL_STORAGE_LOCATION);
   },
   getIsAccountReady: () => {

--- a/src/common/data/stores/app/index.ts
+++ b/src/common/data/stores/app/index.ts
@@ -80,15 +80,13 @@ const { useStore: useAppStore, provider: AppStoreProvider } =
 
 function useLogout() {
   const { logout: privyLogout } = usePrivy();
-  const { storeLogout, setLoginModalOpen } = useAppStore((state) => ({
+  const { storeLogout } = useAppStore((state) => ({
     storeLogout: state.logout,
-    setLoginModalOpen: state.setup.setModalOpen,
   }));
 
   async function logout() {
     await privyLogout();
     storeLogout();
-    setLoginModalOpen(true);
   }
 
   return logout;

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -67,6 +67,7 @@ interface SpaceActions {
     spaceId: string,
     config: UpdatableSpaceConfig,
   ) => Promise<void>;
+  clear: () => void;
 }
 
 export type SpaceStore = SpaceState & SpaceActions;
@@ -237,6 +238,17 @@ export const createSpaceStoreFunc = (
     set((draft) => {
       draft.space.localSpaces[spaceId] = config;
     });
+  },
+  clear: () => {
+    set(
+      (draft) => {
+        draft.space.localSpaces = {};
+        draft.space.editableSpaces = {};
+        draft.space.remoteSpaces = {};
+      },
+      "clearSpaces",
+      true,
+    );
   },
 });
 

--- a/src/common/data/stores/createStore.ts
+++ b/src/common/data/stores/createStore.ts
@@ -10,9 +10,9 @@ type MutativeConfigSetFunction<T> = (
   fn: MutativeFunction<T>,
   name?: string,
   commit?: boolean,
-) => void;
+) => void | StoreReset<T>;
 
-type MatativeConfig<T> = (
+export type MatativeConfig<T> = (
   set: MutativeConfigSetFunction<T>,
   get: StoreApi<T>["getState"],
   store: T,
@@ -47,10 +47,7 @@ export const mutative =
     );
 
 type StoreReset<T> = (newState: Draft<T>) => void;
-export type StoreSet<T> = (
-  fn: MutativeFunction<T>,
-  name?: string,
-) => void | StoreReset<T>;
+export type StoreSet<T> = MutativeConfigSetFunction<T>;
 export type StoreGet<T> = () => T;
 
 export function createStore<T>(

--- a/src/common/providers/LoggedInStateProvider.tsx
+++ b/src/common/providers/LoggedInStateProvider.tsx
@@ -254,7 +254,11 @@ const LoggedInStateProvider: React.FC<LoggedInLayoutProps> = ({ children }) => {
           setCurrentStep(SetupStep.DONE);
         }
       }
-    } else if (ready && !authenticated) {
+    } else if (
+      ready &&
+      !authenticated &&
+      currentStep !== SetupStep.NOT_SIGNED_IN
+    ) {
       setCurrentStep(SetupStep.NOT_SIGNED_IN);
     }
   }, [currentStep, walletsReady, ready, authenticated]);

--- a/src/common/providers/LoggedInStateProvider.tsx
+++ b/src/common/providers/LoggedInStateProvider.tsx
@@ -168,21 +168,26 @@ const LoggedInStateProvider: React.FC<LoggedInLayoutProps> = ({ children }) => {
       await loadFidsForCurrentIdentity();
       currentIdentity = getCurrentIdentity()!;
       if (currentIdentity.associatedFids.length === 0) {
-        const fidResult = (await authenticatorManager.callMethod(
-          "root",
-          "farcaster:nounspace",
-          "getAccountFid",
-        )) as { value: number };
-        const publicKeyResult = (await authenticatorManager.callMethod(
-          "root",
-          "farcaster:nounspace",
-          "getSignerPublicKey",
-        )) as { value: Uint8Array };
+        const fidResult = (await authenticatorManager.callMethod({
+          requestingFidgetId: "root",
+          authenticatorId: "farcaster:nounspace",
+          methodName: "getAccountFid",
+          isLookup: true,
+        })) as { value: number };
+        const publicKeyResult = (await authenticatorManager.callMethod({
+          requestingFidgetId: "root",
+          authenticatorId: "farcaster:nounspace",
+          methodName: "getSignerPublicKey",
+          isLookup: true,
+        })) as { value: Uint8Array };
         const signForFid = async (messageHash) => {
           const signResult = (await authenticatorManager.callMethod(
-            "root",
-            "farcaster:nounspace",
-            "signMessage",
+            {
+              requestingFidgetId: "root",
+              authenticatorId: "farcaster:nounspace",
+              methodName: "signMessage",
+              isLookup: false,
+            },
             messageHash,
           )) as { value: Uint8Array };
           return signResult.value;
@@ -245,6 +250,7 @@ const LoggedInStateProvider: React.FC<LoggedInLayoutProps> = ({ children }) => {
         } else if (currentStep === SetupStep.AUTHENTICATORS_INITIALIZED) {
           registerAccounts();
         } else if (currentStep === SetupStep.ACCOUNTS_REGISTERED) {
+          setModalOpen(false);
           setCurrentStep(SetupStep.DONE);
         }
       }

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 import { Properties } from "csstype";
 import { mergeClasses as classNames } from "@/common/lib/utils/mergeClasses";
 import {

--- a/src/fidgets/farcaster/index.tsx
+++ b/src/fidgets/farcaster/index.tsx
@@ -14,11 +14,12 @@ const createFarcasterSignerFromAuthenticatorManager = async (
   fidgetId: string,
   authenticatorName: string = "farcaster:nounspace",
 ): Promise<Signer> => {
-  const schemeResult = await authenticatorManager.callMethod(
-    fidgetId,
-    authenticatorName,
-    "getSignerScheme",
-  );
+  const schemeResult = await authenticatorManager.callMethod({
+    requestingFidgetId: fidgetId,
+    authenticatorId: authenticatorName,
+    methodName: "getSignerScheme",
+    isLookup: true,
+  });
   const scheme =
     schemeResult.result === "success"
       ? (schemeResult.value as SignatureScheme)
@@ -26,11 +27,12 @@ const createFarcasterSignerFromAuthenticatorManager = async (
   return {
     scheme,
     getSignerKey: async () => {
-      const methodResult = await authenticatorManager.callMethod(
-        fidgetId,
-        authenticatorName,
-        "getSignerPublicKey",
-      );
+      const methodResult = await authenticatorManager.callMethod({
+        requestingFidgetId: fidgetId,
+        authenticatorId: authenticatorName,
+        methodName: "getSignerPublicKey",
+        isLookup: true,
+      });
       if (methodResult.result === "success") {
         return ok(methodResult.value as Uint8Array);
       }
@@ -38,9 +40,12 @@ const createFarcasterSignerFromAuthenticatorManager = async (
     },
     signMessageHash: async (hash: Uint8Array) => {
       const methodResult = await authenticatorManager.callMethod(
-        fidgetId,
-        authenticatorName,
-        "signMessage",
+        {
+          requestingFidgetId: fidgetId,
+          authenticatorId: authenticatorName,
+          methodName: "signMessage",
+          isLookup: false,
+        },
         hash,
       );
       if (methodResult.result === "success") {
@@ -77,7 +82,12 @@ export function useFarcasterSigner(
   const [fid, setFid] = useState(-1);
   useEffect(() => {
     authenticatorManager
-      .callMethod(fidgetId, FARCASTER_AUTHENTICATOR_NAME, "getAccountFid")
+      .callMethod({
+        requestingFidgetId: fidgetId,
+        authenticatorId: FARCASTER_AUTHENTICATOR_NAME,
+        methodName: "getAccountFid",
+        isLookup: true,
+      })
       .then((methodResult) => {
         if (methodResult.result === "success") {
           return setFid(methodResult.value as number);

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -155,16 +155,16 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   const [localFidgetTrayContents, setLocalFidgetTrayContents] =
     useState(fidgetTrayContents);
   useEffect(() => {
-    setLocalFidgetTrayContents(localFidgetTrayContents);
-  }, [localFidgetTrayContents]);
+    setLocalFidgetTrayContents(fidgetTrayContents);
+  }, [fidgetTrayContents]);
   const [localLayout, setLocalLayout] = useState(layoutConfig.layout);
   useEffect(() => {
-    setLocalLayout(localLayout);
-  }, [localLayout]);
+    setLocalLayout(layoutConfig.layout);
+  }, [layoutConfig.layout]);
   const [localTheme, setLocalTheme] = useState(theme);
   useEffect(() => {
-    setLocalTheme(localTheme);
-  }, [localTheme]);
+    setLocalTheme(theme);
+  }, [theme]);
   const [hasLocalChanges, setHasLocalChanges] = useState(false);
 
   const gridDetails = useMemo(() => makeGridDetails(hasProfile), [hasProfile]);


### PR DESCRIPTION
Now properly clears the store when you logout.

This also:
- makes it so the login modal no longer pops up all the time (when first loading the page or logging out)
- reduces page rerenders with constant state update loops
- fixes Grid reactivity issues that caused homebase to empty on logout