### PR TITLE
feat: add table fidget

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "neverthrow": "^6.2.2",
     "next": "14.1",
     "next-themes": "^0.3.0",
+    "papaparse": "^5.4.1",
     "pino-pretty": "^11.2.0",
     "prop-types": "^15.8.1",
     "radix-colors-for-tailwind": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.0",
     "remark-html": "^16.0.1",
+    "rss-parser": "^3.13.0",
     "sharp": "^0.33.4",
     "sonner": "^1.4.41",
     "tailwind-merge": "^2.2.0",

--- a/src/common/components/molecules/BrandHeader.tsx
+++ b/src/common/components/molecules/BrandHeader.tsx
@@ -18,7 +18,7 @@ const BrandHeader = () => {
       <TooltipProvider>
         <Tooltip>
           <Link
-            href="/homebase"
+            href="https://nounspace.com/s/wtfisnouns"
             className="flex items-center ps-2.5"
             rel="noopener noreferrer"
           >

--- a/src/common/components/molecules/BrandHeader.tsx
+++ b/src/common/components/molecules/BrandHeader.tsx
@@ -18,7 +18,7 @@ const BrandHeader = () => {
       <TooltipProvider>
         <Tooltip>
           <Link
-            href="https://nounspace.com/s/wtfisnouns"
+            href="/homebase"
             className="flex items-center ps-2.5"
             rel="noopener noreferrer"
           >

--- a/src/common/components/molecules/CSVInput.tsx
+++ b/src/common/components/molecules/CSVInput.tsx
@@ -1,0 +1,104 @@
+import React, { forwardRef, useCallback, useRef, useState } from "react";
+import styled from "styled-components";
+import { TextareaProps } from "@/common/components/atoms/textarea";
+import { Box } from "@mui/material";
+import { Button } from "../atoms/button";
+
+export interface CSVInputProps extends Omit<TextareaProps, "onChange"> {
+  value: string;
+  onChange?: (value: string) => void;
+}
+
+const TextareaRoot = styled.div<{ isActive: boolean }>`
+  display: flex;
+  align-items: center;
+  position: relative;
+  background: white;
+  border: ${({ isActive }) =>
+    isActive ? "1px solid lightblue" : "1px solid lightgray"};
+  padding: 5px;
+  border-radius: 4px;
+  width: 100%;
+`;
+
+const TextareaInput = styled.textarea`
+  border: none;
+  outline: none;
+  flex: 1;
+  padding: 0 5px;
+  resize: vertical;
+  min-height: 100px;
+`;
+
+const HiddenFileInput = styled.input`
+  display: none;
+`;
+
+const CSVInput = forwardRef<HTMLTextAreaElement, CSVInputProps>(
+  (props, ref) => {
+    const [isActive, setIsActive] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const onChange = useCallback<React.ChangeEventHandler<HTMLTextAreaElement>>(
+      (event) => {
+        props.onChange?.(event.target.value);
+      },
+      [props.onChange],
+    );
+
+    const handleFocus = () => {
+      setIsActive(true);
+    };
+
+    const handleBlur = () => {
+      setIsActive(false);
+    };
+
+    const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (file) {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          const text = e.target?.result as string;
+          props.onChange?.(text);
+          if (fileInputRef.current) {
+            fileInputRef.current.value = "";
+          }
+        };
+        reader.readAsText(file);
+      }
+    };
+
+    return (
+      <Box>
+        <TextareaRoot isActive={isActive}>
+          <TextareaInput
+            {...props}
+            ref={ref}
+            value={props.value ?? ""}
+            onChange={onChange}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+          />
+        </TextareaRoot>
+        <HiddenFileInput
+          type="file"
+          accept=".csv"
+          onChange={handleFileChange}
+          id="csvFileInput"
+          ref={fileInputRef}
+        />
+        <label
+          htmlFor="csvFileInput"
+          className="w-full mt-2 cursor-pointer inline-flex items-center justify-center font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-gray-200 hover:bg-gray-300 active:bg-gray-300 h-10 px-4 rounded-md py-2 text-md flex-1"
+        >
+          Upload CSV
+        </label>
+      </Box>
+    );
+  },
+);
+
+CSVInput.displayName = "CSVInput";
+
+export default CSVInput;

