### PR TITLE
fix: try to remove some grid params

### DIFF
--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -63,8 +63,6 @@ export interface PlacedGridItem extends GridItem {
 
 const makeGridDetails = (hasProfile: boolean, hasFeed: boolean) => ({
   items: 0,
-  isDraggable: false,
-  isResizable: false,
   isDroppable: true,
   isBounded: false,
   // This turns off compaction so you can place items wherever.
@@ -399,8 +397,6 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
             maxW: fidgetProps.size.maxWidth,
             maxH: fidgetProps.size.maxHeight,
             resizeHandles: resizeDirections,
-            isDraggable: inEditMode,
-            isResizable: inEditMode,
             isBounded: false,
           };
 


### PR DESCRIPTION
This PR's fixes the bug where a user is able to (semi)edit a space outside of the edit function

https://github.com/user-attachments/assets/f321996e-64d4-447b-afbf-80cd76fe7af9