### PR TITLE
Add debounce to YouTube music search input

### DIFF
--- a/src/common/components/molecules/YouTubeSelector.tsx
+++ b/src/common/components/molecules/YouTubeSelector.tsx
@@ -1,4 +1,5 @@
 import React, { useState, ChangeEvent } from "react";
+import debounce from "@/common/lib/utils/debounce";
 
 interface VideoResult {
   id: {
@@ -34,10 +35,12 @@ export function YouTubeSelector({ onVideoSelect }: YouTubeSelectorProps) {
     }
   }
 
+  const debouncedSearchYouTube = debounce(searchYouTube, 300);
+
   function handleSearchChange(event: ChangeEvent<HTMLInputElement>) {
     const query = event.target.value;
     setSearchQuery(query);
-    if (query.length > 2) searchYouTube(query);
+    if (query.length > 2) debouncedSearchYouTube(query);
   }
 
   function handleVideoSelect(videoId: string) {

--- a/src/common/lib/utils/debounce.ts
+++ b/src/common/lib/utils/debounce.ts
@@ -1,0 +1,21 @@
+/**
+ * A utility function to debounce a given function.
+ * @param func - The function to debounce.
+ * @param delay - The delay in milliseconds.
+ * @returns A debounced version of the given function.
+ */
+function debounce(func: (...args: any[]) => void, delay: number) {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  return function (...args: any[]) {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+
+    timeoutId = setTimeout(() => {
+      func(...args);
+    }, delay);
+  };
+}
+
+export default debounce;


### PR DESCRIPTION
Add debounce to the YouTube music search input in the Navigation bar.

* **Debounce Utility**: Add a debounce utility function in `src/common/lib/utils/debounce.ts` to handle the debouncing logic.
* **YouTubeSelector Component**: 
  - Import the debounce function in `src/common/components/molecules/YouTubeSelector.tsx`.
  - Update the `handleSearchChange` function to use the debounce function for the search input.
  - Remove the direct call to `searchYouTube` from `handleSearchChange`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Nounspace/nounspace.ts/pull/675?shareId=44aeb646-2dac-4cd4-9879-b9393c2bfdb5).