--- a/src/common/components/molecules/CsvSelector.tsx
+++ b/src/common/components/molecules/CsvSelector.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import {
+  Select,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+} from "@/common/components/atoms/select";
+
+export interface CSVSelectorOption {
+  name: string;
+}
+
+export interface CSVSelectorProps {
+  onChange: (selectedApp: CSVSelectorOption) => void;
+  value: CSVSelectorOption | null;
+  className?: string;
+}
+
+export const CSVSelector: React.FC<CSVSelectorProps> = ({
+  onChange,
+  value = { name: "Text" },
+  className,
+}) => {
+  const settings: CSVSelectorOption[] = [
+    {
+      name: "Text",
+    },
+    {
+      name: "External URL",
+    },
+  ];
+
+  return (
+    <div className={className}>
+      <Select
+        value={value?.name}
+        onValueChange={(selectedName) => {
+          const selectedApp = settings.find((app) => app.name === selectedName);
+          if (selectedApp) {
+            onChange(selectedApp);
+          }
+        }}
+      >
+        <SelectTrigger>
+          <SelectValue>
+            <div className="flex items-center">
+              {value?.name || "Select Platform"}
+            </div>
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          {settings.map((app: CSVSelectorOption) => (
+            <SelectItem key={app.name} value={app.name}>
+              <div className="flex items-center">
+                <span>{app.name}</span>
+              </div>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};

--- a/src/common/components/molecules/LinksInput.tsx
+++ b/src/common/components/molecules/LinksInput.tsx
@@ -94,12 +94,12 @@ const LinksInput = forwardRef<HTMLInputElement, LinksInputProps>(
       const newLink = {
         text: "New Link",
         url: "https://",
-        avatar: "/images/chainEmoji.png",
+        avatar: "https://www.nounspace.com/images/chainEmoji.png",
         description: "Description",
       };
 
       onChange?.([...value, newLink]);
-      setVisibleFields([...visibleFields, true]); // Automatically expand new link
+      setVisibleFields([...visibleFields, true]);
     };
 
     const removeLink = (index: number) => {
@@ -133,7 +133,7 @@ const LinksInput = forwardRef<HTMLInputElement, LinksInputProps>(
                 value={link.url}
                 onChange={(e: any) => {
                   handleLinkChange(index, { ...link, url: e.target.value });
-                  showAdditionalFields(index); // Show fields when URL is updated
+                  showAdditionalFields(index);
                 }}
               />
               <TextFieldSlot>

--- a/src/common/components/molecules/LinksInput.tsx
+++ b/src/common/components/molecules/LinksInput.tsx
@@ -135,6 +135,7 @@ const LinksInput = forwardRef<HTMLInputElement, LinksInputProps>(
                   handleLinkChange(index, { ...link, url: e.target.value });
                   showAdditionalFields(index);
                 }}
+                onFocus={() => showAdditionalFields(index)}
               />
               <TextFieldSlot>
                 <p

--- a/src/common/components/molecules/Modal.tsx
+++ b/src/common/components/molecules/Modal.tsx
@@ -23,11 +23,11 @@ const Modal = ({
   title,
   description,
   children,
-  focusMode,
+  focusMode = true,
   showClose = true,
   overlay = true,
 }: ModalProps) => (
-  <Dialog.Root open={open} onOpenChange={setOpen} modal={focusMode || true}>
+  <Dialog.Root open={open} onOpenChange={setOpen} modal={focusMode}>
     <Dialog.Portal>
       {overlay && open && (
         <Dialog.Overlay className="bg-muted/95 data-[state=open]:animate-overlayShow fixed inset-0 z-50" />

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -163,10 +163,10 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
       <Modal
         open={showCastModal}
         setOpen={setShowCastModal}
-        focusMode
+        focusMode={false}
         showClose={false}
       >
-        <CreateCast />
+        <CreateCast afterSubmit={() => setShowCastModal(false)} />
       </Modal>
       <SearchModal ref={searchRef} />
       <div className="pt-12 pb-12 h-full md:block hidden">

--- a/src/common/components/organisms/NogsChecker.tsx
+++ b/src/common/components/organisms/NogsChecker.tsx
@@ -21,7 +21,7 @@ export default function NogsChecker() {
   return (
     <>
       <p className="mb-2">
-        Tabs are only for early supporters holding a nounspace OG NFT (nOGs){" "}
+        For now Tabs are only for early supporters holding a nounspace OG NFT (nOGs){" "}
         <br />
         Mint a pair{" "}
         <a

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -352,7 +352,7 @@ const TabBar = memo(function TabBar({
       </Reorder.Group>
 
       {inEditMode ? (
-        <div className="flex flex-row pr-32">
+        <div className="flex flex-row pr-32 z-infinity">
           <NogsGateButton
             onClick={handleCreateTab}
             className="items-center flex rounded-xl p-2 m-3 px-auto bg-[#F3F4F6] hover:bg-sky-100 text-[#1C64F2] font-semibold"

--- a/src/common/components/templates/Space.tsx
+++ b/src/common/components/templates/Space.tsx
@@ -109,7 +109,6 @@ export default function Space({
 
   return (
     <div className="user-theme-background w-full h-full relative flex-col">
-      <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
       {isNil(profile) && (
         <TabBar
           hasProfile={!isNil(profile)}
@@ -117,6 +116,7 @@ export default function Space({
           profileFid={fid ? fid : 0}
         />
       )}
+      <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
       <div className="w-full transition-all duration-100 ease-out h-[calc(100vh-64px)]">
         <div className="flex flex-col h-full">
           <div style={{ position: "fixed", zIndex: 9999 }}>

--- a/src/common/components/templates/SpaceLoading.tsx
+++ b/src/common/components/templates/SpaceLoading.tsx
@@ -1,15 +1,17 @@
-import React, { ReactNode, useMemo } from "react";
+import React, { ReactNode, useState, useEffect } from "react";
 import { isUndefined } from "lodash";
 import useWindowSize from "@/common/lib/hooks/useWindowSize";
 
 export default function SpaceLoading({ profile }: { profile?: ReactNode }) {
+  const [rowHeight, setRowHeight] = useState(70);
+  const { height } = useWindowSize();
   const maxRows = 12;
   const cols = 12;
   const margin = [16, 16];
   const containerPadding = [16, 16];
-  const { height } = useWindowSize();
-  const rowHeight = useMemo(
-    () =>
+
+  useEffect(() => {
+    setRowHeight(
       height
         ? Math.round(
             // The 64 magic number here is the height of the tabs bar above the grid
@@ -17,8 +19,9 @@ export default function SpaceLoading({ profile }: { profile?: ReactNode }) {
               maxRows,
           )
         : 70,
-    [height],
-  );
+    ),
+      [height];
+  });
 
   return (
     <>

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -70,7 +70,6 @@ export function FidgetWrapper({
     homebaseConfig: state.homebase.homebaseConfig,
   }));
 
-  console.log(homebaseConfig);
   function onClickEdit() {
     setSelectedFidgetID(bundle.id);
     setCurrentFidgetSettings(

--- a/src/common/fidgets/index.d.ts
+++ b/src/common/fidgets/index.d.ts
@@ -15,6 +15,9 @@ export type FidgetSettingsStyle = {
   fidgetBorderWidth?: string;
   fidgetBorderColor?: Color;
   fidgetShadow?: string;
+  itemBorderWidth?: string;
+  itemBorderColor?: Color;
+  itemBackground?: Color;
 };
 export type FidgetData = Record<string, any>;
 

--- a/src/common/lib/theme/ThemeCard.tsx
+++ b/src/common/lib/theme/ThemeCard.tsx
@@ -25,7 +25,7 @@ export const ThemeCard = ({
 
   return (
     <div
-      className={`bg-gray-50 hover:bg-gray-100 rounded-lg grid [grid-template-areas:'cell'] h-11 cursor-pointer relative ${active ? activeRingBeforeElementClasses : ""}`}
+      className={`shadow-md w-full bg-gray-50 hover:bg-gray-100 rounded-lg grid [grid-template-areas:'cell'] h-11 cursor-pointer relative ${active ? activeRingBeforeElementClasses : ""}`}
       style={{
         backgroundColor: themeProps.background,
       }}

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -34,6 +34,9 @@ import { FaInfoCircle } from "react-icons/fa";
 import { THEMES } from "@/constants/themes";
 import { ThemeCard } from "@/common/lib/theme/ThemeCard";
 import { FONT_FAMILY_OPTIONS_BY_NAME } from "@/common/lib/theme/fonts";
+import { GiOpenBook } from "react-icons/gi";
+import { FaBook } from "react-icons/fa";
+import { MdMenuBook } from "react-icons/md";
 
 export type ThemeSettingsEditorArgs = {
   theme: ThemeSettings;
@@ -153,9 +156,16 @@ export function ThemeSettingsEditor({
                 type="checkbox"
               />
               {/* Templates Dropdown */}
-              <span className="block max-h-12 max-w-xs overflow-hidden rounded-lg transition-all duration-300 peer-checked/showLabel:max-h-full p-1">
-                {/* Theme Card Example */}
-                <ThemeCard themeProps={theme.properties} />
+              <span className="block max-h-14 max-w-xs overflow-hidden rounded-lg transition-all duration-300 peer-checked/showLabel:max-h-full p-1">
+                <div className="flex flex-row w-full">
+                  <div className="flex basis-3/4 grow">
+                    {/* Theme Card Example */}
+                    <ThemeCard themeProps={theme.properties} />
+                  </div>
+                  <div className="flex basis-1/4 items-center justify-center">
+                    <MdMenuBook className="w-6 h-6" />
+                  </div>
+                </div>
 
                 <div className="grid grid-cols-2 gap-3 pb-3 pt-3">
                   {THEMES.map((theme, i) => (

--- a/src/common/lib/utils/ethereum.ts
+++ b/src/common/lib/utils/ethereum.ts
@@ -1,0 +1,6 @@
+export const isEthereumAddress = (address: string) =>
+  /^0x[a-fA-F0-9]{40}$/.test(address);
+
+export const formatEthereumAddress = (address: string, size: number = 4) => {
+  return `${address.slice(0, size + 2)}...${address.slice(-size)}`;
+};

--- a/src/common/lib/utils/generateUserMetadataHtml.tsx
+++ b/src/common/lib/utils/generateUserMetadataHtml.tsx
@@ -31,7 +31,6 @@ export const generateUserMetadataHtml = (userMetadata?: UserMetadata) => {
       <meta property="twitter:domain" content="https://nounspace.com/" />
       <meta property="og:url" content={spaceUrl} />
       <meta property="twitter:url" content={spaceUrl} />
-      <meta property="og:image" content={ogImageUrl} />
       {bio && (
         <>
           <meta name="description" content={bio} />
@@ -41,9 +40,9 @@ export const generateUserMetadataHtml = (userMetadata?: UserMetadata) => {
       )}
       {pfpUrl && (
         <>
-          <meta property="og:image" content={pfpUrl} />
           <meta name="twitter:card" content={pfpUrl} />
-          <meta name="twitter:image" content={pfpUrl} />
+          <meta property="og:image" content={ogImageUrl} />
+          <meta name="twitter:image" content={ogImageUrl} />
         </>
       )}
     </>

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -109,7 +109,7 @@ const feedProperties: FidgetProperties<FeedFidgetSettings> = {
       displayName: "Username",
       inputSelector: TextInput,
       required: false,
-      disabledIf: (settings) => settings.selectPlatform.name === "Farcaster",
+      disabledIf: (settings) => settings.selectPlatform.name === "farcaster",
       default: "thenounspace",
     },
     {

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -93,7 +93,7 @@ const feedProperties: FidgetProperties<FeedFidgetSettings> = {
       displayName: "Select App",
       inputSelector: PlatformSelector,
       required: false,
-      default: { name: "farcaster", icon: "/images/farcaster.jpeg" },
+      default: { name: "Farcaster", icon: "/images/farcaster.jpeg" },
     },
     {
       fieldName: "feedType",
@@ -206,7 +206,7 @@ export const FEED_TYPES = [
 
 const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
   const {
-    selectPlatform = { name: "farcaster", icon: "/images/farcaster.jpeg" },
+    selectPlatform = { name: "Farcaster", icon: "/images/farcaster.jpeg" },
     Xhandle,
     style,
   } = settings;

--- a/src/fidgets/farcaster/utils.ts
+++ b/src/fidgets/farcaster/utils.ts
@@ -28,6 +28,7 @@ import { mnemonicToAccount } from "viem/accounts";
 import { optimismChaninClient } from "@/constants/optimismChainClient";
 import axiosBackend from "@/common/data/api/backend";
 import { ModProtocolCastAddBody } from "./components/CreateCast";
+import { type Channel } from "@mod-protocol/farcaster";
 
 export const WARPCAST_RECOVERY_PROXY: `0x${string}` =
   "0x00000000FcB080a4D6c39a9354dA9EB9bC104cd7";
@@ -404,3 +405,31 @@ export const getSignatureForUsernameProof = async (
   });
   return signature;
 };
+
+export async function fetchChannelsForUser(
+  fid: number,
+  limit: number = 20,
+): Promise<Channel[]> {
+  try {
+    const channelsResponse = await axiosBackend.get(
+      `/api/farcaster/neynar/active-channels/?limit=${limit}&fid=${fid}`,
+    );
+    return channelsResponse.data.channels as Channel[];
+  } catch (e) {
+    return [] as Channel[];
+  }
+}
+
+export async function fetchChannelsByName(
+  query: string,
+  limit: number = 20,
+): Promise<Channel[]> {
+  try {
+    const channelsResponse = await axiosBackend.get(
+      `/api/farcaster/neynar/search-channels?limit=${limit}&q=${query}`,
+    );
+    return channelsResponse.data.channels as Channel[];
+  } catch (e) {
+    return [] as Channel[];
+  }
+}

--- a/src/fidgets/helpers.tsx
+++ b/src/fidgets/helpers.tsx
@@ -34,3 +34,16 @@ export const defaultStyleFields: FidgetFieldConfig[] = [
     group: "style",
   },
 ];
+
+export const transformUrl = (url: string) => {
+  if (url && url.match(/youtube\.com\/watch\?v=/)) {
+    return url.replace("watch?v=", "embed/");
+  }
+  if (url && url.match(/vimeo\.com\/\d+/)) {
+    return url.replace("vimeo.com", "player.vimeo.com/video");
+  }
+  if (url && url.match(/odysee\.com\/@/)) {
+    return url.replace("odysee.com", "odysee.com/$/embed");
+  }
+  return url;
+};

--- a/src/fidgets/index.ts
+++ b/src/fidgets/index.ts
@@ -12,7 +12,7 @@ import Feed from "./farcaster/Feed";
 import CreateCast from "./farcaster/CreateCast";
 import Links from "./ui/Links";
 import snapShot from "./snapshot/SnapShot";
-
+import VideoFidget from "./ui/Video";
 export const CompleteFidgets = {
   //
   example:
@@ -33,6 +33,7 @@ export const CompleteFidgets = {
   links: Links,
   // zora: zoraEmbed, -> 500 server error -Frame ancestors block
   SnapShot: snapShot,
+  Video: VideoFidget,
 };
 
 export const LayoutFidgets = {

--- a/src/fidgets/index.ts
+++ b/src/fidgets/index.ts
@@ -12,7 +12,10 @@ import Feed from "./farcaster/Feed";
 import CreateCast from "./farcaster/CreateCast";
 import Links from "./ui/Links";
 import snapShot from "./snapshot/SnapShot";
+import Swap from "./swap/Swap";
+import rss from "./ui/rss";
 import VideoFidget from "./ui/Video";
+
 export const CompleteFidgets = {
   //
   example:
@@ -33,6 +36,8 @@ export const CompleteFidgets = {
   links: Links,
   // zora: zoraEmbed, -> 500 server error -Frame ancestors block
   SnapShot: snapShot,
+  // Swap: Swap,
+  Rss: rss,
   Video: VideoFidget,
 };
 

--- a/src/fidgets/index.ts
+++ b/src/fidgets/index.ts
@@ -12,6 +12,7 @@ import Feed from "./farcaster/Feed";
 import CreateCast from "./farcaster/CreateCast";
 import Links from "./ui/Links";
 import snapShot from "./snapshot/SnapShot";
+import Table from "./ui/Table";
 
 export const CompleteFidgets = {
   //
@@ -33,6 +34,7 @@ export const CompleteFidgets = {
   links: Links,
   // zora: zoraEmbed, -> 500 server error -Frame ancestors block
   SnapShot: snapShot,
+  Table: Table,
 };
 
 export const LayoutFidgets = {

--- a/src/fidgets/ui/Links.tsx
+++ b/src/fidgets/ui/Links.tsx
@@ -4,7 +4,6 @@ import CSSInput from "@/common/components/molecules/CSSInput";
 import ColorSelector from "@/common/components/molecules/ColorSelector";
 import FontSelector from "@/common/components/molecules/FontSelector";
 import { FidgetArgs, FidgetProperties, FidgetModule } from "@/common/fidgets";
-import { defaultStyleFields } from "../helpers";
 import { FidgetSettingsStyle } from "@/common/fidgets";
 import {
   CardHeader,

--- a/src/fidgets/ui/Links.tsx
+++ b/src/fidgets/ui/Links.tsx
@@ -36,6 +36,8 @@ export type LinkFidgetSettings = {
   itemBackground: string;
   viewMode: ViewMode;
   description?: string;
+  DescriptionColor: string;
+  HeaderColor: string;
 } & FidgetSettingsStyle;
 
 export const linkConfig: FidgetProperties = {
@@ -55,7 +57,7 @@ export const linkConfig: FidgetProperties = {
         {
           text: "Nouns",
           url: "https://nouns.wtf",
-          avatar: "/images/nouns.svg",
+          avatar: "https://nouns.wtf/static/media/noggles.7644bfd0.svg",
           description: "Funds ideas",
         },
       ],
@@ -78,7 +80,14 @@ export const linkConfig: FidgetProperties = {
       group: "style",
     },
     {
-      fieldName: "fontColor",
+      fieldName: "HeaderColor",
+      default: "black",
+      required: false,
+      inputSelector: ColorSelector,
+      group: "style",
+    },
+    {
+      fieldName: "DescriptionColor",
       default: "black",
       required: false,
       inputSelector: ColorSelector,
@@ -153,6 +162,7 @@ export const Links: React.FC<FidgetArgs<LinkFidgetSettings>> = ({
         overflow: "auto",
         scrollbarWidth: "none",
         padding: "0.5rem",
+        borderRadius: "1rem",
       }}
     >
       {settings?.title && (
@@ -161,7 +171,7 @@ export const Links: React.FC<FidgetArgs<LinkFidgetSettings>> = ({
             className="text-2xl font-bold"
             style={{
               fontFamily: settings.headingsFontFamily,
-              color: settings.fontColor,
+              color: settings.HeaderColor,
             }}
           >
             {settings.title}
@@ -223,12 +233,12 @@ export const Links: React.FC<FidgetArgs<LinkFidgetSettings>> = ({
                     className="items-start text-base font-normal text-black dark:text-white flex-grow"
                     style={{
                       fontFamily: settings.fontFamily,
-                      color: settings.fontColor,
+                      color: settings.HeaderColor,
                       textAlign: "left",
                       wordWrap: "break-word",
                       overflow: "hidden",
                       textOverflow: "ellipsis",
-                      maxHeight: "3rem", // Adjust this value to limit the height of the text
+                      maxHeight: "3rem",
                       display: "-webkit-box",
                       WebkitLineClamp: 2,
                       WebkitBoxOrient: "vertical",
@@ -242,11 +252,12 @@ export const Links: React.FC<FidgetArgs<LinkFidgetSettings>> = ({
                   </CardDescription>
                   {link.description && (
                     <p
-                      className="text-sm font-normal text-gray-500 dark:text-gray-400"
+                      className="text-sm font-normal"
                       style={{
                         wordWrap: "break-word",
                         overflow: "hidden",
                         textOverflow: "ellipsis",
+                        color: settings.DescriptionColor,
                       }}
                     >
                       {link.description}

--- a/src/fidgets/ui/Links.tsx
+++ b/src/fidgets/ui/Links.tsx
@@ -66,7 +66,7 @@ export const linkConfig: FidgetProperties = {
     },
     {
       fieldName: "viewMode",
-      default: "grid",
+      default: "list",
       required: false,
       inputSelector: SwitchButton,
       group: "style",
@@ -129,9 +129,9 @@ export const linkConfig: FidgetProperties = {
     },
   ],
   size: {
-    minHeight: 1,
+    minHeight: 2,
     maxHeight: 36,
-    minWidth: 4,
+    minWidth: 2,
     maxWidth: 36,
   },
 };
@@ -141,12 +141,7 @@ export const Links: React.FC<FidgetArgs<LinkFidgetSettings>> = ({
 }) => {
   const links = Array.isArray(settings.links) ? settings.links : [];
   const isGridView = settings.viewMode === "grid";
-  useEffect(() => {
-    console.log("Links fidget settings:", settings.links);
-  }, [settings.links]);
-  useEffect(() => {
-    console.log("Links fidget settings:", settings.links);
-  }, [settings.links]);
+
   return (
     <div
       style={{

--- a/src/fidgets/ui/Links.tsx
+++ b/src/fidgets/ui/Links.tsx
@@ -182,53 +182,62 @@ export const Links: React.FC<FidgetArgs<LinkFidgetSettings>> = ({
       <div className={isGridView ? "grid grid-cols-3 gap-4" : "flex flex-col"}>
         {links.length > 0 &&
           links.map((link, index) => (
-            <CardContent
-              style={{
-                background: settings.itemBackground,
-                wordWrap: "break-word",
-                maxHeight: "200px",
-                height: "auto",
-                display: "flex",
-                flexDirection: isGridView ? "column" : "row",
-                padding: isGridView ? "1rem" : "0.5rem",
-                margin: isGridView ? "0.25rem" : "0.5rem",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                transition: "transform 0.3s",
-              }}
-              className={
-                isGridView
-                  ? "p-4 flex flex-col items-start justify-between m-1 bg-gradient-to-r from-gray-100 to-gray-300 rounded-md hover:scale-105"
-                  : "p-2 flex items-center justify-between m-2 bg-gradient-to-r from-gray-100 to-gray-300 rounded-md hover:scale-105"
-              }
+            <a
               key={index}
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
             >
-              {link.avatar ? (
-                <Avatar className={isGridView ? "mb-2" : "mr-2 flex-shrink-0"}>
-                  <AvatarImage
-                    style={{ padding: "5px" }}
-                    src={link.avatar}
-                    alt={link.text}
-                  />
-                  <AvatarFallback>
-                    <span className="sr-only">{link.text}</span>
-                  </AvatarFallback>
-                </Avatar>
-              ) : (
-                <Avatar className={isGridView ? "mb-2" : "mr-2 flex-shrink-0"}>
-                  <AvatarImage
-                    src="/images/chainEmoji.png"
-                    style={{ padding: "5px" }}
-                    alt={link.text}
-                  />
-                  <AvatarFallback>
-                    <span className="sr-only">{link.text}</span>
-                  </AvatarFallback>
-                </Avatar>
-              )}
+              <CardContent
+                style={{
+                  background: settings.itemBackground,
+                  wordWrap: "break-word",
+                  maxHeight: "200px",
+                  height: "auto",
+                  display: "flex",
+                  flexDirection: isGridView ? "column" : "row",
+                  padding: isGridView ? "1rem" : "0.5rem",
+                  margin: isGridView ? "0.25rem" : "0.5rem",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  transition: "transform 0.3s",
+                }}
+                className={
+                  isGridView
+                    ? "p-4 flex flex-col items-start justify-between m-1 bg-gradient-to-r from-gray-100 to-gray-300 rounded-md hover:scale-105"
+                    : "p-2 flex items-center justify-between m-2 bg-gradient-to-r from-gray-100 to-gray-300 rounded-md hover:scale-105"
+                }
+                key={index}
+              >
+                {link.avatar ? (
+                  <Avatar
+                    className={isGridView ? "mb-2" : "mr-2 flex-shrink-0"}
+                  >
+                    <AvatarImage
+                      style={{ padding: "5px" }}
+                      src={link.avatar}
+                      alt={link.text}
+                    />
+                    <AvatarFallback>
+                      <span className="sr-only">{link.text}</span>
+                    </AvatarFallback>
+                  </Avatar>
+                ) : (
+                  <Avatar
+                    className={isGridView ? "mb-2" : "mr-2 flex-shrink-0"}
+                  >
+                    <AvatarImage
+                      src="/images/chainEmoji.png"
+                      style={{ padding: "5px" }}
+                      alt={link.text}
+                    />
+                    <AvatarFallback>
+                      <span className="sr-only">{link.text}</span>
+                    </AvatarFallback>
+                  </Avatar>
+                )}
 
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <a href={link.url} target="_blank" rel="noopener noreferrer">
+                <div style={{ flex: 1, minWidth: 0 }}>
                   <CardDescription
                     className="items-start text-base font-normal text-black dark:text-white flex-grow"
                     style={{
@@ -263,9 +272,9 @@ export const Links: React.FC<FidgetArgs<LinkFidgetSettings>> = ({
                       {link.description}
                     </p>
                   )}
-                </a>
-              </div>
-            </CardContent>
+                </div>
+              </CardContent>
+            </a>
           ))}
       </div>
     </div>

--- a/src/fidgets/ui/Table.tsx
+++ b/src/fidgets/ui/Table.tsx
@@ -14,17 +14,20 @@ import {
   CardTitle,
   CardDescription,
 } from "@/common/components/atoms/card";
-import { MarkdownRenderers } from "@/common/lib/utils/markdownRenderers";
-import BorderSelector from "@/common/components/molecules/BorderSelector";
 import { CheckIcon, CopyIcon } from "@radix-ui/react-icons";
+import {
+  CSVSelector,
+  CSVSelectorOption,
+} from "@/common/components/molecules/CsvSelector";
 
 export type TableFidgetSettings = {
   title?: string;
   table: string;
   tableBorderColor: string;
+  selectInput: CSVSelectorOption;
 } & FidgetSettingsStyle;
 
-export const tableConfig: FidgetProperties = {
+export const tableConfig: FidgetProperties<TableFidgetSettings> = {
   fidgetName: "Table",
   icon: 0x1f4c4,
   fields: [
@@ -33,6 +36,14 @@ export const tableConfig: FidgetProperties = {
       default: "Table Fidget",
       required: false,
       inputSelector: TextInput,
+      group: "settings",
+    },
+    {
+      fieldName: "selectInput",
+      displayName: "Select Input",
+      inputSelector: CSVSelector,
+      required: false,
+      default: { name: "Text" },
       group: "settings",
     },
     {
@@ -52,6 +63,15 @@ export const tableConfig: FidgetProperties = {
       required: true,
       inputSelector: CSSInput,
       group: "settings",
+      disabledIf: (settings) => settings?.selectInput?.name === "External URL",
+    },
+    {
+      fieldName: "URL",
+      default: ``,
+      required: true,
+      inputSelector: TextInput,
+      group: "settings",
+      disabledIf: (settings) => settings?.selectInput?.name === "Text",
     },
     {
       fieldName: "fontFamily",

--- a/src/fidgets/ui/Table.tsx
+++ b/src/fidgets/ui/Table.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import TextInput from "@/common/components/molecules/TextInput";
+import CSSInput from "@/common/components/molecules/CSSInput";
+import ColorSelector from "@/common/components/molecules/ColorSelector";
+import FontSelector from "@/common/components/molecules/FontSelector";
+import { FidgetArgs, FidgetProperties, FidgetModule } from "@/common/fidgets";
+import ReactMarkdown from "react-markdown";
+import rehypeRaw from "rehype-raw";
+import remarkGfm from "remark-gfm";
+import { defaultStyleFields } from "../helpers";
+import { FidgetSettingsStyle } from "@/common/fidgets";
+import {
+  CardHeader,
+  CardContent,
+  CardTitle,
+  CardDescription,
+} from "@/common/components/atoms/card";
+import { MarkdownRenderers } from "@/common/lib/utils/markdownRenderers";
+
+export type TableFidgetSettings = {
+  title?: string;
+  table: string;
+} & FidgetSettingsStyle;
+
+export const tableConfig: FidgetProperties = {
+  fidgetName: "Table",
+  icon: 0x1f4c4,
+  fields: [
+    {
+      fieldName: "title",
+      default: "Table Fidget",
+      required: false,
+      inputSelector: TextInput,
+      group: "settings",
+    },
+    {
+      fieldName: "table",
+      default: "Jot down your ideas and grow them.",
+      required: true,
+      inputSelector: CSSInput,
+      group: "settings",
+    },
+    {
+      fieldName: "fontFamily",
+      default: "var(--user-theme-font)",
+      required: false,
+      inputSelector: FontSelector,
+      group: "style",
+    },
+    {
+      fieldName: "fontColor",
+      default: "var(--user-theme-font-color)",
+      required: false,
+      inputSelector: ColorSelector,
+      group: "style",
+    },
+    {
+      fieldName: "headingsFontFamily",
+      default: "var(--user-theme-headings-font)",
+      required: false,
+      inputSelector: FontSelector,
+      group: "style",
+    },
+    {
+      fieldName: "headingsFontColor",
+      default: "var(--user-theme-headings-font-color)",
+      required: false,
+      inputSelector: ColorSelector,
+      group: "style",
+    },
+    ...defaultStyleFields,
+    {
+      fieldName: "css",
+      default: "",
+      required: false,
+      inputSelector: CSSInput,
+      group: "code",
+    },
+  ],
+  size: {
+    minHeight: 2,
+    maxHeight: 36,
+    minWidth: 3,
+    maxWidth: 36,
+  },
+};
+
+export const Table: React.FC<FidgetArgs<TableFidgetSettings>> = ({
+  settings,
+}) => {
+  return (
+    <div
+      style={{
+        background: settings.background,
+        height: "100%",
+        borderWidth: settings.fidgetBorderWidth,
+        borderColor: settings.fidgetBorderColor,
+        // Not visible because of the outer div having overflow: hidden
+        boxShadow: settings.fidgetShadow,
+        overflow: "auto",
+        scrollbarWidth: "none",
+      }}
+    >
+      {settings?.title && (
+        <CardHeader className="p-4 pb-2">
+          <CardTitle
+            className="table-2xl font-bold"
+            style={{
+              fontFamily: settings.headingsFontFamily,
+              color: settings.headingsFontColor,
+            }}
+          >
+            {settings.title}
+          </CardTitle>
+        </CardHeader>
+      )}
+      {settings?.table && (
+        <CardContent className="p-4 pt-2">
+          <CardDescription
+            className="table-base font-normal table-black dark:table-white"
+            style={{
+              fontFamily: settings.fontFamily,
+              color: settings.fontColor,
+            }}
+          >
+            <ReactMarkdown
+              rehypePlugins={[rehypeRaw]}
+              remarkPlugins={[remarkGfm]}
+              components={MarkdownRenderers}
+            >
+              {settings.table}
+            </ReactMarkdown>
+          </CardDescription>
+        </CardContent>
+      )}
+    </div>
+  );
+};
+
+export default {
+  fidget: Table,
+  properties: tableConfig,
+} as FidgetModule<FidgetArgs<TableFidgetSettings>>;

--- a/src/fidgets/ui/Table.tsx
+++ b/src/fidgets/ui/Table.tsx
@@ -17,6 +17,10 @@ import { CheckIcon, CopyIcon } from "@radix-ui/react-icons";
 import Papa from "papaparse";
 import React, { useEffect, useState } from "react";
 import { defaultStyleFields } from "../helpers";
+import {
+  formatEthereumAddress,
+  isEthereumAddress,
+} from "@/common/lib/utils/ethereum";
 
 export type TableFidgetSettings = {
   title?: string;
@@ -227,7 +231,11 @@ export const Table: React.FC<FidgetArgs<TableFidgetSettings>> = ({
                     className="p-2 group"
                     key={index}
                   >
-                    <span>{row[header]}</span>
+                    <span>
+                      {isEthereumAddress(row[header])
+                        ? formatEthereumAddress(row[header])
+                        : row[header]}
+                    </span>
                     <button
                       className="absolute right-2 group-hover:block hidden"
                       onClick={() => handleCopy(row[header], rowIndex)}

--- a/src/fidgets/ui/Table.tsx
+++ b/src/fidgets/ui/Table.tsx
@@ -113,13 +113,6 @@ export const tableConfig: FidgetProperties<TableFidgetSettings> = {
       group: "style",
     },
     ...defaultStyleFields,
-    {
-      fieldName: "css",
-      default: "",
-      required: false,
-      inputSelector: CSSInput,
-      group: "code",
-    },
   ],
   size: {
     minHeight: 2,

--- a/src/fidgets/ui/Table.tsx
+++ b/src/fidgets/ui/Table.tsx
@@ -1,24 +1,22 @@
-import React, { useEffect, useState } from "react";
-import TextInput from "@/common/components/molecules/TextInput";
+import { CardHeader, CardTitle } from "@/common/components/atoms/card";
 import CSSInput from "@/common/components/molecules/CSSInput";
 import ColorSelector from "@/common/components/molecules/ColorSelector";
-import FontSelector from "@/common/components/molecules/FontSelector";
-import { FidgetArgs, FidgetProperties, FidgetModule } from "@/common/fidgets";
-import ReactMarkdown from "react-markdown";
-import { defaultStyleFields } from "../helpers";
-import { FidgetSettingsStyle } from "@/common/fidgets";
-import Papa from "papaparse";
-import {
-  CardHeader,
-  CardContent,
-  CardTitle,
-  CardDescription,
-} from "@/common/components/atoms/card";
-import { CheckIcon, CopyIcon } from "@radix-ui/react-icons";
 import {
   CSVSelector,
   CSVSelectorOption,
 } from "@/common/components/molecules/CsvSelector";
+import FontSelector from "@/common/components/molecules/FontSelector";
+import TextInput from "@/common/components/molecules/TextInput";
+import {
+  FidgetArgs,
+  FidgetModule,
+  FidgetProperties,
+  FidgetSettingsStyle,
+} from "@/common/fidgets";
+import { CheckIcon, CopyIcon } from "@radix-ui/react-icons";
+import Papa from "papaparse";
+import React, { useEffect, useState } from "react";
+import { defaultStyleFields } from "../helpers";
 
 export type TableFidgetSettings = {
   title?: string;

--- a/src/fidgets/ui/Table.tsx
+++ b/src/fidgets/ui/Table.tsx
@@ -1,5 +1,4 @@
 import { CardHeader, CardTitle } from "@/common/components/atoms/card";
-import CSSInput from "@/common/components/molecules/CSSInput";
 import ColorSelector from "@/common/components/molecules/ColorSelector";
 import {
   CSVSelector,
@@ -126,21 +125,21 @@ export const Table: React.FC<FidgetArgs<TableFidgetSettings>> = ({
   settings,
 }) => {
   const [tableData, setTableData] = useState([]);
-  const [copiedIndex, setCopiedIndex] = useState(null);
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
   const headers = tableData.length > 0 ? Object.keys(tableData[0]) : [];
-  const usingTextCsv = settings.selectInput.name == "Text";
+  const usingTextCsv = settings.selectInput.name === "Text";
 
-  const parseCSV = (data) => {
+  const parseCSV = (data: string) => {
     Papa.parse(data, {
       header: true,
       skipEmptyLines: true,
-      complete: function (results) {
+      complete: (results) => {
         setTableData(results.data);
       },
     });
   };
 
-  const handleCopy = (content, index) => {
+  const handleCopy = (content: string, index: number) => {
     navigator.clipboard.writeText(content);
     setCopiedIndex(index);
     setTimeout(() => setCopiedIndex(null), 3000);
@@ -154,7 +153,6 @@ export const Table: React.FC<FidgetArgs<TableFidgetSettings>> = ({
       }
 
       const text = await res.text();
-      console.log(text);
       parseCSV(text);
     } catch (err) {
       console.error("Error loading data for table fidget:", err);
@@ -171,25 +169,20 @@ export const Table: React.FC<FidgetArgs<TableFidgetSettings>> = ({
 
   return (
     <div
+      className="flex flex-col h-full overflow-auto scrollbar-none"
       style={{
         background: settings.background,
-        height: "100%",
         borderWidth: settings.fidgetBorderWidth,
         borderColor: settings.fidgetBorderColor,
         boxShadow: settings.fidgetShadow,
-        overflow: "auto",
-        scrollbarWidth: "none",
         color: settings.fontColor,
         fontFamily: settings.fontFamily,
-        display: "flex",
-        flexDirection: "column",
-        textOverflow: "ellipsis",
       }}
     >
       {settings?.title && (
         <CardHeader className="p-4 pb-2">
           <CardTitle
-            className="table-2xl font-bold"
+            className="text-2xl font-bold"
             style={{
               fontFamily: settings.headingsFontFamily,
               color: settings.headingsFontColor,
@@ -201,26 +194,20 @@ export const Table: React.FC<FidgetArgs<TableFidgetSettings>> = ({
       )}
       {settings?.table && (
         <table
+          className="w-full h-auto flex-grow border border-solid"
           style={{
-            border: "1px solid",
-            width: "100%",
-            height: "auto",
-            flexGrow: 1,
             borderColor: settings.tableBorderColor,
           }}
-          className="overflow-hidden"
         >
           <thead>
             <tr>
               {headers.map((header, index) => (
                 <th
+                  key={index}
+                  className="border border-solid p-2"
                   style={{
-                    borderStyle: "solid",
-                    borderWidth: "1px",
                     borderColor: settings.tableBorderColor,
                   }}
-                  className="p-2"
-                  key={index}
                 >
                   {header}
                 </th>
@@ -229,21 +216,14 @@ export const Table: React.FC<FidgetArgs<TableFidgetSettings>> = ({
           </thead>
           <tbody>
             {tableData.map((row, rowIndex) => (
-              <tr key={rowIndex} style={{ maxWidth: "100%" }}>
+              <tr key={rowIndex} className="max-w-full">
                 {headers.map((header, index) => (
                   <td
-                    style={{
-                      border: "1px solid",
-                      textAlign: "center",
-                      borderColor: settings.tableBorderColor,
-                      maxWidth: "100%",
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
-                      position: "relative",
-                    }}
-                    className="p-2 group"
                     key={index}
+                    className="border border-solid text-center p-2 relative overflow-hidden text-ellipsis whitespace-nowrap group"
+                    style={{
+                      borderColor: settings.tableBorderColor,
+                    }}
                   >
                     <span>
                       {isEthereumAddress(row[header])
@@ -251,11 +231,9 @@ export const Table: React.FC<FidgetArgs<TableFidgetSettings>> = ({
                         : row[header]}
                     </span>
                     <button
-                      className="absolute right-2 group-hover:block hidden"
+                      className="absolute right-2 top-1/2 -translate-y-1/2 transition-transform group-hover:block hidden"
                       onClick={() => handleCopy(row[header], rowIndex)}
                       style={{
-                        top: "50%",
-                        transform: "translateY(-50%)",
                         transition: "transform 0.3s ease",
                       }}
                     >

--- a/src/fidgets/ui/Table.tsx
+++ b/src/fidgets/ui/Table.tsx
@@ -21,6 +21,7 @@ import {
   formatEthereumAddress,
   isEthereumAddress,
 } from "@/common/lib/utils/ethereum";
+import CSVInput from "@/common/components/molecules/CSVInput";
 
 export type TableFidgetSettings = {
   title?: string;
@@ -64,7 +65,7 @@ export const tableConfig: FidgetProperties<TableFidgetSettings> = {
 10, 23
 `,
       required: true,
-      inputSelector: CSSInput,
+      inputSelector: CSVInput,
       group: "settings",
       disabledIf: (settings) => settings?.selectInput?.name === "External URL",
     },
@@ -173,7 +174,7 @@ export const Table: React.FC<FidgetArgs<TableFidgetSettings>> = ({
     } else {
       fetchUrl(settings.URL);
     }
-  }, [usingTextCsv]);
+  }, [settings.selectInput, settings.table, settings.URL]);
 
   return (
     <div

--- a/src/fidgets/ui/Video.tsx
+++ b/src/fidgets/ui/Video.tsx
@@ -11,7 +11,8 @@ import useSafeUrl from "@/common/lib/hooks/useSafeUrl";
 import { defaultStyleFields } from "@/fidgets/helpers";
 import IFrameWidthSlider from "@/common/components/molecules/IframeScaleSlider";
 import { transformUrl } from "@/fidgets/helpers";
-export type IFrameFidgetSettings = {
+
+export type VideoFidgetSettings = {
   url: string;
   size: number;
 } & FidgetSettingsStyle;
@@ -24,12 +25,13 @@ const DISALLOW_URL_PATTERNS = [
 ];
 
 const frameConfig: FidgetProperties = {
-  fidgetName: "Iframe",
-  icon: 0x1f310, // 🌐
+  fidgetName: "Video",
+  icon: 0x1f4fa, // 📺
   fields: [
     {
       fieldName: "url",
       required: true,
+      default: "https://www.youtube.com/watch?v=lOzCA7bZG_k",
       inputSelector: TextInput,
       group: "settings",
     },
@@ -63,14 +65,20 @@ const ErrorWrapper: React.FC<{
   );
 };
 
-const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
+const VideoFidget: React.FC<FidgetArgs<VideoFidgetSettings>> = ({
   settings: { url, size = 1 },
 }) => {
   const isValid = isValidUrl(url);
   const sanitizedUrl = useSafeUrl(url, DISALLOW_URL_PATTERNS);
   const transformedUrl = transformUrl(sanitizedUrl || "");
+
   if (!url) {
-    return <ErrorWrapper icon="➕" message="Provide a URL to display here." />;
+    return (
+      <ErrorWrapper
+        icon="➕"
+        message="Provide a YouTube/Vimeo URL to display here."
+      />
+    );
   }
 
   if (!isValid) {
@@ -94,6 +102,7 @@ const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
         src={transformedUrl}
         title="IFrame Fidget"
         sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+        allowFullScreen
         style={{
           transform: `scale(${scaleValue})`,
           transformOrigin: "0 0",
@@ -107,6 +116,6 @@ const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
 };
 
 export default {
-  fidget: IFrame,
+  fidget: VideoFidget,
   properties: frameConfig,
-} as FidgetModule<FidgetArgs<IFrameFidgetSettings>>;
+} as FidgetModule<FidgetArgs<VideoFidgetSettings>>;

--- a/src/fidgets/ui/rss.tsx
+++ b/src/fidgets/ui/rss.tsx
@@ -1,0 +1,240 @@
+import React, { useEffect, useState } from "react";
+import RSSParser from "rss-parser";
+import TextInput from "@/common/components/molecules/TextInput";
+import CSSInput from "@/common/components/molecules/CSSInput";
+import ColorSelector from "@/common/components/molecules/ColorSelector";
+import FontSelector from "@/common/components/molecules/FontSelector";
+import { FidgetArgs, FidgetProperties, FidgetModule } from "@/common/fidgets";
+import ReactMarkdown from "react-markdown";
+import { defaultStyleFields } from "../helpers";
+import { FidgetSettingsStyle } from "@/common/fidgets";
+import {
+  CardHeader,
+  CardContent,
+  CardTitle,
+} from "@/common/components/atoms/card";
+import { MarkdownRenderers } from "@/common/lib/utils/markdownRenderers";
+
+export type TextFidgetSettings = {
+  title?: string;
+  rssUrl: string;
+} & FidgetSettingsStyle;
+
+export const textConfig: FidgetProperties = {
+  fidgetName: "Rss",
+  icon: 0x1f6f0,
+  fields: [
+    {
+      fieldName: "rssUrl",
+      default: "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml",
+      required: true,
+      inputSelector: TextInput,
+      group: "settings",
+    },
+    {
+      fieldName: "fontFamily",
+      default: "var(--user-theme-font)",
+      required: false,
+      inputSelector: FontSelector,
+      group: "style",
+    },
+    {
+      fieldName: "fontColor",
+      default: "var(--user-theme-font-color)",
+      required: false,
+      inputSelector: ColorSelector,
+      group: "style",
+    },
+    {
+      fieldName: "headingsFontFamily",
+      default: "var(--user-theme-headings-font)",
+      required: false,
+      inputSelector: FontSelector,
+      group: "style",
+    },
+    {
+      fieldName: "headingsFontColor",
+      default: "var(--user-theme-headings-font-color)",
+      required: false,
+      inputSelector: ColorSelector,
+      group: "style",
+    },
+
+    ...defaultStyleFields,
+    {
+      fieldName: "itemBackground",
+      default: "var(--user-theme-fidget-background)",
+      required: false,
+      inputSelector: ColorSelector,
+      group: "style",
+    },
+    {
+      fieldName: "itemBorderColor",
+      default: "var(--user-theme-fidget-border-color)",
+      required: false,
+      inputSelector: ColorSelector,
+      group: "style",
+    },
+    {
+      fieldName: "css",
+      default: "",
+      required: false,
+      inputSelector: CSSInput,
+      group: "code",
+    },
+  ],
+  size: {
+    minHeight: 2,
+    maxHeight: 36,
+    minWidth: 3,
+    maxWidth: 36,
+  },
+};
+
+export const Rss: React.FC<FidgetArgs<TextFidgetSettings>> = ({ settings }) => {
+  const [rssItems, setRssItems] = useState<any[]>([]);
+  const [rssFeed, setRssFeed] = useState<any>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchRssFeed = async () => {
+      try {
+        const parser = new RSSParser();
+        const feed = await parser.parseURL(settings.rssUrl);
+
+        if (feed.items && feed.items.length > 0) {
+          setRssItems(feed.items);
+          setRssFeed(feed);
+        } else {
+          console.warn("No items found in the RSS feed.");
+        }
+      } catch (error) {
+        console.error("Error fetching RSS feed:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchRssFeed();
+  }, [settings.rssUrl]);
+
+  return (
+    <div
+      style={{
+        background: settings.background,
+        height: "100%",
+        borderWidth: settings.fidgetBorderWidth,
+        borderColor: settings.fidgetBorderColor,
+        boxShadow: settings.fidgetShadow,
+        overflow: "auto",
+        scrollbarWidth: "none",
+      }}
+    >
+      {rssFeed?.title && (
+        <CardHeader className="p-2 ml-5">
+          <div className="flex-col items-center">
+            {rssFeed?.image && (
+              <img
+                src={rssFeed.image.url}
+                alt={rssFeed.title}
+                className="mt-4 h-auto rounded w-10"
+              />
+            )}
+
+            <CardTitle
+              className="text-2xl font-bold mt-4 ml-1"
+              style={{
+                fontFamily: settings.headingsFontFamily,
+                color: settings.headingsFontColor,
+              }}
+            >
+              {rssFeed.title || settings.title}
+            </CardTitle>
+          </div>
+        </CardHeader>
+      )}
+      <CardContent className="p-4 pt-2">
+        {isLoading ? (
+          <p>Loading RSS feed...</p>
+        ) : rssItems.length > 0 ? (
+          rssItems.map((item, index) => (
+            <div
+              key={index}
+              className="mb-6 p-4 rounded-lg border"
+              style={{
+                borderWidth: settings.fidgetBorderWidth,
+                borderColor: settings.itemBorderColor,
+                backgroundColor: settings.itemBackground,
+                boxShadow: settings.fidgetShadow,
+              }}
+            >
+              <div className="flex-row items-center ">
+                <div className="flex flex-col justify-between">
+                  <h3
+                    className="text-xl font-semibold mb-2"
+                    style={{
+                      fontFamily: settings.headingsFontFamily,
+                      color: settings.headingsFontColor,
+                    }}
+                  >
+                    {item.title}
+                  </h3>
+                  {item.pubDate && (
+                    <p
+                      className="text-xs text-gray-500 mb-2"
+                      style={{ fontFamily: settings.fontFamily }}
+                    >
+                      Published on:{" "}
+                      {new Date(item.pubDate).toLocaleDateString()}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {item.contentSnippet && (
+                <div
+                  className="mb-4"
+                  style={{
+                    fontFamily: settings.fontFamily,
+                    color: settings.fontColor,
+                  }}
+                >
+                  <ReactMarkdown components={MarkdownRenderers}>
+                    {item.contentSnippet}
+                  </ReactMarkdown>
+                </div>
+              )}
+              {item.link && (
+                <a
+                  href={item.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{
+                    color: settings.fontColor,
+                    textDecoration: "underline",
+                  }}
+                  className="text-sm"
+                >
+                  Read more
+                </a>
+              )}
+            </div>
+          ))
+        ) : (
+          <div>
+            <p>No RSS items found.</p>
+            <p>
+              It seems that there are no articles available from this feed.
+              Please check the feed URL or try again later.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </div>
+  );
+};
+
+export default {
+  fidget: Rss,
+  properties: textConfig,
+} as FidgetModule<FidgetArgs<TextFidgetSettings>>;

--- a/src/pages/api/farcaster/neynar/active-channels.ts
+++ b/src/pages/api/farcaster/neynar/active-channels.ts
@@ -1,0 +1,38 @@
+import requestHandler from "@/common/data/api/requestHandler";
+import axios, { AxiosRequestConfig, isAxiosError } from "axios";
+import Error from "next/error";
+import { NextApiRequest, NextApiResponse } from "next/types";
+
+async function loadUserChannels(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const options: AxiosRequestConfig = {
+      method: "GET",
+      url: `https://api.neynar.com/v2/farcaster/channel/user`,
+      headers: {
+        accept: "application/json",
+        api_key: process.env.NEYNAR_API_KEY!,
+      },
+      params: req.query,
+    };
+
+    const { data } = await axios.request(options);
+
+    if (data.status && data.status !== 200) {
+      return res.status(data.status).json(data);
+    }
+
+    res.status(200).json(data);
+  } catch (e) {
+    if (isAxiosError(e)) {
+      res
+        .status(e.response!.data.status || 500)
+        .json(e.response!.data || "An unknown error occurred");
+    } else {
+      res.status(500).json("An unknown error occurred");
+    }
+  }
+}
+
+export default requestHandler({
+  get: loadUserChannels,
+});

--- a/src/pages/api/farcaster/neynar/search-channels.ts
+++ b/src/pages/api/farcaster/neynar/search-channels.ts
@@ -1,0 +1,38 @@
+import requestHandler from "@/common/data/api/requestHandler";
+import axios, { AxiosRequestConfig, isAxiosError } from "axios";
+import Error from "next/error";
+import { NextApiRequest, NextApiResponse } from "next/types";
+
+async function searchChannels(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const options: AxiosRequestConfig = {
+      method: "GET",
+      url: `https://api.neynar.com/v2/farcaster/channel/search`,
+      headers: {
+        accept: "application/json",
+        api_key: process.env.NEYNAR_API_KEY!,
+      },
+      params: req.query,
+    };
+
+    const { data } = await axios.request(options);
+
+    if (data.status && data.status !== 200) {
+      return res.status(data.status).json(data);
+    }
+
+    res.status(200).json(data);
+  } catch (e) {
+    if (isAxiosError(e)) {
+      res
+        .status(e.response!.data.status || 500)
+        .json(e.response!.data || "An unknown error occurred");
+    } else {
+      res.status(500).json("An unknown error occurred");
+    }
+  }
+}
+
+export default requestHandler({
+  get: searchChannels,
+});

--- a/src/pages/api/metadata/spaces.tsx
+++ b/src/pages/api/metadata/spaces.tsx
@@ -53,8 +53,8 @@ const ProfileCard = ({ userMetadata }: { userMetadata: UserMetadata }) => {
     >
       <img
         src={userMetadata.pfpUrl}
-        width={"120px"}
-        height={"120px"}
+        width={"180px"}
+        height={"180px"}
         style={{ borderRadius: "300px" }}
       />
       <p

--- a/src/pages/homebase/index.tsx
+++ b/src/pages/homebase/index.tsx
@@ -68,7 +68,7 @@ const Homebase: NextPageWithLayout = () => {
           feedType: FeedType.Following,
           users: "",
           filterType: FilterType.Users,
-          selectPlatform: { name: "farcaster", icon: "/images/farcaster.jpeg" },
+          selectPlatform: { name: "Farcaster", icon: "/images/farcaster.jpeg" },
           Xhandle: "",
           style: "",
         }}

--- a/src/pages/homebase/index.tsx
+++ b/src/pages/homebase/index.tsx
@@ -65,8 +65,8 @@ const Homebase: NextPageWithLayout = () => {
     args.feed = (
       <FeedModule.fidget
         settings={{
-          feedType: FeedType.Filter,
-          users: String(currentFid),
+          feedType: FeedType.Following,
+          users: "",
           filterType: FilterType.Users,
           selectPlatform: { name: "farcaster", icon: "/images/farcaster.jpeg" },
           Xhandle: "",

--- a/supabase/migrations/20240821215436_spaceOrderings.sql
+++ b/supabase/migrations/20240821215436_spaceOrderings.sql
@@ -10,8 +10,6 @@ create table "public"."spaceOrderings" (
 
 alter table "public"."spaceOrderings" enable row level security;
 
-alter table "public"."spaceRegistrations" drop column "isDefault";
-
 CREATE INDEX "fidRegistrations_fid_idx" ON public."fidRegistrations" USING btree (fid);
 
 CREATE UNIQUE INDEX "spaceOrderings_pkey" ON public."spaceOrderings" USING btree (id);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12670,6 +12670,11 @@ pako@^0.2.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
   integrity sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==
 
+papaparse@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.4.1.tgz#f45c0f871853578bd3a30f92d96fdcfb6ebea127"
+  integrity sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -14660,16 +14665,7 @@ string-argv@~0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14778,14 +14774,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -16145,7 +16134,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -16158,15 +16147,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8764,6 +8764,11 @@ enhanced-resolve@^5.14.1:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
+entities@^2.0.3:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
 entities@^4.2.0, entities@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
@@ -14228,6 +14233,14 @@ rrweb-cssom@^0.7.0:
   resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz#c73451a484b86dd7cfb1e0b2898df4b703183e4b"
   integrity sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==
 
+rss-parser@^3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/rss-parser/-/rss-parser-3.13.0.tgz#f1f83b0a85166b8310ec531da6fbaa53ff0f50f0"
+  integrity sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==
+  dependencies:
+    entities "^2.0.3"
+    xml2js "^0.5.0"
+
 run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -14329,6 +14342,11 @@ satori@0.10.9:
     parse-css-color "^0.2.1"
     postcss-value-parser "^4.2.0"
     yoga-wasm-web "^0.3.3"
+
+sax@>=0.6.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
+  integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
 
 saxes@^6.0.0:
   version "6.0.0"
@@ -16232,6 +16250,19 @@ xml-name-validator@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
   integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
+
+xml2js@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"
+  integrity sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
This PR adds a table fidget that parses CSVs and displays them as tables.

The tables are fully customizable and it's possible to use data from text, file and url.

The text and file are the same input, as far as the file button just opens a file and puts it's contents into the text input. And the url is loaded as soon as the fidget is loaded.

Obs: I loved the experience of developing fidgets, it's so cool to think about the possibilities of creations. I have always argued that the web should be modular, and this is how Nounspace works!