### PR TITLE
feat: Add geckoterminal as option for MarketData Fidget

### DIFF
--- a/src/common/components/molecules/MarketDataSelector.tsx
+++ b/src/common/components/molecules/MarketDataSelector.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@/common/components/atoms/select";
+
+const DATA_SOURCE_OPTIONS = [
+  { id: "dexscreener", name: "DexScreener" },
+  { id: "geckoterminal", name: "GeckoTerminal" },
+];
+
+export interface MarketDataSelectorProps {
+  onChange: (source: string) => void;
+  value: string;
+  className?: string;
+}
+
+export const MarketDataSelector: React.FC<MarketDataSelectorProps> = ({
+  onChange,
+  value,
+  className,
+}) => {
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className={className} aria-label="Select data source">
+        <div className="flex items-center">
+          <span>
+            {DATA_SOURCE_OPTIONS.find((option) => option.id === value)?.name ||
+              "Select a data source"}
+          </span>
+        </div>
+      </SelectTrigger>
+      <SelectContent>
+        {DATA_SOURCE_OPTIONS.map((source) => (
+          <SelectItem
+            value={source.id}
+            key={source.id}
+            className="flex items-center"
+          >
+            <div className="flex items-center">
+              <span>{source.name}</span>
+            </div>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};
+
+export default MarketDataSelector;

--- a/src/fidgets/token/marketData.tsx
+++ b/src/fidgets/token/marketData.tsx
@@ -81,9 +81,12 @@ const MarketData: React.FC<FidgetArgs<MarketDataProps>> = ({
 }) => {
   const buildUrl = () => {
     if (dataSource === "geckoterminal") {
-      return `https://www.geckoterminal.com/${chain?.name ?? "base"}/pools/${token}?embed=1&info=0&swaps=0&grayscale=0&light_chart=0`;
+      const lightChart = theme === "light" ? 1 : 0;
+      const url = `https://www.geckoterminal.com/${chain?.name ?? "base"}/pools/${token}?embed=1&info=0&swaps=0&grayscale=0&light_chart=${lightChart}`;
+      return url;
     }
-    return `https://dexscreener.com/${chain?.name ?? "base"}/${token}?embed=1&loadChartSettings=0&trades=0&tabs=1&info=0&chartLeftToolbar=0&chartDefaultOnMobile=1&chartTheme=${theme}&theme=${theme}&chartStyle=1&chartType=usd&interval=60`;
+    const url = `https://dexscreener.com/${chain?.name ?? "base"}/${token}?embed=1&loadChartSettings=0&trades=0&tabs=1&info=0&chartLeftToolbar=0&chartDefaultOnMobile=1&chartTheme=${theme}&theme=${theme}&chartStyle=1&chartType=usd&interval=60`;
+    return url;
   };
 
   const scaleValue = size;

--- a/src/fidgets/token/marketData.tsx
+++ b/src/fidgets/token/marketData.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import TextInput from "@/common/components/molecules/TextInput";
 import ChainSelector from "@/common/components/molecules/ChainSelector";
+import MarketDataSelector from "@/common/components/molecules/MarketDataSelector";
 import {
   FidgetArgs,
   FidgetProperties,
@@ -16,6 +17,7 @@ export type MarketDataProps = {
   token: string;
   size: number;
   theme: string;
+  dataSource: string;
 } & FidgetSettingsStyle;
 
 const frameConfig: FidgetProperties = {
@@ -44,6 +46,14 @@ const frameConfig: FidgetProperties = {
       group: "style",
       default: "light",
     },
+    {
+      fieldName: "dataSource",
+      displayName: "Data Source",
+      inputSelector: MarketDataSelector,
+      required: true,
+      group: "settings",
+      default: "dexscreener",
+    },
     ...defaultStyleFields,
     {
       fieldName: "size",
@@ -66,12 +76,14 @@ const MarketData: React.FC<FidgetArgs<MarketDataProps>> = ({
     token,
     size = 1,
     theme = "light",
+    dataSource = "dexscreener",
   },
 }) => {
-  const dexscreenerBaseUrl = "https://dexscreener.com";
-
-  const buildDexScreenerUrl = () => {
-    return `${dexscreenerBaseUrl}/${chain?.name ?? "base"}/${token}?embed=1&loadChartSettings=0&trades=0&tabs=1&info=0&chartLeftToolbar=0&chartDefaultOnMobile=1&chartTheme=${theme}&theme=${theme}&chartStyle=1&chartType=usd&interval=60`;
+  const buildUrl = () => {
+    if (dataSource === "geckoterminal") {
+      return `https://www.geckoterminal.com/${chain?.name ?? "base"}/pools/${token}?embed=1&info=0&swaps=0&grayscale=0&light_chart=0`;
+    }
+    return `https://dexscreener.com/${chain?.name ?? "base"}/${token}?embed=1&loadChartSettings=0&trades=0&tabs=1&info=0&chartLeftToolbar=0&chartDefaultOnMobile=1&chartTheme=${theme}&theme=${theme}&chartStyle=1&chartType=usd&interval=60`;
   };
 
   const scaleValue = size;
@@ -79,8 +91,8 @@ const MarketData: React.FC<FidgetArgs<MarketDataProps>> = ({
   return (
     <div style={{ overflow: "hidden", width: "100%", height: "100%" }}>
       <iframe
-        src={buildDexScreenerUrl()}
-        title="DexScreener Market Data"
+        src={buildUrl()}
+        title="Market Data"
         sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
         style={{
           transform: `scale(${scaleValue})`,


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/7bad6a28-56e3-492b-93c9-99e3bc6996fa)

### New Component Addition:

* [`src/common/components/molecules/MarketDataSelector.tsx`](diffhunk://#diff-9c84bb696afac4b9720aa666c8c32f1b66b087e1f27880ebb4b29fe2fc762fceR1-R52): Added a new `MarketDataSelector` component that allows users to select between different market data sources.

### Integration and Updates:

* [`src/fidgets/token/marketData.tsx`](diffhunk://#diff-c2f203344cbb4fa7bebf44bc816dd483acaada48c2c4eea2716e948ea7d0e613R4): Imported the `MarketDataSelector` component and updated the `MarketDataProps` type to include a `dataSource` field. [[1]](diffhunk://#diff-c2f203344cbb4fa7bebf44bc816dd483acaada48c2c4eea2716e948ea7d0e613R4) [[2]](diffhunk://#diff-c2f203344cbb4fa7bebf44bc816dd483acaada48c2c4eea2716e948ea7d0e613R20)
* [`src/fidgets/token/marketData.tsx`](diffhunk://#diff-c2f203344cbb4fa7bebf44bc816dd483acaada48c2c4eea2716e948ea7d0e613R49-R56): Added a new field configuration for `dataSource` in the `frameConfig` object.
* [`src/fidgets/token/marketData.tsx`](diffhunk://#diff-c2f203344cbb4fa7bebf44bc816dd483acaada48c2c4eea2716e948ea7d0e613R79-R95): Updated the URL-building logic in the `MarketData` component to use the selected data source and construct the appropriate URL.