### PR TITLE
[CLIENT]: fix: allow popups in new tab/window

### DIFF
--- a/src/fidgets/ui/IFrame.tsx
+++ b/src/fidgets/ui/IFrame.tsx
@@ -84,7 +84,7 @@ const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
     <iframe
       src={sanitizedUrl}
       title="IFrame Fidget"
-      sandbox="allow-scripts allow-same-origin"
+      sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
       className="size-full"
     />
   );


### PR DESCRIPTION
Allows users to click links within an iframe that open in a new tab. Closes #278