### PR TITLE
refactor: show metadata for all users

### DIFF
--- a/src/common/lib/utils/generateUserMetadataHtml.tsx
+++ b/src/common/lib/utils/generateUserMetadataHtml.tsx
@@ -28,7 +28,7 @@ export const generateUserMetadataHtml = (userMetadata?: UserMetadata) => {
       <meta property="twitter:url" content={spaceUrl} />
       <meta
         property="og:image"
-        content={`https://954c-187-108-213-88.ngrok-free.app/api/metadata/spaces?${queryString}`}
+        content={`https://nounspace.com/api/metadata/spaces?${queryString}`}
       />
       {bio && (
         <>

--- a/src/common/lib/utils/generateUserMetadataHtml.tsx
+++ b/src/common/lib/utils/generateUserMetadataHtml.tsx
@@ -13,8 +13,6 @@ export const generateUserMetadataHtml = (userMetadata?: UserMetadata) => {
   }
 
   const { username, displayName, pfpUrl, bio } = userMetadata;
-  const queryString = new URLSearchParams(userMetadata).toString();
-
   const title = `${displayName} (@${username}) on Nounspace`;
   const spaceUrl = `https://nounspace.com/s/${username}`;
 
@@ -28,7 +26,7 @@ export const generateUserMetadataHtml = (userMetadata?: UserMetadata) => {
       <meta property="twitter:url" content={spaceUrl} />
       <meta
         property="og:image"
-        content={`https://nounspace-ts-git-fork-r4topunk-canary-nounspace.vercel.app/api/metadata/spaces?${queryString}`}
+        content={`https://nounspace-ts-git-fork-r4topunk-canary-nounspace.vercel.app/api/metadata/spaces?username=${username}&displayName=${displayName}&pfpUrl=${pfpUrl}&bio=${bio}`}
       />
       {bio && (
         <>

--- a/src/common/lib/utils/generateUserMetadataHtml.tsx
+++ b/src/common/lib/utils/generateUserMetadataHtml.tsx
@@ -28,7 +28,7 @@ export const generateUserMetadataHtml = (userMetadata?: UserMetadata) => {
       <meta property="twitter:url" content={spaceUrl} />
       <meta
         property="og:image"
-        content={`https://nounspace.com/api/metadata/spaces?${queryString}`}
+        content={`https://nounspace-ts-git-fork-r4topunk-canary-nounspace.vercel.app/api/metadata/spaces?${queryString}`}
       />
       {bio && (
         <>

--- a/src/common/lib/utils/generateUserMetadataHtml.tsx
+++ b/src/common/lib/utils/generateUserMetadataHtml.tsx
@@ -13,6 +13,7 @@ export const generateUserMetadataHtml = (userMetadata?: UserMetadata) => {
   }
 
   const { username, displayName, pfpUrl, bio } = userMetadata;
+  const queryString = new URLSearchParams(userMetadata).toString();
 
   const title = `${displayName} (@${username}) on Nounspace`;
   const spaceUrl = `https://nounspace.com/s/${username}`;
@@ -25,7 +26,10 @@ export const generateUserMetadataHtml = (userMetadata?: UserMetadata) => {
       <meta property="twitter:domain" content="https://nounspace.com/" />
       <meta property="og:url" content={spaceUrl} />
       <meta property="twitter:url" content={spaceUrl} />
-
+      <meta
+        property="og:image"
+        content={`https://954c-187-108-213-88.ngrok-free.app/api/metadata/spaces?${queryString}`}
+      />
       {bio && (
         <>
           <meta name="description" content={bio} />

--- a/src/common/lib/utils/generateUserMetadataHtml.tsx
+++ b/src/common/lib/utils/generateUserMetadataHtml.tsx
@@ -16,6 +16,14 @@ export const generateUserMetadataHtml = (userMetadata?: UserMetadata) => {
   const title = `${displayName} (@${username}) on Nounspace`;
   const spaceUrl = `https://nounspace.com/s/${username}`;
 
+  const encodedDisplayName = encodeURIComponent(displayName || "");
+  const encodedPfpUrl = encodeURIComponent(pfpUrl || "");
+  const encodedBio = encodeURIComponent(bio || "");
+
+  const nounspaceUrl =
+    "https://nounspace-ts-git-fork-r4topunk-canary-nounspace.vercel.app";
+  const ogImageUrl = `${nounspaceUrl}/api/metadata/spaces?username=${username}&displayName=${encodedDisplayName}&pfpUrl=${encodedPfpUrl}&bio=${encodedBio}`;
+
   return (
     <>
       <title>{title}</title>
@@ -24,10 +32,7 @@ export const generateUserMetadataHtml = (userMetadata?: UserMetadata) => {
       <meta property="twitter:domain" content="https://nounspace.com/" />
       <meta property="og:url" content={spaceUrl} />
       <meta property="twitter:url" content={spaceUrl} />
-      <meta
-        property="og:image"
-        content={`https://nounspace-ts-git-fork-r4topunk-canary-nounspace.vercel.app/api/metadata/spaces?username=${username}&displayName=${displayName}&pfpUrl=${pfpUrl}&bio=${bio}`}
-      />
+      <meta property="og:image" content={ogImageUrl} />
       {bio && (
         <>
           <meta name="description" content={bio} />

--- a/src/pages/api/metadata/spaces.tsx
+++ b/src/pages/api/metadata/spaces.tsx
@@ -1,0 +1,78 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { ImageResponse } from "next/og";
+
+export const config = {
+  runtime: "edge",
+};
+
+interface UserMetadata {
+  username: string;
+  displayName: string;
+  pfpUrl: string;
+  bio: string;
+}
+
+export default async function GET(
+  req: NextApiRequest,
+  res: NextApiResponse<ImageResponse | string>,
+) {
+  if (!req.url) {
+    return res.status(404).send("Url not found");
+  }
+
+  const params = new URLSearchParams(req.url.split("?")[1]);
+  const userMetadata: UserMetadata = {
+    username: params.get("username") || "",
+    displayName: params.get("displayName") || "",
+    pfpUrl: params.get("pfpUrl") || "",
+    bio: params.get("bio") || "",
+  };
+
+  return new ImageResponse(<ProfileCard userMetadata={userMetadata} />, {
+    width: 1200,
+    height: 630,
+  });
+}
+
+const ProfileCard = ({ userMetadata }: { userMetadata: UserMetadata }) => {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        padding: "20px",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "white",
+        gap: "0px",
+      }}
+    >
+      <img
+        src={userMetadata.pfpUrl}
+        width={"120px"}
+        height={"120px"}
+        style={{ borderRadius: "300px" }}
+      />
+      <p
+        style={{
+          fontSize: "64px",
+          fontWeight: "bold",
+        }}
+      >
+        @{userMetadata.username}
+      </p>
+      <div
+        style={{
+          fontSize: "22px",
+          display: "flex",
+          textAlign: "center",
+          maxWidth: "600px",
+        }}
+      >
+        {userMetadata.bio}
+      </div>
+    </div>
+  );
+};

--- a/src/pages/api/metadata/spaces.tsx
+++ b/src/pages/api/metadata/spaces.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 import { NextApiRequest, NextApiResponse } from "next";
 import { ImageResponse } from "next/og";
 

--- a/src/pages/s/[handle]/[[...tabName]].tsx
+++ b/src/pages/s/[handle]/[[...tabName]].tsx
@@ -1,18 +1,17 @@
-import React from "react";
+import SpaceNotFound from "@/common/components/pages/SpaceNotFound";
+import UserDefinedSpace from "@/common/components/pages/UserDefinedSpace";
 import neynar from "@/common/data/api/neynar";
 import supabaseClient from "@/common/data/database/supabase/clients/server";
 import { useAppStore } from "@/common/data/stores/app";
-import { first, isArray, isNil, isNull, isUndefined } from "lodash";
-import { GetServerSideProps, GetServerSidePropsContext } from "next";
-import Head from "next/head";
-import { useEffect } from "react";
-import { NextPageWithLayout } from "@/pages/_app";
-import UserDefinedSpace from "@/common/components/pages/UserDefinedSpace";
-import SpaceNotFound from "@/common/components/pages/SpaceNotFound";
 import {
   generateUserMetadataHtml,
   type UserMetadata,
 } from "@/common/lib/utils/generateUserMetadataHtml";
+import { NextPageWithLayout } from "@/pages/_app";
+import { first, isArray, isNil, isNull, isUndefined } from "lodash";
+import { GetServerSideProps, GetServerSidePropsContext } from "next";
+import Head from "next/head";
+import { useEffect } from "react";
 
 type SpacePageProps = {
   spaceId: string | null;
@@ -63,6 +62,13 @@ export const getServerSideProps = (async ({
       result: { user },
     } = await neynar.lookupUserByUsername(handle);
 
+    const userMetadata = {
+      username: user.username,
+      displayName: user.displayName,
+      pfpUrl: user.pfp.url,
+      bio: user.profile.bio.text,
+    };
+
     const { data } = await supabaseClient
       .from("spaceRegistrations")
       .select("spaceId")
@@ -78,12 +84,7 @@ export const getServerSideProps = (async ({
             fid: user.fid,
             handle,
             tabName: tabName,
-            userMetadata: {
-              username: user.username,
-              displayName: user.displayName,
-              pfpUrl: user.pfp.url,
-              bio: user.profile.bio.text,
-            },
+            userMetadata,
           },
         };
       }
@@ -95,6 +96,7 @@ export const getServerSideProps = (async ({
         fid: user.fid,
         handle,
         tabName: tabName,
+        userMetadata,
       },
     };
   } catch (e) {

--- a/src/pages/s/[handle]/[[...tabName]].tsx
+++ b/src/pages/s/[handle]/[[...tabName]].tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 import SpaceNotFound from "@/common/components/pages/SpaceNotFound";
 import UserDefinedSpace from "@/common/components/pages/UserDefinedSpace";
 import neynar from "@/common/data/api/neynar";


### PR DESCRIPTION
Update the metadata to display metadata for every Farcaster account, even if the user is not in the spaceRegistrations Supabase table.