### PR TITLE
Rename Iframe fidget to Embed and fixed a possible error on tabconfig

### DIFF
--- a/src/common/data/stores/app/homebase/homebaseTabsStore.ts
+++ b/src/common/data/stores/app/homebase/homebaseTabsStore.ts
@@ -309,8 +309,9 @@ export const createHomeBaseTabStoreFunc = (
     }
   },
   commitHomebaseTabToDatabase: debounce(async (tabname) => {
-    const localCopy = cloneDeep(get().homebase.tabs[tabname].config);
-    if (localCopy) {
+    const tab = get().homebase.tabs[tabname];
+    if (tab && tab.config) {
+      const localCopy = cloneDeep(tab.config);
       const file = await get().account.createEncryptedSignedFile(
         stringify(localCopy),
         "json",

--- a/src/fidgets/ui/IFrame.tsx
+++ b/src/fidgets/ui/IFrame.tsx
@@ -24,7 +24,7 @@ const DISALLOW_URL_PATTERNS = [
 ];
 
 const frameConfig: FidgetProperties = {
-  fidgetName: "iFrame",
+  fidgetName: "Embed",
   icon: 0x1f310, // 🌐
   fields: [
     {

--- a/src/fidgets/ui/IFrame.tsx
+++ b/src/fidgets/ui/IFrame.tsx
@@ -24,7 +24,7 @@ const DISALLOW_URL_PATTERNS = [
 ];
 
 const frameConfig: FidgetProperties = {
-  fidgetName: "Embed",
+  fidgetName: "Web Embed",
   icon: 0x1f310, // 🌐
   fields: [
     {


### PR DESCRIPTION
I was getting this error during the Iframe /embed fidget 

```js

 1 of 1 unhandled error

Unhandled Runtime Error
TypeError: Cannot read properties of undefined (reading 'config')

Source
src/common/data/stores/app/homebase/homebaseTabsStore.ts (312:19) @ get

  310 | },
  311 | commitHomebaseTabToDatabase: debounce(async (tabname) => {
> 312 |   const config = get().homebase.tabs[tabname]?.config;
      |                 ^
  313 |   if (config) {
  314 |     const localCopy = cloneDeep(config);
  315 |     const file = await get().account.createEncryptedSignedFile(
  

``` 


So I added this conditional to the tab config as well: 


```js
    const tab = get().homebase.tabs[tabname];
    if (tab && tab.config) {
      const localCopy = cloneDeep(tab.config);
``` 

Can use some testing here too 

