### PR TITLE
Update Neynar SDK to v2.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@mod-protocol/react-editor": "^0.1.0",
     "@mod-protocol/react-ui-shadcn": "^0.3.1",
     "@mui/material": "^5.16.1",
-    "@neynar/nodejs-sdk": "~1.20.2",
+    "@neynar/nodejs-sdk": "^2.23.0",
     "@noble/ciphers": "^0.5.3",
     "@noble/ed25519": "^2.1.0",
     "@noble/secp256k1": "^2.1.0",

--- a/src/common/components/organisms/SearchAutocompleteInput.tsx
+++ b/src/common/components/organisms/SearchAutocompleteInput.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import useSearchUsers from "@/common/lib/hooks/useSearchUsers";
-import { User } from "@neynar/nodejs-sdk/build/neynar-api/v2";
+import { User } from "@neynar/nodejs-sdk/build/api";
 import { Avatar, AvatarImage } from "@/common/components/atoms/avatar";
 import {
   Command,

--- a/src/common/data/api/etherscan.ts
+++ b/src/common/data/api/etherscan.ts
@@ -176,8 +176,11 @@ export async function contractOwnerFromContract(
         String(network),
       );
       ownerId = contractCreation.contractCreator;
+      const addresses = [ownerId];
+      // const addressTypes = ;
+      // const viewerFid = ;
       try {
-        const userFid = await neynar.fetchBulkUsersByEthereumAddress([ownerId]);
+        const userFid = await neynar.fetchBulkUsersByEthOrSolAddress({ addresses });
         if (userFid[ownerId]) {
           ownerId = userFid[ownerId][0].fid.toString();
           ownerIdType = "fid" as OwnerType;

--- a/src/common/data/api/neynar.ts
+++ b/src/common/data/api/neynar.ts
@@ -1,3 +1,3 @@
 import { NeynarAPIClient } from "@neynar/nodejs-sdk";
 
-export default new NeynarAPIClient(process.env.NEYNAR_API_KEY!);
+export default new NeynarAPIClient({apiKey: process.env.NEYNAR_API_KEY!});

--- a/src/common/data/queries/farcaster.ts
+++ b/src/common/data/queries/farcaster.ts
@@ -4,7 +4,7 @@ import {
   FeedResponse,
   FeedType,
   FilterType,
-} from "@neynar/nodejs-sdk/build/neynar-api/v2";
+} from "@neynar/nodejs-sdk/build/api";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import axiosBackend from "../api/backend";
 import { isUndefined } from "lodash";

--- a/src/common/lib/hooks/useNotifications.ts
+++ b/src/common/lib/hooks/useNotifications.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { NotificationsResponse } from "@neynar/nodejs-sdk/build/neynar-api/v2";
+import { NotificationsResponse } from "@neynar/nodejs-sdk/build/api";
 import { useInfiniteQuery, keepPreviousData } from "@tanstack/react-query";
 import { NounspaceResponse } from "@/common/data/api/requestHandler";
 import axiosBackend from "@/common/data/api/backend";

--- a/src/common/lib/hooks/useSearchUsers.ts
+++ b/src/common/lib/hooks/useSearchUsers.ts
@@ -3,7 +3,7 @@ import { debounce } from "lodash";
 import axios, { CancelTokenSource, isAxiosError } from "axios";
 import axiosBackend from "@/common/data/api/backend";
 import { NounspaceResponse } from "@/common/data/api/requestHandler";
-import { User } from "@neynar/nodejs-sdk/build/neynar-api/v2";
+import { User } from "@neynar/nodejs-sdk/build/api";
 
 type UserSearchResult = {
   users: User[];

--- a/src/constants/initialPersonSpace.ts
+++ b/src/constants/initialPersonSpace.ts
@@ -1,6 +1,6 @@
 import { SpaceConfig } from "@/common/components/templates/Space";
 import DEFAULT_THEME from "@/common/lib/theme/defaultTheme";
-import { FeedType, FilterType } from "@neynar/nodejs-sdk";
+import { FeedType, FilterType } from "@neynar/nodejs-sdk/build/api";
 import { cloneDeep } from "lodash";
 
 export const INITIAL_SPACE_CONFIG_EMPTY: Omit<SpaceConfig, "isEditable"> = {

--- a/src/fidgets/farcaster/Channel.tsx
+++ b/src/fidgets/farcaster/Channel.tsx
@@ -1,4 +1,3 @@
-import { FilterType } from "@neynar/nodejs-sdk";
 import { useQuery } from "@tanstack/react-query";
 import TextInput from "@/common/components/molecules/TextInput";
 import React, { useMemo } from "react";
@@ -6,9 +5,10 @@ import { FidgetArgs, FidgetModule, FidgetProperties } from "@/common/fidgets";
 import { isWebUrl } from "@/common/lib/utils/urls";
 import axiosBackend from "@/common/data/api/backend";
 import {
+  FilterType,
   ChannelResponse,
   FeedResponse,
-} from "@neynar/nodejs-sdk/build/neynar-api/v2";
+} from "@neynar/nodejs-sdk/build/api";
 
 // TO DO: Make this into a Feed that is configured to filter to a specific channel that is selectable in settings
 

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -7,6 +7,7 @@ import {
   type FidgetSettingsStyle,
 } from "@/common/fidgets";
 import { FeedType } from "@neynar/nodejs-sdk/build/api";
+
 import { CastRow } from "./components/CastRow";
 import { useFarcasterSigner } from ".";
 import Loading from "@/common/components/molecules/Loading";

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -6,7 +6,7 @@ import {
   FidgetModule,
   type FidgetSettingsStyle,
 } from "@/common/fidgets";
-import { FeedType } from "@neynar/nodejs-sdk/build/neynar-api/v2";
+import { FeedType } from "@neynar/nodejs-sdk/build/api";
 import { CastRow } from "./components/CastRow";
 import { useFarcasterSigner } from ".";
 import Loading from "@/common/components/molecules/Loading";

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -17,7 +17,7 @@ import {
   CastWithInteractions,
   EmbedUrl,
   User,
-} from "@neynar/nodejs-sdk/build/neynar-api/v2";
+} from "@neynar/nodejs-sdk/build/api";
 import { useFarcasterSigner } from "@/fidgets/farcaster/index";
 import { CastReactionType } from "@/fidgets/farcaster/types";
 import { ReactionType } from "@farcaster/core";

--- a/src/fidgets/farcaster/components/CastThreadView.tsx
+++ b/src/fidgets/farcaster/components/CastThreadView.tsx
@@ -4,7 +4,7 @@ import { CastRow } from "./CastRow";
 import { IoArrowBack } from "react-icons/io5";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { Button } from "@/common/components/atoms/button";
-import { CastWithInteractions } from "@neynar/nodejs-sdk/build/neynar-api/v2";
+import { CastWithInteractions } from "@neynar/nodejs-sdk/build/api";
 import { useLoadFarcasterConversation } from "@/common/data/queries/farcaster";
 import { CardHeader, CardTitle } from "@/common/components/atoms/card";
 import ScrollToIndex from "@/common/components/molecules/ScrollToIndex";

--- a/src/fidgets/farcaster/components/Embeds/EmbededCast.tsx
+++ b/src/fidgets/farcaster/components/Embeds/EmbededCast.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { CastRow } from "@/fidgets/farcaster/components/CastRow";
 import { isEmpty, isString } from "lodash";
-import { CastParamType } from "@neynar/nodejs-sdk";
-import { CastWithInteractions } from "@neynar/nodejs-sdk/build/neynar-api/v2";
-import { CastResponse } from "@neynar/nodejs-sdk/build/neynar-api/v2";
+import { CastParamType, 
+  CastWithInteractions, 
+  CastResponse } from "@neynar/nodejs-sdk/build/api";
 import type { CastEmbed } from ".";
 import { bytesToHex } from "@noble/ciphers/utils";
 import axiosBackend from "@/common/data/api/backend";

--- a/src/fidgets/ui/profile.tsx
+++ b/src/fidgets/ui/profile.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo } from "react";
 import TextInput from "@/common/components/molecules/TextInput";
 import { FidgetArgs, FidgetProperties, FidgetModule } from "@/common/fidgets";
 import { CgProfile } from "react-icons/cg";
-import { User } from "@neynar/nodejs-sdk/build/neynar-api/v2";
+import { User } from "@neynar/nodejs-sdk/build/api";
 import { first, isUndefined } from "lodash";
 import FarcasterLinkify from "../farcaster/components/linkify";
 import { useLoadFarcasterUser } from "@/common/data/queries/farcaster";
@@ -64,6 +64,8 @@ const Profile: React.FC<FidgetArgs<ProfileFidgetSettings>> = ({
       const wasFollowing = user.viewer_context?.following ?? false;
       user.viewer_context = {
         ...user.viewer_context,
+        blocking: false,
+        blocked_by: false,
         following: !wasFollowing,
         followed_by: user.viewer_context?.followed_by ?? false, // Default to false if undefined
       };

--- a/src/pages/api/farcaster/neynar/cast.ts
+++ b/src/pages/api/farcaster/neynar/cast.ts
@@ -1,6 +1,6 @@
 import neynar from "@/common/data/api/neynar";
 import requestHandler from "@/common/data/api/requestHandler";
-import { CastParamType } from "@neynar/nodejs-sdk";
+import { CastParamType } from "@neynar/nodejs-sdk/build/api";
 import { isAxiosError } from "axios";
 import { isString } from "lodash";
 import { NextApiRequest, NextApiResponse } from "next/types";
@@ -12,7 +12,7 @@ async function loadCast(req: NextApiRequest, res: NextApiResponse) {
     : CastParamType.Hash;
 
   try {
-    const data = await neynar.lookUpCastByHashOrWarpcastUrl(id, type);
+    const data = await neynar.lookupCastByHashOrWarpcastUrl({identifier: id, type});
 
     res.status(200).json(data);
   } catch (e) {

--- a/src/pages/api/farcaster/neynar/conversation.ts
+++ b/src/pages/api/farcaster/neynar/conversation.ts
@@ -1,6 +1,6 @@
 import neynar from "@/common/data/api/neynar";
 import requestHandler from "@/common/data/api/requestHandler";
-import { CastParamType } from "@neynar/nodejs-sdk";
+import { CastParamType } from "@neynar/nodejs-sdk/build/api";
 import { isAxiosError } from "axios";
 import { isString } from "lodash";
 import { NextApiRequest, NextApiResponse } from "next/types";
@@ -12,8 +12,10 @@ async function loadConversation(req: NextApiRequest, res: NextApiResponse) {
     : CastParamType.Hash;
 
   try {
-    const data = await neynar.lookupCastConversation(id, type, {
-      ...req.query,
+    const data = await neynar.lookupCastConversation({
+        ...req.query,
+        identifier: id, 
+        type,
     });
 
     res.status(200).json(data);

--- a/src/pages/api/farcaster/neynar/feed.ts
+++ b/src/pages/api/farcaster/neynar/feed.ts
@@ -1,5 +1,5 @@
 import requestHandler from "@/common/data/api/requestHandler";
-import { FeedType } from "@neynar/nodejs-sdk";
+import { FeedType } from "@neynar/nodejs-sdk/build/api";
 import axios, { AxiosRequestConfig, isAxiosError } from "axios";
 import { isArray, isNil } from "lodash";
 import { NextApiRequest, NextApiResponse } from "next/types";

--- a/src/pages/api/fid-link.ts
+++ b/src/pages/api/fid-link.ts
@@ -40,7 +40,7 @@ export type FidLinkToIdentityResponse = NounspaceResponse<{
 
 async function checkSigningKeyValidForFid(fid: number, signingKey: string) {
   try {
-    const result = await neynar.lookupDeveloperManagedSigner(signingKey);
+    const result = await neynar.lookupDeveloperManagedSigner({publicKey: signingKey});
     return result.fid === fid && result.status === "approved";
   } catch {
     return false;

--- a/src/pages/api/notifications/index.ts
+++ b/src/pages/api/notifications/index.ts
@@ -1,7 +1,7 @@
 import neynar from "@/common/data/api/neynar";
 import requestHandler from "@/common/data/api/requestHandler";
 import { NounspaceResponse } from "@/common/data/api/requestHandler";
-import { NotificationsResponse } from "@neynar/nodejs-sdk/build/neynar-api/v2";
+import { NotificationsResponse } from "@neynar/nodejs-sdk/build/api";
 import { isAxiosError } from "axios";
 import { isString } from "lodash";
 import { NextApiRequest, NextApiResponse } from "next/types";
@@ -45,7 +45,8 @@ const get = async (
   }
 
   try {
-    const data = await neynar.fetchAllNotifications(fid, {
+    const data = await neynar.fetchAllNotifications({
+      fid,
       limit,
       cursor,
     });

--- a/src/pages/api/search/users.ts
+++ b/src/pages/api/search/users.ts
@@ -5,7 +5,7 @@ import requestHandler, {
   NounspaceResponse,
 } from "@/common/data/api/requestHandler";
 import neynar from "@/common/data/api/neynar";
-import { User } from "@neynar/nodejs-sdk/build/neynar-api/v2";
+import { User } from "@neynar/nodejs-sdk/build/api";
 import { flatMap } from "lodash";
 
 const QuerySchema = z.object({
@@ -75,7 +75,9 @@ const _fetchAndFormat = async (
 const _searchUsersByUsername =
   (params: z.infer<typeof QuerySchema>) =>
   async (): Promise<UserSearchResult> => {
-    const response = await neynar.searchUser(params!.q, params!.viewerFid, {
+    const response = await neynar.searchUser({ 
+      q:params!.q, 
+      viewerFid:params!.viewerFid, 
       limit: params!.limit,
       cursor: params!.cursor,
     });
@@ -89,7 +91,7 @@ const _searchUsersByFids =
   (params: z.infer<typeof QuerySchema>) =>
   async (): Promise<UserSearchResult> => {
     const fids = [Number.parseInt(params!.q)];
-    const response = await neynar.fetchBulkUsers(fids);
+    const response = await neynar.fetchBulkUsers({fids});
     return {
       users: response.users,
       cursor: null,
@@ -99,7 +101,7 @@ const _searchUsersByFids =
 const _searchUsersByAddr =
   (params: z.infer<typeof QuerySchema>) =>
   async (): Promise<UserSearchResult> => {
-    const response = await neynar.fetchBulkUsersByEthereumAddress([params!.q]);
+    const response = await neynar.fetchBulkUsersByEthOrSolAddress({addresses: [params!.q]});
     return {
       users: flatMap(response, (x) => x),
       cursor: null,

--- a/src/pages/homebase/index.tsx
+++ b/src/pages/homebase/index.tsx
@@ -4,12 +4,12 @@ import { useAppStore } from "@/common/data/stores/app";
 import USER_NOT_LOGGED_IN_HOMEBASE_CONFIG from "@/constants/userNotLoggedInHomebase";
 import SpacePage, { SpacePageArgs } from "@/common/components/pages/SpacePage";
 import FeedModule, { FilterType } from "@/fidgets/farcaster/Feed";
-import { FeedType } from "@neynar/nodejs-sdk";
 import { noop } from "lodash";
 import useCurrentFid from "@/common/lib/hooks/useCurrentFid";
 import TabBar from "@/common/components/organisms/TabBar";
 import { useRouter } from "next/router";
 import { useSidebarContext } from "@/common/components/organisms/Sidebar";
+import { FeedType } from "@neynar/nodejs-sdk/build/api";
 
 const Homebase: NextPageWithLayout = () => {
   const router = useRouter();

--- a/src/pages/notifications/index.tsx
+++ b/src/pages/notifications/index.tsx
@@ -6,7 +6,7 @@ import {
   Notification,
   NotificationTypeEnum,
   User,
-} from "@neynar/nodejs-sdk/build/neynar-api/v2";
+} from "@neynar/nodejs-sdk/build/api";
 import {
   Tabs,
   TabsList,

--- a/src/pages/s/[handle]/[tabName].tsx
+++ b/src/pages/s/[handle]/[tabName].tsx
@@ -24,13 +24,13 @@ export const getServerSideProps = (async ({
 
   try {
     const {
-      result: { user },
-    } = await neynar.lookupUserByUsername(handle);
+      user,
+    } = await neynar.lookupUserByUsername({username: handle});
 
     const userMetadata = {
       username: user.username,
-      displayName: user.displayName,
-      pfpUrl: user.pfp.url,
+      displayName: user.display_name,
+      pfpUrl: user.pfp_url,
       bio: user.profile.bio.text,
     };
 

--- a/src/pages/s/[handle]/index.tsx
+++ b/src/pages/s/[handle]/index.tsx
@@ -43,13 +43,13 @@ export const getServerSideProps = (async ({
 
   try {
     const {
-      result: { user },
-    } = await neynar.lookupUserByUsername(handle);
+      user,
+    } = await neynar.lookupUserByUsername({username: handle});
 
     const userMetadata = {
       username: user.username,
-      displayName: user.displayName,
-      pfpUrl: user.pfp.url,
+      displayName: user.display_name,
+      pfpUrl: user.pfp_url,
       bio: user.profile.bio.text,
     };
 


### PR DESCRIPTION
This PR updates the Neynar SDK to version 2.23.0, introducing several changes that impact method usage, API structure, and enum naming. The key modifications include method removals, renaming, and API updates.

## Key Changes:

Updated @neynar/nodejs-sdk to **^2.23.0**

## Breaking Changes:

Several methods have been removed and require alternative approaches:

- fetchRecentUsers
- fetchAllCastsLikedByUser → Replaced with fetchUserReactions
- lookupUserByFid, lookupCustodyAddressForUser, fetchUserVerifications → Use fetchBulkUsers
- fetchRecentCasts
- fetchMentionAndReplyNotifications → Use fetchAllNotifications
- fetchUserLikesAndRecasts → Use fetchUserReactions

### Method Renames:

- publishReactionToCast → publishReaction
- deleteReactionFromCast → deleteReaction
- fetchBulkUsersByEthereumAddress → fetchBulkUsersByEthOrSolAddress

### API v2 Updates:

- fetchUserFollowersV2, fetchUserFollowingV2, lookupUserByUsernameV2 are now streamlined under v2.
- API import paths changed from @neynar/nodejs-sdk/build/neynar-api/v2 to @neynar/nodejs-sdk/build/api.

## Enum Changes:

- TimeWindow → FetchTrendingChannelsTimeWindowEnum
- TrendingFeedTimeWindow → FetchTrendingFeedTimeWindowEnum
- BulkCastsSortType → FetchBulkCastsSortTypeEnum

## Code Changes:

- Refactored method calls to align with new SDK structure.
- Updated import paths across multiple files (SearchAutocompleteInput.tsx, etherscan.ts, neynar.ts, etc.).
- Modified enum references in places where deprecated enums were used.

## Migration Notes:

- Ensure that deprecated methods are replaced with the suggested alternatives.
- Update any code that relied on the old enum names.
- Webhooks and Kafka integration should be considered for fetching real-time user and cast data.

## Testing & Validation:

- Verified method replacements and API calls.
- Confirmed that all enum changes align with v2 SDK.
- Ensured backward compatibility by testing affected components.