### PR TITLE
Images from gallery can turn buttons and scale 

### DIFF
--- a/src/common/components/molecules/ImageScaleSlider.tsx
+++ b/src/common/components/molecules/ImageScaleSlider.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Slider } from "@mui/material";
 
-export type WidthSliderProps = {
+export type ImageScaleSliderProps = {
   min: number;
   max: number;
   step?: number;
@@ -9,7 +9,7 @@ export type WidthSliderProps = {
   onChange: (value: number) => void;
 };
 
-const ImageScaleSlider: React.FC<WidthSliderProps> = ({
+const ImageScaleSlider: React.FC<ImageScaleSliderProps> = ({
   min = 0.2,
   max = 3,
   step = 0.1,

--- a/src/common/components/molecules/ImageScaleSlider.tsx
+++ b/src/common/components/molecules/ImageScaleSlider.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Slider } from "@mui/material";
+
+export type WidthSliderProps = {
+  min: number;
+  max: number;
+  step?: number;
+  defaultValue?: number;
+  onChange: (value: number) => void;
+};
+
+const ImageScaleSlider: React.FC<WidthSliderProps> = ({
+  min = 0.2,
+  max = 3,
+  step = 0.1,
+  defaultValue = 1,
+  onChange,
+}) => {
+  return (
+    <div className="ml-3 mr-3">
+      <Slider
+        defaultValue={defaultValue}
+        step={step}
+        min={min}
+        max={max}
+        onChange={(_, value) => onChange(value as number)}
+      />
+    </div>
+  );
+};
+
+export default ImageScaleSlider;

--- a/src/fidgets/ui/gallery.tsx
+++ b/src/fidgets/ui/gallery.tsx
@@ -39,7 +39,7 @@ const galleryConfig: FidgetProperties = {
       required: false,
       inputSelector: ImageScaleSlider,
       default: 1,
-      group: "settings",
+      group: "style",
     },
     ...defaultStyleFields,
   ],

--- a/src/fidgets/ui/gallery.tsx
+++ b/src/fidgets/ui/gallery.tsx
@@ -7,9 +7,12 @@ import {
   type FidgetSettingsStyle,
 } from "@/common/fidgets";
 import { defaultStyleFields } from "@/fidgets/helpers";
+import ImageScaleSlider from "@/common/components/molecules/ImageScaleSlider";
 
 export type GalleryFidgetSettings = {
   imageUrl: string;
+  RedirectionURL: string;
+  Scale: number;
 } & FidgetSettingsStyle;
 
 const galleryConfig: FidgetProperties = {
@@ -24,6 +27,20 @@ const galleryConfig: FidgetProperties = {
         "https://storage.googleapis.com/papyrus_images/d467b07030969fab95a8f44b1de596ab.png",
       group: "settings",
     },
+    {
+      fieldName: "RedirectionURL",
+      required: false,
+      inputSelector: TextInput,
+      default: "",
+      group: "settings",
+    },
+    {
+      fieldName: "Scale",
+      required: false,
+      inputSelector: ImageScaleSlider,
+      default: 1,
+      group: "settings",
+    },
     ...defaultStyleFields,
   ],
   size: {
@@ -34,18 +51,42 @@ const galleryConfig: FidgetProperties = {
   },
 };
 
-const Gallery: React.FC<FidgetArgs<GalleryFidgetSettings>> = ({
-  settings: { imageUrl },
-}) => {
-  const imageUrlStyle = {
-    "--image-url": `url(${imageUrl})`,
+const Gallery: React.FC<FidgetArgs<GalleryFidgetSettings>> = ({ settings }) => {
+  const contentStyle = {
+    backgroundImage: `url(${settings.imageUrl})`,
+    transform: `scale(${settings.Scale})`,
+    transition: "transform 0.3s ease",
   } as CSSProperties;
 
-  return (
-    <div className="rounded-md flex-1 items-center justify-center overflow-hidden relative size-full bg-cover">
+  const wrapperStyle = {
+    overflow: "hidden",
+  } as CSSProperties;
+
+  return settings.RedirectionURL ? (
+    <a
+      href={settings.RedirectionURL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="absolute inset-0"
+    >
       <div
-        className="bg-[image:var(--image-url)] bg-cover size-full overflow-hidden"
-        style={imageUrlStyle}
+        className="rounded-md flex-1 items-center justify-center relative size-full"
+        style={wrapperStyle}
+      >
+        <div
+          className="bg-cover bg-center w-full h-full"
+          style={contentStyle}
+        ></div>
+      </div>
+    </a>
+  ) : (
+    <div
+      className="rounded-md flex-1 items-center justify-center relative size-full"
+      style={wrapperStyle}
+    >
+      <div
+        className="bg-cover bg-center w-full h-full"
+        style={contentStyle}
       ></div>
     </div>
   );


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/32e03fd6-2087-4ae6-ae2b-dc2e4baa7a83)


OBS: I tried to re-use the other molecule I created for the Iframe scaling, but I could pass props for defining max and min for the slider in the inputs selector we can probably reuse more molecules if we can pass props from the fidgets

```js
const ImageScaleSlider: React.FC<ImageScaleSliderProps> = ({
  min = 0.2,
  max = 3,
  step = 0.1,
  defaultValue = 1,
  onChange,
})
```

So I had to repeat the molecule and hardcode those values, appreciate any optimization insights. 