### PR TITLE
Update Spaces using merge instead of keeping Grid Local state

### DIFF
--- a/src/common/components/pages/SpacePage.tsx
+++ b/src/common/components/pages/SpacePage.tsx
@@ -1,12 +1,12 @@
 import React, { ReactNode, useRef, useState } from "react";
 import Sidebar from "../organisms/Sidebar";
-import Space, { SpaceConfig } from "../templates/Space";
+import Space, { SpaceConfig, SpaceConfigSaveDetails } from "../templates/Space";
 import { isUndefined } from "lodash";
 import SpaceLoading from "../templates/SpaceLoading";
 
 type SpacePageArgs = {
   config?: SpaceConfig;
-  saveConfig?: (config: SpaceConfig) => Promise<void>;
+  saveConfig?: (config: SpaceConfigSaveDetails) => Promise<void>;
   commitConfig?: () => Promise<void>;
   resetConfig?: () => Promise<void>;
   profile?: ReactNode;

--- a/src/common/components/pages/UserDefinedSpace.tsx
+++ b/src/common/components/pages/UserDefinedSpace.tsx
@@ -93,12 +93,13 @@ export default function UserDefinedSpace({
     [fid],
   );
 
+  const currentSpaceConfig = getCurrentSpaceConfig();
+
   const config: SpaceConfig | undefined = useMemo(() => {
     if (!isNil(spaceId)) {
       if (loading) {
         return undefined;
       }
-      const currentSpaceConfig = getCurrentSpaceConfig();
       if (loadSuccess && currentSpaceConfig) {
         return {
           ...currentSpaceConfig,
@@ -110,7 +111,7 @@ export default function UserDefinedSpace({
       ...INITIAL_PERSONAL_SPACE_CONFIG,
       isEditable,
     };
-  }, [spaceId, isEditable, loading, loadSuccess, fid]);
+  }, [spaceId, isEditable, loading, loadSuccess, fid, currentSpaceConfig]);
 
   useEffect(() => {
     if (isEditable && isNil(spaceId) && !isNil(currentUserFid)) {

--- a/src/common/components/pages/UserDefinedSpace.tsx
+++ b/src/common/components/pages/UserDefinedSpace.tsx
@@ -3,8 +3,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuthenticatorManager } from "@/authenticators/AuthenticatorManager";
 import { useAppStore } from "@/common/data/stores/app";
 import createIntialPersonSpaceConfigForFid from "@/constants/initialPersonSpace";
-import { SpaceConfig } from "../templates/Space";
-import { UpdatableSpaceConfig } from "@/common/data/stores/app/space/spaceStore";
+import { SpaceConfig, SpaceConfigSaveDetails } from "../templates/Space";
 import Profile from "@/fidgets/ui/profile";
 import SpacePage from "./SpacePage";
 
@@ -122,14 +121,14 @@ export default function UserDefinedSpace({
   }, [isEditable, spaceId, currentUserFid]);
 
   const saveConfig = useCallback(
-    async (spaceConfig: SpaceConfig) => {
+    async (spaceConfig: SpaceConfigSaveDetails) => {
       if (isNil(currentUserFid)) {
         throw new Error("Attempted to save config when user is not signed in!");
       }
       if (isNil(spaceId)) {
         throw new Error("Cannot save config until space is registered");
       }
-      const saveableConfig: UpdatableSpaceConfig = {
+      const saveableConfig = {
         ...spaceConfig,
         fidgetInstanceDatums: mapValues(
           spaceConfig.fidgetInstanceDatums,

--- a/src/common/components/templates/Space.tsx
+++ b/src/common/components/templates/Space.tsx
@@ -29,9 +29,15 @@ export type SpaceConfig = {
   theme: UserTheme;
 };
 
+export type SpaceConfigSaveDetails = Partial<
+  Omit<SpaceConfig, "layoutDetails">
+> & {
+  layoutDetails?: Partial<LayoutFidgetDetails<LayoutFidgetConfig<any>>>;
+};
+
 type SpaceArgs = {
   config: SpaceConfig;
-  saveConfig: (config: SpaceConfig) => Promise<void>;
+  saveConfig: (config: SpaceConfigSaveDetails) => Promise<void>;
   commitConfig: () => Promise<void>;
   resetConfig: () => Promise<void>;
   profile?: ReactNode;
@@ -71,13 +77,13 @@ export default function Space({
     layoutConfig,
     fidgetInstanceDatums,
     fidgetTrayContents,
-  }: LayoutFidgetSaveableConfig<LayoutFidgetConfig<any>>) {
+  }: Partial<LayoutFidgetSaveableConfig<LayoutFidgetConfig<any>>>) {
     return saveConfig({
-      ...config,
-      layoutDetails: {
-        ...config.layoutDetails,
-        layoutConfig,
-      },
+      layoutDetails: layoutConfig
+        ? {
+            layoutConfig,
+          }
+        : undefined,
       theme,
       fidgetInstanceDatums,
       fidgetTrayContents,

--- a/src/common/data/stores/app/accounts/identityStore.ts
+++ b/src/common/data/stores/app/accounts/identityStore.ts
@@ -171,7 +171,7 @@ export const identityStore = (
   setCurrentIdentity: (publicKey: string) => {
     set((draft) => {
       draft.account.currentSpaceIdentityPublicKey = publicKey;
-    });
+    }, "setCurrentIdentity");
   },
   loadIdentitiesForWallet: async (wallet: Wallet) => {
     // Load Identity + Nonce + Wallet address info from DB
@@ -190,7 +190,7 @@ export const identityStore = (
       : [];
     set((draft) => {
       draft.account.walletIdentities[wallet.address] = walletIdentities;
-    });
+    }, "loadIdentitiesForWallet");
     return walletIdentities;
   },
   getIdentitiesForWallet: (wallet: Wallet) => {
@@ -255,7 +255,7 @@ export const identityStore = (
         preKeys: [],
         associatedFids: [],
       });
-    });
+    }, "decryptIdentityKeys");
   },
   createIdentityForWallet: async (
     signMessage: SignMessageFunctionSignature,
@@ -307,7 +307,7 @@ export const identityStore = (
         preKeys: [],
         associatedFids: [],
       });
-    });
+    }, "createIdentityForWallet");
     return identityKeys.publicKey;
   },
 });

--- a/src/common/data/stores/app/accounts/prekeyStore.ts
+++ b/src/common/data/stores/app/accounts/prekeyStore.ts
@@ -173,7 +173,7 @@ export const prekeyStore = (
         ),
         ["timestamp"],
       );
