### PR TITLE
Cleanup2

### DIFF
--- a/src/common/components/organisms/FidgetSettingsEditor.tsx
+++ b/src/common/components/organisms/FidgetSettingsEditor.tsx
@@ -5,7 +5,7 @@ import {
   FidgetFieldConfig,
 } from "@/common/fidgets";
 import BackArrowIcon from "../atoms/icons/BackArrow";
-import { FaTrashCan, FaTriangleExclamation } from "react-icons/fa6";
+import { FaTrashCan } from "react-icons/fa6";
 import { Button } from "@/common/components/atoms/button";
 import {
   Tabs,

--- a/src/common/components/organisms/LoadingSidebar.tsx
+++ b/src/common/components/organisms/LoadingSidebar.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import BrandHeader from "../molecules/BrandHeader";
 
 export default function LoadingSidebar() {
   return (

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -129,7 +129,7 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
           target={openInNewTab ? "_blank" : undefined}
         >
           {badgeText && <NavIconBadge>{badgeText}</NavIconBadge>}
-          <Icon aria-hidden="true" />
+          <Icon />
           <span className="ms-3">{label}</span>
         </Link>
       </li>

--- a/src/common/components/organisms/Player.tsx
+++ b/src/common/components/organisms/Player.tsx
@@ -18,8 +18,7 @@ import {
 import { Button } from "@/common/components/atoms/button";
 import { trackAnalyticsEvent } from "@/common/lib/utils/analyticsUtils";
 import { AnalyticsEvent } from "@/common/providers/AnalyticsProvider";
-import { formatEthereumAddress } from "@/common/lib/utils/ethereum";
-import { Address, isAddress, zeroAddress } from "viem";
+import { Address } from "viem";
 import ScanAddress from "../molecules/ScanAddress";
 import { AlchemyNetwork } from "@/fidgets/ui/gallery";
 

--- a/src/common/components/organisms/Sidebar.tsx
+++ b/src/common/components/organisms/Sidebar.tsx
@@ -4,10 +4,8 @@ import React, {
   useState,
   useRef,
   useMemo,
-  useEffect,
 } from "react";
 import Navigation from "./Navigation";
-import LoadingSidebar from "./LoadingSidebar";
 export interface SidebarProps {}
 
 export type SidebarContextProviderProps = { children: React.ReactNode };

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -1,16 +1,9 @@
 import React from "react";
 import { FaPlus } from "react-icons/fa6";
-import { first, map } from "lodash";
-import { useLoadFarcasterUser } from "@/common/data/queries/farcaster";
-import { useFarcasterSigner } from "@/fidgets/farcaster";
-import { memo, useEffect, useMemo, useState } from "react";
-import { useAppStore } from "@/common/data/stores/app";
+import { map } from "lodash";
 import { Reorder, AnimatePresence } from "framer-motion";
 import { Tab } from "../atoms/reorderable-tab";
-import { useRouter } from "next/router";
-import { SpaceLookupInfo } from "@/common/data/stores/app/space/spaceStore";
 import NogsGateButton from "./NogsGateButton";
-import Link from "next/link";
 
 interface TabBarProps {
   inHome?: boolean;

--- a/src/common/components/pages/SpacePage.tsx
+++ b/src/common/components/pages/SpacePage.tsx
@@ -3,7 +3,6 @@ import Space, { SpaceConfig, SpaceConfigSaveDetails } from "../templates/Space";
 import { isUndefined } from "lodash";
 import SpaceLoading from "@/common/components/templates/SpaceLoading";
 import { useSidebarContext } from "@/common/components/organisms/Sidebar";
-import moment from "moment";
 
 export type SpacePageArgs = {
   config?: SpaceConfig;

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -377,7 +377,7 @@ export const createSpaceStoreFunc = (
         }
 
         const localTab = draft.space.localSpaces[spaceId].tabs[tabName];
-        const remoteTab = draft.space.remoteSpaces[spaceId].tabs[tabName];
+        // const remoteTab = draft.space.remoteSpaces[spaceId].tabs[tabName];
 
         // Compare timestamps if local tab exists
         if (localTab) {

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { useAppStore } from "@/common/data/stores/app";
 import { Card, CardContent } from "@/common/components/atoms/card";
 import { toast } from "sonner";
@@ -18,7 +18,6 @@ import ScopedStyles from "@/common/components/molecules/ScopedStyles";
 import GrabHandleIcon from "../components/atoms/icons/GrabHandle";
 import StashIcon from "../components/atoms/icons/Stash";
 import { FaX } from "react-icons/fa6";
-import BackArrowIcon from "../components/atoms/icons/BackArrow";
 import {
   Tooltip,
   TooltipContent,

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -34,8 +34,6 @@ import { FaInfoCircle } from "react-icons/fa";
 import { THEMES } from "@/constants/themes";
 import { ThemeCard } from "@/common/lib/theme/ThemeCard";
 import { FONT_FAMILY_OPTIONS_BY_NAME } from "@/common/lib/theme/fonts";
-import { GiOpenBook } from "react-icons/gi";
-import { FaBook } from "react-icons/fa";
 import { MdMenuBook } from "react-icons/md";
 import { VideoSelector } from "@/common/components/molecules/VideoSelector";
 

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from "react";
-import { isNil, size } from "lodash";
+import { isNil } from "lodash";
 import {
   FidgetArgs,
   FidgetProperties,

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -20,7 +20,7 @@ import {
 } from "@neynar/nodejs-sdk/build/neynar-api/v2";
 import { useFarcasterSigner } from "@/fidgets/farcaster/index";
 import { CastReactionType } from "@/fidgets/farcaster/types";
-import { bytesToHexString, ReactionType } from "@farcaster/core";
+import { ReactionType } from "@farcaster/core";
 import { hexToBytes } from "@noble/ciphers/utils";
 import CreateCast, { DraftType } from "./CreateCast";
 import Modal from "@/common/components/molecules/Modal";

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -1,4 +1,4 @@
-import React, { FC, use, useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useEditor, EditorContent } from "@mod-protocol/react-editor";
 import { EmbedsEditor } from "@mod-protocol/react-ui-shadcn/dist/lib/embeds";
 import {
@@ -15,7 +15,7 @@ import {
 } from "@mod-protocol/farcaster";
 import { createRenderMentionsSuggestionConfig } from "@mod-protocol/react-ui-shadcn/dist/lib/mentions";
 import { CastLengthUIIndicator } from "@mod-protocol/react-ui-shadcn/dist/components/cast-length-ui-indicator";
-import { debounce, map, isEmpty, isUndefined, replace } from "lodash";
+import { debounce, map, isEmpty, isUndefined } from "lodash";
 import { Button } from "@/common/components/atoms/button";
 import { MentionList } from "./mentionList";
 import { ChannelList } from "@mod-protocol/react-ui-shadcn/dist/components/channel-list";
@@ -25,7 +25,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/common/components/atoms/popover";
-import { CreationMod, RichEmbed } from "@mod-protocol/react";
+import { CreationMod } from "@mod-protocol/react";
 import { creationMods } from "@mod-protocol/mod-registry";
 import { renderers } from "@mod-protocol/react-ui-shadcn/dist/renderers";
 import { renderEmbedForUrl } from "./Embeds";
@@ -282,8 +282,8 @@ const CreateCast: React.FC<CreateCastProps> = ({
           );
 
           mentionsPositions = [];
-          const currentTextIndex = 0;
-          const finalText = text;
+          // const currentTextIndex = 0;
+          // const finalText = text;
           const mentions = [];
           mentionsText = text;
 

--- a/src/fidgets/farcaster/components/channelPicker.tsx
+++ b/src/fidgets/farcaster/components/channelPicker.tsx
@@ -8,7 +8,6 @@ import {
   CommandInput,
   CommandItem,
   CommandEmpty,
-  CommandGroup,
   CommandList,
 } from "@/common/components/atoms/command"; // Adjust the import paths if needed
 import {

--- a/src/pages/api/signerRequests.ts
+++ b/src/pages/api/signerRequests.ts
@@ -3,8 +3,7 @@ import requestHandler, {
 } from "@/common/data/api/requestHandler";
 import { APP_FID } from "@/constants/app";
 import { AppSigner } from "@/constants/appServerSide";
-import { NOGS_CONTRACT_ADDR } from "@/constants/nogs";
-import { ALCHEMY_API, WARPCAST_API } from "@/constants/urls";
+import { WARPCAST_API } from "@/constants/urls";
 import {
   SIGNED_KEY_REQUEST_TYPE,
   SIGNED_KEY_REQUEST_VALIDATOR_EIP_712_DOMAIN,

--- a/src/pages/homebase/[tabname].tsx
+++ b/src/pages/homebase/[tabname].tsx
@@ -4,11 +4,10 @@ import { useAppStore } from "@/common/data/stores/app";
 import USER_NOT_LOGGED_IN_HOMEBASE_CONFIG from "@/constants/userNotLoggedInHomebase";
 import SpacePage from "@/common/components/pages/SpacePage";
 import { useRouter } from "next/router";
-import { isArray, isNull, isString, noop } from "lodash";
+import { isNull, isString } from "lodash";
 import { SpaceConfigSaveDetails } from "@/common/components/templates/Space";
 import TabBar from "@/common/components/organisms/TabBar";
 import { useSidebarContext } from "@/common/components/organisms/Sidebar";
-import tabOrder from "../api/space/homebase/tabOrder";
 
 const Homebase: NextPageWithLayout = () => {
   const {


### PR DESCRIPTION
This pull request focuses on cleaning up unused imports and simplifying the codebase across multiple files. The most important changes include the removal of unused imports, minor adjustments to component properties, and the commenting out of unused variables.

### Codebase simplification:

* [`src/common/components/organisms/FidgetSettingsEditor.tsx`](diffhunk://#diff-d92821207eed81f2eeeeb9fa342131374a4874547b0d5893c3d8ae71c7ddd988L8-R8): Removed the unused `FaTriangleExclamation` import from `react-icons/fa6`.
* [`src/common/components/organisms/LoadingSidebar.tsx`](diffhunk://#diff-ba71f1179d1594f9fe858b41e668248f13005b6dc9b3b2266b895101d3c69ddcL2): Removed the unused `BrandHeader` import.
* [`src/common/components/organisms/Navigation.tsx`](diffhunk://#diff-d63ecb533cb05c8741ddf1e1a0a951f842fa22cf003733a001301f036cd11f8fL132-R132): Simplified the `Icon` component usage by removing the `aria-hidden` attribute.
* [`src/common/components/organisms/Player.tsx`](diffhunk://#diff-8651d746b3ec512d065d7d3f6426370ca1b300e29c58d16ed597b4180f2119e2L21-R21): Removed unused imports `formatEthereumAddress` and `isAddress` from `viem`.
* [`src/common/components/organisms/Sidebar.tsx`](diffhunk://#diff-712d5d2772807ab63d7e5add8042aeecba97727d2d75ab21cde01e8e7a302f01L7-L10): Removed the unused `useEffect` import and `LoadingSidebar` import.

### Unused imports removal:

* [`src/common/components/organisms/TabBar.tsx`](diffhunk://#diff-bdc78f77ca5b7e379471bf7d0b8292d6d30d7c3a660437260337950bb65e8578L3-L13): Removed multiple unused imports including `first`, `useLoadFarcasterUser`, `useFarcasterSigner`, `memo`, `useEffect`, `useMemo`, `useState`, `useRouter`, `SpaceLookupInfo`, and `Link`.
* [`src/common/components/pages/SpacePage.tsx`](diffhunk://#diff-1cc746f87bf7fc5768a71aea489ad8d68c3bf2244e4393586312a38f46dc0b78L6): Removed the unused `moment` import.
* [`src/common/fidgets/FidgetWrapper.tsx`](diffhunk://#diff-8e9e61415638487089464bb1814990207dce47502d9de15d2aafb36ff571f171L1-R1): Removed the unused `useState` import and `BackArrowIcon` import. [[1]](diffhunk://#diff-8e9e61415638487089464bb1814990207dce47502d9de15d2aafb36ff571f171L1-R1) [[2]](diffhunk://#diff-8e9e61415638487089464bb1814990207dce47502d9de15d2aafb36ff571f171L21)
* [`src/common/lib/theme/ThemeSettingsEditor.tsx`](diffhunk://#diff-7dfc6b7a6c04e69891455f32bb7412b8295844f73053618ab7b47522f45a3001L37-L38): Removed the unused `GiOpenBook` and `FaBook` imports.
* [`src/fidgets/farcaster/Feed.tsx`](diffhunk://#diff-ee80eeddaa1ac4ac3effcec01543364a1dad9aaf5969203932e778a277023be4L2-R2): Removed the unused `size` import.
* [`src/fidgets/farcaster/components/CastRow.tsx`](diffhunk://#diff-0b96b0c1dfb58d8be26f0bfccd6be78d64bde6a392b04d186b4e16506c838c53L23-R23): Removed the unused `bytesToHexString` import.
* [`src/fidgets/farcaster/components/CreateCast.tsx`](diffhunk://#diff-8a0c1b7283d488eece372c8f92fb4831934f18d66ee576ffb5c1db6e4a7fdd6eL1-R1): Removed the unused `FC`, `use`, and `RichEmbed` imports, and commented out unused variables. [[1]](diffhunk://#diff-8a0c1b7283d488eece372c8f92fb4831934f18d66ee576ffb5c1db6e4a7fdd6eL1-R1) [[2]](diffhunk://#diff-8a0c1b7283d488eece372c8f92fb4831934f18d66ee576ffb5c1db6e4a7fdd6eL18-R18) [[3]](diffhunk://#diff-8a0c1b7283d488eece372c8f92fb4831934f18d66ee576ffb5c1db6e4a7fdd6eL28-R28) [[4]](diffhunk://#diff-8a0c1b7283d488eece372c8f92fb4831934f18d66ee576ffb5c1db6e4a7fdd6eL285-R286)
* [`src/fidgets/farcaster/components/channelPicker.tsx`](diffhunk://#diff-6d71156fcb826a51b3c2a05850ee02f0ef0e9d4bbe305c788db6bbaa541128baL11): Removed the unused `CommandGroup` import.
* [`src/pages/api/signerRequests.ts`](diffhunk://#diff-aabb0c502e965a6f454035e789273e5a772f87712aa3018239a8575b47f61c18L6-R6): Removed the unused `NOGS_CONTRACT_ADDR` and `ALCHEMY_API` imports.
* `src/pages/homebase/[tabname].tsx`: Removed the unused `isArray` and `noop` imports. ([src/pages/homebase/[tabname].tsxL7-L11](diffhunk://#diff-8fba97cea03dcb9662a833fc30d6e9b77a010a4cfc2079a5b8eb2e7e9b73d03cL7-L11))

### Commented out unused variables:

* [`src/common/data/stores/app/space/spaceStore.ts`](diffhunk://#diff-98fd495414735652a5f73447d8c21927977f2526811c440d6ced426a573a9a3bL380-R380): Commented out the unused `remoteTab` variable.