### PR TITLE
Matcha scale

### DIFF
--- a/src/common/components/molecules/ChainSelector.tsx
+++ b/src/common/components/molecules/ChainSelector.tsx
@@ -9,64 +9,47 @@ import {
 
 const CHAIN_OPTIONS = [
   {
-    id: "ETH",
+    id: "1", // Ethereum Mainnet Chain ID
     name: "Ethereum",
     logo: "https://raw.githubusercontent.com/rango-exchange/assets/main/blockchains/ETH/icon.svg",
   },
   {
-    id: "BSC",
+    id: "56", // Binance Smart Chain Mainnet Chain ID
     name: "Binance Smart Chain",
     logo: "https://raw.githubusercontent.com/rango-exchange/assets/main/blockchains/BSC/icon.svg",
   },
   {
-    id: "ARBITRUM",
+    id: "42161", // Arbitrum One Chain ID
     name: "Arbitrum",
     logo: "https://raw.githubusercontent.com/rango-exchange/assets/main/blockchains/ARBITRUM/icon.svg",
   },
   {
-    id: "POLYGON",
+    id: "137", // Polygon Mainnet Chain ID
     name: "Polygon",
     logo: "https://raw.githubusercontent.com/rango-exchange/assets/main/blockchains/POLYGON/icon.svg",
   },
   {
-    id: "AVAX",
+    id: "43114", // Avalanche C-Chain Chain ID
     name: "Avalanche",
     logo: "https://raw.githubusercontent.com/rango-exchange/assets/main/blockchains/AVAX_CCHAIN/icon.svg",
   },
   {
-    id: "OPTIMISM",
+    id: "10", // Optimism Mainnet Chain ID
     name: "Optimism",
     logo: "https://raw.githubusercontent.com/rango-exchange/assets/main/blockchains/OPTIMISM/icon.svg",
   },
-  // Blast
   {
-    id: "BLAST",
+    id: "81457", // Blast Mainnet Chain ID
     name: "Blast",
     logo: "https://raw.githubusercontent.com/rango-exchange/assets/main/blockchains/BLAST/icon.svg",
   },
   {
-    id: "LINEA",
+    id: "59144", // Linea Mainnet Chain ID
     name: "Linea",
     logo: "https://raw.githubusercontent.com/rango-exchange/assets/main/blockchains/LINEA/icon.svg",
   },
-  // {
-  //   id: "BTC",
-  //   name: "Bitcoin",
-  //   logo: "https://raw.githubusercontent.com/rango-exchange/assets/main/blockchains/BTC/icon.svg",
-  // },
-  // {
-  //   id: "LTC",
-  //   name: "Litecoin",
-  //   logo: "https://raw.githubusercontent.com/rango-exchange/assets/main/blockchains/LTC/icon.svg",
-  // },
-  // {
-  //   id: "DOGE",
-  //   name: "Dogecoin",
-  //   logo: "https://raw.githubusercontent.com/rango-exchange/assets/main/blockchains/DOGE/icon.svg",
-  // },
-  // add BASE
   {
-    id: "BASE",
+    id: "8453", // Base Mainnet Chain ID
     name: "Base",
     logo: "https://raw.githubusercontent.com/rango-exchange/assets/main/blockchains/BASE/icon.svg",
   },

--- a/src/common/components/molecules/ScaleSliderSelector.tsx
+++ b/src/common/components/molecules/ScaleSliderSelector.tsx
@@ -9,7 +9,7 @@ export type WidthSliderProps = {
 };
 
 const WidthSlider: React.FC<WidthSliderProps> = ({
-  min = 1,
+  min = 0.1,
   max = 2.1,
   step = 0.1,
   defaultValue = 1,

--- a/src/fidgets/swap/Swap.tsx
+++ b/src/fidgets/swap/Swap.tsx
@@ -113,7 +113,7 @@ const Swap: React.FC<FidgetArgs<MatchaFidgetSettings>> = ({ settings }) => {
     if (toChain) params.append("buyChain", toChain.toString().toLowerCase());
     return `${matchaBaseUrl}?${params.toString()}`;
   };
-  let size = settings.size || 1;
+  const size = settings.size || 1;
   const scaleValue = size;
 
   return (

--- a/src/fidgets/swap/Swap.tsx
+++ b/src/fidgets/swap/Swap.tsx
@@ -17,6 +17,7 @@ type MatchaFidgetSettings = {
   fontFamily: string;
   fontColor: string;
   swapScale: number;
+  optionalFeeRecipient?: string;
 } & FidgetSettingsStyle;
 
 const matchaProperties: FidgetProperties = {
@@ -49,6 +50,14 @@ const matchaProperties: FidgetProperties = {
       default: 8453,
       required: false,
       inputSelector: ChainSelector,
+      group: "settings",
+    },
+    // added inout for optional fee recipient
+    {
+      fieldName: "optionalFeeRecipient",
+      default: "0xabc..12345",
+      required: false,
+      inputSelector: TextInput,
       group: "settings",
     },
     // {
@@ -92,7 +101,13 @@ const Swap: React.FC<FidgetArgs<MatchaFidgetSettings>> = ({ settings }) => {
   const matchaBaseUrl = "https://matcha.xyz/trade";
 
   const buildMatchaUrl = () => {
-    const { defaultSellToken, defaultBuyToken, fromChain, toChain } = settings;
+    const {
+      defaultSellToken,
+      defaultBuyToken,
+      fromChain,
+      toChain,
+      optionalFeeRecipient,
+    } = settings;
 
     const params = new URLSearchParams();
     if (defaultSellToken) params.append("sellAddress", defaultSellToken);
@@ -100,13 +115,18 @@ const Swap: React.FC<FidgetArgs<MatchaFidgetSettings>> = ({ settings }) => {
     if (fromChain)
       params.append("sellChain", fromChain.toString().toLowerCase());
     if (toChain) params.append("buyChain", toChain.toString().toLowerCase());
+
+    // Add referral reward parameters if optionalFeeRecipient is provided
+    if (optionalFeeRecipient) {
+      params.append("ref", optionalFeeRecipient); // Referral address
+      params.append("swapFeeBps", "10"); // Example fee percentage in bps (adjust as needed)
+    }
+    // function calculateHeight(value: number) {
+    //   const translation = (value - 1) * 30;
+    //   return `${translation}%`;
+    // }
     return `${matchaBaseUrl}?${params.toString()}`;
   };
-
-  // function calculateHeight(value: number) {
-  //   const translation = (value - 1) * 30;
-  //   return `${translation}%`;
-  // }
 
   return (
     <div

--- a/src/fidgets/swap/Swap.tsx
+++ b/src/fidgets/swap/Swap.tsx
@@ -54,13 +54,13 @@ const matchaProperties: FidgetProperties = {
       group: "settings",
     },
     // added inout for optional fee recipient
-    {
-      fieldName: "optionalFeeRecipient",
-      default: "",
-      required: false,
-      inputSelector: TextInput,
-      group: "settings",
-    },
+    // {
+    //   fieldName: "optionalFeeRecipient",
+    //   default: "",
+    //   required: false,
+    //   inputSelector: TextInput,
+    //   group: "settings",
+    // },
     // {
     //   fieldName: "background",
     //   default: "",
@@ -102,13 +102,7 @@ const Swap: React.FC<FidgetArgs<MatchaFidgetSettings>> = ({ settings }) => {
   const matchaBaseUrl = "https://matcha.xyz/trade";
 
   const buildMatchaUrl = () => {
-    const {
-      defaultSellToken,
-      defaultBuyToken,
-      fromChain,
-      toChain,
-      optionalFeeRecipient,
-    } = settings;
+    const { defaultSellToken, defaultBuyToken, fromChain, toChain } = settings;
 
     const params = new URLSearchParams();
     if (defaultSellToken) params.append("sellAddress", defaultSellToken);
@@ -116,12 +110,6 @@ const Swap: React.FC<FidgetArgs<MatchaFidgetSettings>> = ({ settings }) => {
     if (fromChain)
       params.append("sellChain", fromChain.toString().toLowerCase());
     if (toChain) params.append("buyChain", toChain.toString().toLowerCase());
-
-    // Add referral reward parameters if optionalFeeRecipient is provided
-    if (optionalFeeRecipient) {
-      params.append("ref", optionalFeeRecipient); // Referral address
-      params.append("swapFeeBps", "10"); // Example fee percentage in bps (adjust as needed)
-    }
     return `${matchaBaseUrl}?${params.toString()}`;
   };
 

--- a/src/fidgets/swap/Swap.tsx
+++ b/src/fidgets/swap/Swap.tsx
@@ -56,7 +56,7 @@ const matchaProperties: FidgetProperties = {
     // added inout for optional fee recipient
     {
       fieldName: "optionalFeeRecipient",
-      default: "0xabc..12345",
+      default: "",
       required: false,
       inputSelector: TextInput,
       group: "settings",
@@ -151,7 +151,7 @@ const Swap: React.FC<FidgetArgs<MatchaFidgetSettings>> = ({ settings }) => {
         }}
       >
         <iframe
-          src="https://simpleswap.io/widget/df29d743-6c03-4c7e-a745-4a0bfd19c656"
+          src={buildMatchaUrl()}
           style={{
             width: "480px", // Original iframe width
             height: "660px", // Original iframe height

--- a/src/fidgets/swap/Swap.tsx
+++ b/src/fidgets/swap/Swap.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/common/fidgets";
 import ChainSelector from "@/common/components/molecules/ChainSelector";
 import WidthSlider from "@/common/components/molecules/ScaleSliderSelector";
+import IFrameWidthSlider from "@/common/components/molecules/IframeScaleSlider";
 
 type MatchaFidgetSettings = {
   defaultSellToken: string;
@@ -19,6 +20,7 @@ type MatchaFidgetSettings = {
   fontColor: string;
   swapScale: number;
   optionalFeeRecipient?: string;
+  size: number;
 } & FidgetSettingsStyle;
 
 const matchaProperties: FidgetProperties = {
@@ -83,10 +85,9 @@ const matchaProperties: FidgetProperties = {
     //   group: "style",
     // },
     {
-      fieldName: "swapScale",
-      default: 1,
+      fieldName: "size",
       required: false,
-      inputSelector: WidthSlider,
+      inputSelector: IFrameWidthSlider,
       group: "style",
     },
   ],
@@ -112,42 +113,22 @@ const Swap: React.FC<FidgetArgs<MatchaFidgetSettings>> = ({ settings }) => {
     if (toChain) params.append("buyChain", toChain.toString().toLowerCase());
     return `${matchaBaseUrl}?${params.toString()}`;
   };
-
-  function calculateHeight(value: number) {
-    const translation = (value - 1) * 30;
-    const scale = value;
-    return `translateY(${translation}%) scale(${scale})`;
-  }
+  let size = settings.size || 1;
+  const scaleValue = size;
 
   return (
-    <div
-      style={{
-        position: "relative",
-        width: "100%",
-        height: "100%",
-        overflow: "hidden",
-        backgroundColor: settings.background || "transparent",
-      }}
-    >
-      <div
+    <div style={{ overflow: "hidden", width: "100%", height: "100%" }}>
+      <iframe
+        src={buildMatchaUrl()}
+        sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
         style={{
-          position: "absolute",
-          top: "50%",
-          left: "50%",
-          transform: `translate(-50%, -50%) scale(${settings.swapScale})`,
-          transformOrigin: "center",
+          transform: `scale(${scaleValue})`,
+          transformOrigin: "0 0",
+          width: `${100 / scaleValue}%`,
+          height: `${100 / scaleValue}%`,
         }}
-      >
-        <iframe
-          src={buildMatchaUrl()}
-          style={{
-            width: "480px", // Original iframe width
-            height: "660px", // Original iframe height
-            border: "none",
-          }}
-          title="Matcha Swap"
-        />
-      </div>
+        className="size-full"
+      />
     </div>
   );
 };

--- a/src/fidgets/swap/Swap.tsx
+++ b/src/fidgets/swap/Swap.tsx
@@ -121,12 +121,13 @@ const Swap: React.FC<FidgetArgs<MatchaFidgetSettings>> = ({ settings }) => {
       params.append("ref", optionalFeeRecipient); // Referral address
       params.append("swapFeeBps", "10"); // Example fee percentage in bps (adjust as needed)
     }
-    // function calculateHeight(value: number) {
-    //   const translation = (value - 1) * 30;
-    //   return `${translation}%`;
-    // }
     return `${matchaBaseUrl}?${params.toString()}`;
   };
+
+  // function calculateHeight(value: number) {
+  //   const translation = (value - 1) * 30;
+  //   return `${translation}%`;
+  // }
 
   return (
     <div

--- a/src/fidgets/swap/Swap.tsx
+++ b/src/fidgets/swap/Swap.tsx
@@ -7,6 +7,7 @@ import {
   type FidgetSettingsStyle,
 } from "@/common/fidgets";
 import ChainSelector from "@/common/components/molecules/ChainSelector";
+import WidthSlider from "@/common/components/molecules/ScaleSliderSelector";
 
 type MatchaFidgetSettings = {
   defaultSellToken: string;
@@ -81,13 +82,13 @@ const matchaProperties: FidgetProperties = {
     //   inputSelector: SimpleColorSelector,
     //   group: "style",
     // },
-    // {
-    //   fieldName: "swapScale",
-    //   default: 1,
-    //   required: false,
-    //   inputSelector: WidthSlider,
-    //   group: "style",
-    // },
+    {
+      fieldName: "swapScale",
+      default: 1,
+      required: false,
+      inputSelector: WidthSlider,
+      group: "style",
+    },
   ],
   size: {
     minHeight: 3,
@@ -124,31 +125,41 @@ const Swap: React.FC<FidgetArgs<MatchaFidgetSettings>> = ({ settings }) => {
     return `${matchaBaseUrl}?${params.toString()}`;
   };
 
-  // function calculateHeight(value: number) {
-  //   const translation = (value - 1) * 30;
-  //   return `${translation}%`;
-  // }
+  function calculateHeight(value: number) {
+    const translation = (value - 1) * 30;
+    const scale = value;
+    return `translateY(${translation}%) scale(${scale})`;
+  }
 
   return (
     <div
       style={{
-        overflow: "auto",
+        position: "relative",
         width: "100%",
         height: "100%",
+        overflow: "hidden",
         backgroundColor: settings.background || "transparent",
-        transform: `scale(${settings.swapScale})`,
-        transformOrigin: "top left",
       }}
     >
-      <iframe
-        src={buildMatchaUrl()}
+      <div
         style={{
-          width: "100%",
-          height: "100%",
-          border: "none",
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: `translate(-50%, -50%) scale(${settings.swapScale})`,
+          transformOrigin: "center",
         }}
-        title="Matcha Swap"
-      />
+      >
+        <iframe
+          src="https://simpleswap.io/widget/df29d743-6c03-4c7e-a745-4a0bfd19c656"
+          style={{
+            width: "480px", // Original iframe width
+            height: "660px", // Original iframe height
+            border: "none",
+          }}
+          title="Matcha Swap"
+        />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
This pull request includes several updates to the `src/fidgets/swap/Swap.tsx` and `src/common/components/molecules/ScaleSliderSelector.tsx` files, focusing on enhancing the functionality and flexibility of the swap component. Key changes include adjusting default values, adding new properties, and improving the layout and scaling of the swap interface.

### Enhancements to Swap Component:

* **Default Value Adjustment:**
  - Updated the `min` value in `WidthSlider` from 1 to 0.1 in `ScaleSliderSelector.tsx` to allow for finer adjustments. (NEED TO TEST THE IFRAME FIDGET COUNTER EFFECT IF ANY)

* **New Property Addition:**
  - Added an `optionalFeeRecipient` property to `MatchaFidgetSettings` to support referral rewards and fee settings. [[1]](diffhunk://#diff-30fad142bd9fcce0282d8b8c0999f8a80d9e3f43f66c9428ef4139e32150e265R21) [[2]](diffhunk://#diff-30fad142bd9fcce0282d8b8c0999f8a80d9e3f43f66c9428ef4139e32150e265R56-R63)

* **Layout and Scaling Improvements:**
  - Updated the `Swap` component to include the `optionalFeeRecipient` in the URL parameters and adjusted the iframe styles for better positioning and scaling.

* **Code Refactoring:**
  - Reintroduced the `swapScale` property in `matchaProperties` to utilize `WidthSlider` for scaling adjustments.