### PR TITLE
temp fix: tabs routing on tokenPages

### DIFF
--- a/src/common/components/pages/DesktopContractDefinedSpace.tsx
+++ b/src/common/components/pages/DesktopContractDefinedSpace.tsx
@@ -284,24 +284,12 @@ const DesktopContractDefinedSpace = ({
       const resolvedConfig = await config;
       saveLocalSpaceTab(spaceId, providedTabName, resolvedConfig);
     }
-
-    // TODO: This is a hack to get the profile tab to work, we need to fix this in a proper way
-    if (tabName === "Profile") {
-      router.push(`/t/base/${contractAddress}/${tabName.toLocaleLowerCase()}`);
-    }
-    else {
+    if (tabName)
       router.push(`/t/base/${contractAddress}/${tabName}`);
-    }
   }
-  // TODO: This is a hack to get the profile tab to work, we need to fix this in a proper way
 
   function getSpacePageUrl(tabName: string) {
-    if (tabName === "Profile") {
-      return `/t/base/${contractAddress}/${tabName.toLocaleLowerCase()}`;
-    }
-    else {
-      return `/t/base/${contractAddress}/${tabName}`;
-    }
+    return `/t/base/${contractAddress}/${tabName}`;
   }
 
   const { editMode } = useSidebarContext();

--- a/src/common/components/pages/DesktopContractDefinedSpace.tsx
+++ b/src/common/components/pages/DesktopContractDefinedSpace.tsx
@@ -284,11 +284,24 @@ const DesktopContractDefinedSpace = ({
       const resolvedConfig = await config;
       saveLocalSpaceTab(spaceId, providedTabName, resolvedConfig);
     }
-    router.push(`/t/base/${contractAddress}/${tabName.toLocaleLowerCase()}`);
+
+    // TODO: This is a hack to get the profile tab to work, we need to fix this in a proper way
+    if (tabName === "Profile") {
+      router.push(`/t/base/${contractAddress}/${tabName.toLocaleLowerCase()}`);
+    }
+    else {
+      router.push(`/t/base/${contractAddress}/${tabName}`);
+    }
   }
+  // TODO: This is a hack to get the profile tab to work, we need to fix this in a proper way
 
   function getSpacePageUrl(tabName: string) {
-    return `/t/base/${contractAddress}/${tabName.toLocaleLowerCase()}`;
+    if (tabName === "Profile") {
+      return `/t/base/${contractAddress}/${tabName.toLocaleLowerCase()}`;
+    }
+    else {
+      return `/t/base/${contractAddress}/${tabName}`;
+    }
   }
 
   const { editMode } = useSidebarContext();

--- a/src/pages/t/base/[contractAddress]/index.tsx
+++ b/src/pages/t/base/[contractAddress]/index.tsx
@@ -84,7 +84,7 @@ const ContractPrimarySpaceContent: React.FC<ContractSpacePageProps> = ({
 
   if (!isNil(ownerId) && !isNil(contractAddress)) {
     if (
-      (isNil(spaceId) && (tabName === "profile" || tabName === null)) ||
+      (isNil(spaceId) && (tabName?.toLocaleLowerCase() === "profile" || tabName === null)) ||
       !isNil(spaceId)
     )
       return (


### PR DESCRIPTION

Routing adjustments for tabs:

* [`src/common/components/pages/DesktopContractDefinedSpace.tsx`](diffhunk://#diff-09110a267d87f08bf02fdac9b72c08b23770ae46c25ac134dd5d3bcfef93d1f6R287-R305): Added conditional logic to handle routing for the "Profile" tab separately from other tabs. This includes a temporary workaround to ensure the "Profile" tab functions correctly.