### PR TITLE
feat: Add ImgBB image upload functionality to Gallery fidget

### DIFF
--- a/src/common/components/molecules/ImgBBUploader.tsx
+++ b/src/common/components/molecules/ImgBBUploader.tsx
@@ -1,0 +1,150 @@
+import { Button } from "@/common/components/atoms/button";
+import { Loader2 } from "lucide-react";
+import React, { useRef, useState } from "react";
+
+declare global {
+  interface Window {
+    handleGalleryImageUpload?: (url: string) => void;
+  }
+}
+
+const ImageIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 20 20"
+    fill="currentColor"
+    aria-hidden="true"
+    data-slot="icon"
+    className="mr-1 w-5 h-5"
+  >
+    <path
+      fillRule="evenodd"
+      d="M1 5.25A2.25 2.25 0 0 1 3.25 3h13.5A2.25 2.25 0 0 1 19 5.25v9.5A2.25 2.25 0 0 1 16.75 17H3.25A2.25 2.25 0 0 1 1 14.75v-9.5Zm1.5 5.81v3.69c0 .414.336.75.75.75h13.5a.75.75 0 0 0 .75-.75v-2.69l-2.22-2.219a.75.75 0 0 0-1.06 0l-1.91 1.909.47.47a.75.75 0 1 1-1.06 1.06L6.53 8.091a.75.75 0 0 0-1.06 0l-2.97 2.97ZM12 7a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
+interface ImgBBUploaderProps {
+  onImageUploaded: (url: string) => void;
+}
+
+const ImgBBUploader: React.FC<ImgBBUploaderProps> = ({ onImageUploaded }) => {
+  const [isUploading, setIsUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [uploadedUrl, setUploadedUrl] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const imgBBApiKey = process.env.NEXT_PUBLIC_IMGBB_API_KEY;
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
+
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (file.size > 5 * 1024 * 1024) {
+      setError("File size exceeds 5MB limit");
+      return;
+    }
+
+    if (!imgBBApiKey) {
+      setError("ImgBB API key is not configured");
+      return;
+    }
+
+    setIsUploading(true);
+    setError(null);
+
+    try {
+      const formData = new FormData();
+      formData.append("image", file);
+
+      const response = await fetch(`https://api.imgbb.com/1/upload?key=${imgBBApiKey}`, {
+        method: "POST",
+        body: formData,
+      });
+
+      const data = await response.json();
+
+      if (data.success) {
+        const imageUrl = data.data.display_url || data.data.url;
+        setUploadedUrl(imageUrl);
+        onImageUploaded(imageUrl);
+
+        if (window.handleGalleryImageUpload) {
+          window.handleGalleryImageUpload(imageUrl);
+        }
+      } else {
+        setError("Failed to upload image: " + (data.error?.message || "Unknown error"));
+      }
+    } catch (err) {
+      console.error("Error uploading image:", err);
+      setError("Error uploading image. Please try again.");
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleButtonClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    fileInputRef.current?.click();
+  };
+
+  return (
+    <div
+      className="flex flex-col gap-4"
+      onSubmit={(e) => e.preventDefault()}
+    >
+      <div className="grid w-full max-w-sm items-center gap-1.5">
+        <input
+          ref={fileInputRef}
+          id="image-upload"
+          type="file"
+          accept="image/*"
+          onChange={handleFileChange}
+          className="hidden"
+        />
+        <Button
+          variant="outline"
+          onClick={handleButtonClick}
+          className="w-full"
+          disabled={isUploading}
+        >
+          {isUploading ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Uploading...
+            </>
+          ) : (
+            <>
+              <ImageIcon />
+              Add
+            </>
+          )}
+        </Button>
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <p className="text-xs text-muted-foreground mt-1">
+          Maximum file size: 5MB
+        </p>
+      </div>
+
+      {uploadedUrl && (
+        <div className="flex flex-col gap-2">
+          <p className="text-sm text-green-500">Image uploaded successfully!</p>
+          <div className="relative h-40 w-full overflow-hidden rounded-md border">
+            <img
+              src={uploadedUrl}
+              alt="Uploaded"
+              className="h-full w-full object-contain"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ImgBBUploader; 

--- a/src/common/components/molecules/MediaSourceSelector.tsx
+++ b/src/common/components/molecules/MediaSourceSelector.tsx
@@ -1,16 +1,17 @@
-import React from "react";
 import {
   Select,
-  SelectValue,
-  SelectTrigger,
   SelectContent,
   SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@/common/components/atoms/select";
+import React from "react";
 
 export enum MediaSourceTypes {
   URL = "URL",
-  WALLET = "My Wallet",
   EXTERNAL = "External NFT Collection",
+  WALLET = "My Wallet",
+  UPLOAD = "UPLOAD",
 }
 
 export interface MediaSource {
@@ -24,15 +25,10 @@ export interface MediaSourceSelectorProps {
 }
 
 const settings: MediaSource[] = [
-  {
-    name: MediaSourceTypes.URL,
-  },
-  {
-    name: MediaSourceTypes.WALLET,
-  },
-  {
-    name: MediaSourceTypes.EXTERNAL,
-  },
+  { name: MediaSourceTypes.URL },
+  { name: MediaSourceTypes.UPLOAD },
+  { name: MediaSourceTypes.EXTERNAL },
+  { name: MediaSourceTypes.WALLET},
 ];
 
 const MediaSourceSelector: React.FC<MediaSourceSelectorProps> = ({

--- a/src/common/types/global.d.ts
+++ b/src/common/types/global.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  interface Window {
+    handleGalleryImageUpload?: (url: string) => void;
+  }
+}
+
+export { };

--- a/src/fidgets/ui/gallery.tsx
+++ b/src/fidgets/ui/gallery.tsx
@@ -1,9 +1,3 @@
-declare global {
-  interface Window {
-    handleGalleryImageUpload?: (url: string) => void;
-  }
-}
-
 import VerifiedNft from "@/common/components/atoms/icons/VerifiedNft";
 import {
   Tooltip,

--- a/src/fidgets/ui/gallery.tsx
+++ b/src/fidgets/ui/gallery.tsx
@@ -1,21 +1,9 @@
-import React, { CSSProperties, useEffect, useState } from "react";
-import TextInput from "@/common/components/molecules/TextInput";
-import {
-  FidgetArgs,
-  FidgetProperties,
-  FidgetModule,
-  type FidgetSettingsStyle,
-} from "@/common/fidgets";
-import { defaultStyleFields } from "@/fidgets/helpers";
-import ImageScaleSlider from "@/common/components/molecules/ImageScaleSlider";
-import MediaSourceSelector, {
-  MediaSource,
-  MediaSourceTypes,
-} from "@/common/components/molecules/MediaSourceSelector";
-import AlchemyChainSelector from "@/common/components/molecules/AlchemyChainSelector";
-import AlchemyNftSelector, {
-  AlchemyNftSelectorValue,
-} from "@/common/components/molecules/AlchemyNFTSelector";
+declare global {
+  interface Window {
+    handleGalleryImageUpload?: (url: string) => void;
+  }
+}
+
 import VerifiedNft from "@/common/components/atoms/icons/VerifiedNft";
 import {
   Tooltip,
@@ -23,12 +11,31 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/common/components/atoms/tooltip";
+import AlchemyChainSelector from "@/common/components/molecules/AlchemyChainSelector";
+import AlchemyNftSelector, {
+  AlchemyNftSelectorValue,
+} from "@/common/components/molecules/AlchemyNFTSelector";
 import ColorSelector from "@/common/components/molecules/ColorSelector";
+import ImageScaleSlider from "@/common/components/molecules/ImageScaleSlider";
+import ImgBBUploader from "@/common/components/molecules/ImgBBUploader";
+import MediaSourceSelector, {
+  MediaSource,
+  MediaSourceTypes,
+} from "@/common/components/molecules/MediaSourceSelector";
+import TextInput from "@/common/components/molecules/TextInput";
+import {
+  FidgetArgs,
+  FidgetModule,
+  FidgetProperties,
+  type FidgetSettingsStyle,
+} from "@/common/fidgets";
 import { Color } from "@/common/lib/theme";
-import { ErrorWrapper } from "@/fidgets/helpers";
+import { defaultStyleFields, ErrorWrapper } from "@/fidgets/helpers";
+import React, { CSSProperties, useEffect, useState } from "react";
 
 export type GalleryFidgetSettings = {
   imageUrl: string;
+  uploadedImage: string;
   RedirectionURL: string;
   Scale: number;
   selectMediaSource: MediaSource;
@@ -50,6 +57,32 @@ const galleryConfig: FidgetProperties = {
       required: false,
       default: { name: MediaSourceTypes.URL },
       group: "settings",
+    },
+    {
+      fieldName: "imageUploader",
+      displayName: "Upload Image",
+      inputSelector: ({ updateSettings }) => {
+        const [localImageUrl, setLocalImageUrl] = React.useState<string | null>(null);
+
+        const handleImageUploaded = (Upload: string) => {
+          console.log("Image uploaded, URL:", Upload);
+          setLocalImageUrl(Upload);
+          updateSettings?.({
+            uploadedImage: Upload,
+            imageUrl: Upload
+          });
+        };
+
+        return (
+          <div className="flex flex-col gap-4">
+            <ImgBBUploader onImageUploaded={handleImageUploaded} />
+          </div>
+        );
+      },
+      required: false,
+      group: "settings",
+      disabledIf: (settings) =>
+        settings?.selectMediaSource?.name !== MediaSourceTypes.UPLOAD,
     },
     {
       fieldName: "imageUrl",
@@ -114,6 +147,8 @@ const galleryConfig: FidgetProperties = {
       inputSelector: TextInput,
       default: "",
       group: "settings",
+      disabledIf: (settings) =>
+        settings?.selectMediaSource?.name === MediaSourceTypes.UPLOAD,
     },
     {
       fieldName: "badgeColor",
@@ -125,6 +160,7 @@ const galleryConfig: FidgetProperties = {
       disabledIf: (settings) =>
         settings?.selectMediaSource?.name !== MediaSourceTypes.WALLET,
     },
+   
     ...defaultStyleFields,
   ],
   size: {
@@ -154,6 +190,30 @@ const Gallery: React.FC<FidgetArgs<GalleryFidgetSettings>> = ({ settings }) => {
   const [nftImageUrl, setNftImageUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [badgeColor, setBadgeColor] = useState<Color>(settings.badgeColor);
+  const [uploadedImage, setuploadedImage] = useState<string | null>(settings.uploadedImage || null);
+
+  React.useEffect(() => {
+    if (uploadedImage) {
+      localStorage.setItem('galleryuploadedImage', uploadedImage);
+    }
+
+    window.handleGalleryImageUpload = (url: string) => {
+      console.log("Global handler called with URL:", url);
+      setuploadedImage(url);
+      localStorage.setItem('galleryuploadedImage', url);
+    };
+
+    return () => {
+      delete window.handleGalleryImageUpload;
+    };
+  }, [uploadedImage]);
+
+  React.useEffect(() => {
+    const savedImageUrl = localStorage.getItem('galleryuploadedImage');
+    if (savedImageUrl && settings.selectMediaSource?.name === MediaSourceTypes.UPLOAD) {
+      setuploadedImage(savedImageUrl);
+    }
+  }, [settings.selectMediaSource?.name]);
 
   useEffect(() => {
     if (settings.selectMediaSource?.name === MediaSourceTypes.EXTERNAL) {
@@ -189,6 +249,17 @@ const Gallery: React.FC<FidgetArgs<GalleryFidgetSettings>> = ({ settings }) => {
     } else if (settings.selectMediaSource?.name === MediaSourceTypes.WALLET) {
       setNftImageUrl(settings.nftSelector?.imageUrl || "");
       setError(null);
+    } else if (settings.selectMediaSource?.name === MediaSourceTypes.UPLOAD) {
+      if (uploadedImage) {
+        console.log("Using local uploaded image URL:", uploadedImage);
+        setNftImageUrl(uploadedImage);
+        setError(null);
+      } else if (settings.uploadedImage) {
+        setNftImageUrl(settings.uploadedImage);
+        setError(null);
+      } else {
+        setError("Please upload an image");
+      }
     } else {
       setNftImageUrl(null);
       setError("Please select a media source.");
@@ -198,6 +269,8 @@ const Gallery: React.FC<FidgetArgs<GalleryFidgetSettings>> = ({ settings }) => {
     settings.nftAddress,
     settings.nftTokenId,
     settings.network,
+    settings.uploadedImage,
+    uploadedImage,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
Image Upload Feature for Gallery Fidget - Summary

Changes:

Added "Upload" option to MediaSourceSelector
Added UPLOAD to MediaSourceTypes enum
Added Upload option to default sources list
Created ImgBBUploader component
Simple button with image icon to select files
Handles upload to ImgBB with API key
Shows upload progress and preview
Prevents navigation issues
Added global type declaration
Added handleGalleryImageUpload to Window interface
Updated Gallery fidget
Added uploadedImage field to settings
Added ImgBBUploader when "Upload" source is selected
Uses localStorage for image persistence
Hides "Links To" field for Upload source

Pros:

Better user experience: Users can upload images directly without needing external hosting
Simplified workflow: No need to copy/paste image URLs
Visual feedback: Shows upload progress and preview
Persistence: Uploaded images remain after page refresh
Clean UI: Only shows relevant fields based on selected source

The implementation uses ImgBB for image hosting with a direct upload interface, making it easy for users to add images to their gallery fidgets.