-    });
+    }, "addPreKeysToIdentity");
   },
   loadPreKeys: async () => {
     const { data } = await axiosBackend.get<PreKeyResponse>(

--- a/src/common/data/stores/app/accounts/privyStore.ts
+++ b/src/common/data/stores/app/accounts/privyStore.ts
@@ -71,7 +71,7 @@ export const privyStore = (set: StoreSet<AppStore>): PrivyStore => ({
   setPrivyUser: (user: PrivyUser) => {
     set((draft) => {
       draft.account.privyUser = user;
-    });
+    }, "setPrivyUser");
   },
 });
 

--- a/src/common/data/stores/app/homebase/index.ts
+++ b/src/common/data/stores/app/homebase/index.ts
@@ -4,10 +4,13 @@ import axios from "axios";
 import { createClient } from "../../../database/supabase/clients/component";
 import { homebasePath } from "@/constants/supabase";
 import { SignedFile } from "@/common/lib/signedFiles";
-import { debounce } from "lodash";
+import { debounce, isArray, mergeWith } from "lodash";
 import stringify from "fast-json-stable-stringify";
 import axiosBackend from "../../../api/backend";
-import { SpaceConfig } from "@/common/components/templates/Space";
+import {
+  SpaceConfig,
+  SpaceConfigSaveDetails,
+} from "@/common/components/templates/Space";
 import INITIAL_HOMEBASE_CONFIG from "@/constants/intialHomebase";
 import {
   analytics,
@@ -22,7 +25,7 @@ interface HomeBaseStoreState {
 interface HomeBaseStoreActions {
   loadHomebase: () => Promise<SpaceConfig>;
   commitHomebaseToDatabase: () => Promise<void>;
-  saveHomebaseConfig: (config: SpaceConfig) => Promise<void>;
+  saveHomebaseConfig: (config: SpaceConfigSaveDetails) => Promise<void>;
   resetHomebaseConfig: () => Promise<void>;
   clearHomebase: () => void;
 }
@@ -94,7 +97,13 @@ export const createHomeBaseStoreFunc = (
   },
   saveHomebaseConfig: async (config) => {
     set((draft) => {
-      draft.homebase.homebaseConfig = config;
+      draft.homebase.homebaseConfig = mergeWith(
+        get().homebase.homebaseConfig,
+        config,
+        (newItem) => {
+          if (isArray(newItem)) return newItem;
+        },
+      );
     });
   },
   resetHomebaseConfig: async () => {

--- a/src/common/data/stores/app/index.ts
+++ b/src/common/data/stores/app/index.ts
@@ -15,7 +15,7 @@ import {
   HomeBaseStore,
   createHomeBaseStoreFunc,
   partializedHomebaseStore,
-} from "./homebase";
+} from "./homebase/homebaseStore";
 import {
   createSpaceStoreFunc,
   partializedSpaceStore,

--- a/src/common/fidgets/index.d.ts
+++ b/src/common/fidgets/index.d.ts
@@ -92,12 +92,12 @@ export interface FidgetModule<P extends FidgetArgs> {
 }
 
 type LayoutFidgetSavableConfig<C extends LayoutFidgetConfig> = {
-  fidgetInstanceDatums: {
+  fidgetInstanceDatums?: {
     [key: string]: FidgetInstanceData;
   };
-  layoutConfig: C;
-  fidgetTrayContents: FidgetInstanceData[];
-  theme: UserTheme;
+  layoutConfig?: C;
+  fidgetTrayContents?: FidgetInstanceData[];
+  theme?: UserTheme;
 };
 
 interface LayoutFidgetProps<C extends LayoutFidgetConfig> {

--- a/src/constants/intialHomebase.ts
+++ b/src/constants/intialHomebase.ts
@@ -1,13 +1,8 @@
 import { SpaceConfig } from "@/common/components/templates/Space";
-import { LayoutFidgetConfig, LayoutFidgetDetails } from "@/common/fidgets";
 import DEFAULT_THEME from "@/common/lib/theme/defaultTheme";
-import { FeedType, FilterType } from "@neynar/nodejs-sdk";
+import { FeedType } from "@neynar/nodejs-sdk";
 
 const layoutID = "";
-const layoutDetails: LayoutFidgetDetails<LayoutFidgetConfig<any[]>> = {
-  layoutConfig: { layout: [] },
-  layoutFidget: "grid",
-};
 const INITIAL_HOMEBASE_CONFIG: SpaceConfig = {
   layoutID,
   layoutDetails: {

--- a/src/fidgets/farcaster/Frame.tsx
+++ b/src/fidgets/farcaster/Frame.tsx
@@ -19,9 +19,9 @@ const frameProperties: FidgetProperties = {
     },
   ],
   size: {
-    minHeight: 1,
+    minHeight: 2,
     maxHeight: 36,
-    minWidth: 1,
+    minWidth: 2,
     maxWidth: 36,
   },
   icon: 0x23f9, // ⏹

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -465,7 +465,7 @@ export const CastRow = ({
           <CreateCast initialDraft={replyCastDraft} />
         </div>
       </Modal>
-      <button onClick={onSelect}>
+      <div onClick={onSelect}>
         <div className="p-3">
           <div className="flex items-top gap-x-2">
             <CastLeftAvatar isEmbed={isEmbed} cast={cast} />
@@ -482,7 +482,7 @@ export const CastRow = ({
             />
           </div>
         </div>
-      </button>
+      </div>
     </div>
   );
 };

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -204,8 +204,6 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     item: PlacedGridItem,
     e: DragEvent<HTMLDivElement>,
   ) {
-    setCurrentlyDragging(false);
-
     const fidgetData: FidgetInstanceData = JSON.parse(
       e.dataTransfer.getData("text/plain"),
     );
@@ -233,6 +231,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     analytics.track(AnalyticsEvent.ADD_FIDGET, {
       fidgetType: fidgetData.fidgetType,
     });
+    setCurrentlyDragging(false);
   }
 
   function removeFidgetFromTray(fidgetId: string) {
@@ -260,19 +259,25 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     delete newFidgetInstanceDatums[fidgetId];
 
     //Make new layout with item removed
-    const newLayoutConfig = {
-      layout: reject(layoutConfig.layout, (x) => x.i == fidgetId),
-    };
+    const newLayout = reject(layoutConfig.layout, (x) => x.i == fidgetId);
 
     // Clear editor panel
     unselectFidget();
 
-    saveLayoutConditional(newLayoutConfig.layout);
+    saveLayout(newLayout);
     saveFidgetInstanceDatums(newFidgetInstanceDatums);
   }
 
   function saveLayoutConditional(newLayout: PlacedGridItem[]) {
-    if (!currentlyDragging && inEditMode) {
+    // We only use to move items on the grid
+    // We only update if the same items exist
+    // We aren't adding or removing an item
+    // And we are in edit mode
+    if (
+      !currentlyDragging &&
+      inEditMode &&
+      newLayout.length === layoutConfig.layout.length
+    ) {
       saveLayout(newLayout);
     }
   }


### PR DESCRIPTION
This removes all of the Grid local state and instead switches to keeping all space state in the store. To do so, we need to use `cloneDeep` to fix problems with overwriting the same object and `mergeWith` to handle adding changes to the existing store so that we don't overwrite other changes made in the same update step