### PR TITLE
[client] chore(): Move explore page to app router

### DIFF
--- a/src/common/data/explore/loadExploreMarkdown.ts
+++ b/src/common/data/explore/loadExploreMarkdown.ts
@@ -61,7 +61,10 @@ export async function getAllSlugs() {
       return [];
     }
     return map(
-      filter(data, (d) => endsWith(d.name, ".md") && !startsWith(d.name, ".")),
+      filter(
+        data,
+        (d: FileObject) => endsWith(d.name, ".md") && !startsWith(d.name, "."),
+      ),
       (d) => d.name.replace(/\.md$/, ""),
     );
   }


### PR DESCRIPTION
This pull request migrates the explore page (and slug page) to app router.