### PR TITLE
Collapsible NavBar + Icons org

### DIFF
--- a/src/common/components/atoms/icons/ExploreIcon.tsx
+++ b/src/common/components/atoms/icons/ExploreIcon.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+const ExploreIcon = () => (
+  <svg
+    className="w-6 h-6 text-gray-800 dark:text-white"
+    aria-hidden="true"
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    fill="none"
+    viewBox="0 0 24 24"
+  >
+    <path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeWidth="2"
+      d="M4.37 7.657c2.063.528 2.396 2.806 3.202 3.87 1.07 1.413 2.075 1.228 3.192 2.644 1.805 2.289 1.312 5.705 1.312 6.705M20 15h-1a4 4 0 0 0-4 4v1M8.587 3.992c0 .822.112 1.886 1.515 2.58 1.402.693 2.918.351 2.918 2.334 0 .276 0 2.008 1.972 2.008 2.026.031 2.026-1.678 2.026-2.008 0-.65.527-.9 1.177-.9H20M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+    />
+  </svg>
+);
+
+export default ExploreIcon;

--- a/src/common/components/atoms/icons/HomeIcon.tsx
+++ b/src/common/components/atoms/icons/HomeIcon.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+const HomeIcon = () => (
+  <svg
+    className="w-6 h-6 text-gray-800 dark:text-white"
+    aria-hidden="true"
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    fill="none"
+    viewBox="0 0 24 24"
+  >
+    <path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="m4 12 8-8 8 8M6 10.5V19a1 1 0 0 0 1 1h3v-3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3h3a1 1 0 0 0 1-1v-8.5"
+    />
+  </svg>
+);
+
+export default HomeIcon;

--- a/src/common/components/atoms/icons/LoginIcon.tsx
+++ b/src/common/components/atoms/icons/LoginIcon.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+const LoginIcon = () => (
+  <svg
+    className="w-[24px] h-[24px] text-gray-800 dark:text-white"
+    aria-hidden="true"
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    fill="none"
+    viewBox="0 0 24 24"
+  >
+    <path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M16 12H4m12 0-4 4m4-4-4-4m3-4h2a3 3 0 0 1 3 3v10a3 3 0 0 1-3 3h-2"
+    />
+  </svg>
+);
+
+export default LoginIcon;

--- a/src/common/components/atoms/icons/LogoutIcon.tsx
+++ b/src/common/components/atoms/icons/LogoutIcon.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+const LogoutIcon = () => (
+  <svg
+    className="w-[24px] h-[24px] text-gray-800 dark:text-white scale-x-[-1] translate-x-[2px]"
+    aria-hidden="true"
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    fill="none"
+    viewBox="0 0 24 24"
+  >
+    <path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M16 12H4m12 0-4 4m4-4-4-4m3-4h2a3 3 0 0 1 3 3v10a3 3 0 0 1-3 3h-2"
+    />
+  </svg>
+);
+
+export default LogoutIcon;

--- a/src/common/components/atoms/icons/NotificationsIcon.tsx
+++ b/src/common/components/atoms/icons/NotificationsIcon.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+const NotificationsIcon = () => (
+  <svg
+    className="w-6 h-6 text-gray-800 dark:text-white"
+    aria-hidden="true"
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    fill="none"
+    viewBox="0 0 24 24"
+  >
+    <path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="M12 5.365V3m0 2.365a5.338 5.338 0 0 1 5.133 5.368v1.8c0 2.386 1.867 2.982 1.867 4.175 0 .593 0 1.292-.538 1.292H5.538C5 18 5 17.301 5 16.708c0-1.193 1.867-1.789 1.867-4.175v-1.8A5.338 5.338 0 0 1 12 5.365ZM8.733 18c.094.852.306 1.54.944 2.112a3.48 3.48 0 0 0 4.646 0c.638-.572 1.236-1.26 1.33-2.112h-6.92Z"
+    />
+  </svg>
+);
+
+export default NotificationsIcon;

--- a/src/common/components/atoms/icons/RocketIcon.tsx
+++ b/src/common/components/atoms/icons/RocketIcon.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+const RocketIcon = () => (
+  <svg
+    className="w-[24px] h-[24px] text-gray-800 dark:text-white"
+    aria-hidden="true"
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    fill="none"
+    viewBox="0 0 24 24"
+  >
+    <path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      d="m10.051 8.102-3.778.322-1.994 1.994a.94.94 0 0 0 .533 1.6l2.698.316m8.39 1.617-.322 3.78-1.994 1.994a.94.94 0 0 1-1.595-.533l-.4-2.652m8.166-11.174a1.366 1.366 0 0 0-1.12-1.12c-1.616-.279-4.906-.623-6.38.853-1.671 1.672-5.211 8.015-6.31 10.023a.932.932 0 0 0 .162 1.111l.828.835.833.832a.932.932 0 0 0 1.111.163c2.008-1.102 8.35-4.642 10.021-6.312 1.475-1.478 1.133-4.77.855-6.385Zm-2.961 3.722a1.88 1.88 0 1 1-3.76 0 1.88 1.88 0 0 1 3.76 0Z"
+    />
+  </svg>
+);
+
+export default RocketIcon;

--- a/src/common/components/atoms/icons/SearchIcon.tsx
+++ b/src/common/components/atoms/icons/SearchIcon.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+const SearchIcon = () => (
+  <svg
+    className="w-6 h-6 text-gray-800 dark:text-white"
+    aria-hidden="true"
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    fill="none"
+    viewBox="0 0 24 24"
+  >
+    <path
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeWidth="2"
+      d="m21 21-3.5-3.5M17 10a7 7 0 1 1-14 0 7 7 0 0 1 14 0Z"
+    />
+  </svg>
+);
+
+export default SearchIcon;

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -22,6 +22,13 @@ import { trackAnalyticsEvent } from "@/common/lib/utils/analyticsUtils";
 import useNotificationBadgeText from "@/common/lib/hooks/useNotificationBadgeText";
 import { Badge } from "@/common/components/atoms/badge";
 import { usePathname } from "next/navigation";
+import HomeIcon from "../atoms/icons/HomeIcon";
+import SearchIcon from "../atoms/icons/SearchIcon";
+import NotificationsIcon from "../atoms/icons/NotificationsIcon";
+import RocketIcon from "../atoms/icons/RocketIcon";
+import ExploreIcon from "../atoms/icons/ExploreIcon";
+import LogoutIcon from "../atoms/icons/LogoutIcon";
+import LoginIcon from "../atoms/icons/LoginIcon";
 
 type NavItemProps = {
   label: string;
@@ -59,7 +66,7 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
       setModalOpen: state.setup.setModalOpen,
       getIsLoggedIn: state.getIsAccountReady,
       getIsInitializing: state.getIsInitializing,
-    }),
+    })
   );
   const userTheme: UserTheme = useUserTheme();
 
@@ -68,6 +75,8 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
   const pathname = usePathname();
   const isNotificationsPage = pathname === "/notifications";
   const isExplorerPage = pathname === "/explore";
+
+  const [shrunk, setShrunk] = useState(true);
 
   function handleLogout() {
     router.push("/home");
@@ -101,7 +110,7 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
       ) : (
         <CgProfile />
       ),
-    [user],
+    [user]
   );
 
   const router = useRouter();
@@ -120,8 +129,9 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
         <Link
           href={disable ? "#" : href}
           className={mergeClasses(
-            "flex relative items-center p-2 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group w-full",
+            "flex relative items-center p-2 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 w-full group",
             href === pathname ? "bg-gray-100" : "",
+            shrunk ? "justify-center" : ""
           )}
           onClick={onClick}
           rel={openInNewTab ? "noopener noreferrer" : undefined}
@@ -129,7 +139,7 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
         >
           {badgeText && <NavIconBadge>{badgeText}</NavIconBadge>}
           <Icon />
-          <span className="ms-3">{label}</span>
+          {!shrunk && <span className="ms-3 relative z-10">{label}</span>}
         </Link>
       </li>
     );
@@ -147,13 +157,15 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
         <button
           disabled={disable}
           className={mergeClasses(
-            "flex relative items-center p-2 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group w-full",
+            "flex relative items-center p-2 text-gray-900 rounded-lg dark:text-white w-full group",
+            "hover:bg-gray-100 dark:hover:bg-gray-700",
+            shrunk ? "justify-center" : ""
           )}
           onClick={onClick}
         >
           {badgeText && <NavIconBadge>{badgeText}</NavIconBadge>}
           <Icon aria-hidden="true" />
-          <span className="ms-3">{label}</span>
+          {!shrunk && <span className="ms-3 relative z-10">{label}</span>}
         </button>
       </li>
     );
@@ -169,6 +181,8 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
       id="logo-sidebar"
       className="w-full transition-transform -translate-x-full sm:translate-x-0 border-r-2 bg-white"
       aria-label="Sidebar"
+      onMouseEnter={() => setShrunk(false)}
+      onMouseLeave={() => setShrunk(true)}
     >
       <Modal
         open={showCastModal}
@@ -180,9 +194,19 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
       </Modal>
       <SearchModal ref={searchRef} />
       <div className="pt-12 pb-12 h-full md:block hidden">
-        <div className="flex flex-col h-full w-[270px] ml-auto">
+        <div
+          className={mergeClasses(
+            "flex flex-col h-full w-[270px] ml-auto transition-all duration-300",
+            shrunk ? "w-[90px]" : "w-[270px]"
+          )}
+        >
           <BrandHeader />
-          <div className="flex flex-col text-lg font-medium pb-3 px-4 overflow-auto">
+          <div
+            className={mergeClasses(
+              "flex flex-col text-lg font-medium pb-3 px-4 overflow-auto transition-all duration-300",
+              shrunk ? "px-1" : "px-4"
+            )}
+          >
             <div className="flex-auto">
               <ul className="space-y-2">
                 <NavItem
@@ -257,13 +281,20 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
             </div>
           </div>
           <div className="flex flex-col flex-auto justify-between border-t px-4">
-            <div className="mt-8 px-2">
+            <div
+              className={mergeClasses("mt-8 px-2", shrunk ? "px-0" : "px-2")}
+            >
               <Player
                 url={userTheme?.properties?.musicURL || NOUNISH_LOWFI_URL}
               />
             </div>
             {isLoggedIn && (
-              <div className="pt-3 flex items-center gap-2 justify-center">
+              <div
+                className={mergeClasses(
+                  "pt-3 flex items-center gap-2 justify-center",
+                  shrunk ? "flex-col gap-1" : ""
+                )}
+              >
                 {!isNotificationsPage && !isExplorerPage && isEditable && (
                   <Button
                     onClick={turnOnEditMode}
@@ -276,191 +307,29 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
                   </Button>
                 )}
                 <Button onClick={openCastModal} variant="primary" width="auto">
-                  Cast
+                  {shrunk ? <span className="sr-only">Cast</span> : "Cast"}
+                  {shrunk && <span className="text-lg font-bold">+</span>}
                 </Button>
               </div>
             )}
             {!isLoggedIn && (
               <Link
                 href="https://discord.gg/eYQeXU2WuH"
-                className="flex items-center p-2 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group w-full gap-2 text-lg font-medium"
+                className={mergeClasses(
+                  "flex items-center p-2 text-gray-900 rounded-lg dark:text-white group w-full gap-2 text-lg font-medium",
+                  shrunk ? "justify-center gap-0" : ""
+                )}
                 rel="noopener noreferrer"
                 target="_blank"
               >
                 <FaDiscord className="text-[#5865f2] w-6 h-6" />
-                Join
+                {!shrunk && "Join"}
               </Link>
             )}
           </div>
         </div>
       </div>
     </aside>
-  );
-};
-
-const HomeIcon = () => {
-  return (
-    <svg
-      className="w-6 h-6 text-gray-800 dark:text-white"
-      aria-hidden="true"
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
-      <path
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-        d="m4 12 8-8 8 8M6 10.5V19a1 1 0 0 0 1 1h3v-3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3h3a1 1 0 0 0 1-1v-8.5"
-      />
-    </svg>
-  );
-};
-
-const SearchIcon = () => (
-  <svg
-    className="w-6 h-6 text-gray-800 dark:text-white"
-    aria-hidden="true"
-    xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
-    fill="none"
-    viewBox="0 0 24 24"
-  >
-    <path
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeWidth="2"
-      d="m21 21-3.5-3.5M17 10a7 7 0 1 1-14 0 7 7 0 0 1 14 0Z"
-    />
-  </svg>
-);
-
-const NotificationsIcon = () => (
-  <svg
-    className="w-6 h-6 text-gray-800 dark:text-white"
-    aria-hidden="true"
-    xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
-    fill="none"
-    viewBox="0 0 24 24"
-  >
-    <path
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="2"
-      d="M12 5.365V3m0 2.365a5.338 5.338 0 0 1 5.133 5.368v1.8c0 2.386 1.867 2.982 1.867 4.175 0 .593 0 1.292-.538 1.292H5.538C5 18 5 17.301 5 16.708c0-1.193 1.867-1.789 1.867-4.175v-1.8A5.338 5.338 0 0 1 12 5.365ZM8.733 18c.094.852.306 1.54.944 2.112a3.48 3.48 0 0 0 4.646 0c.638-.572 1.236-1.26 1.33-2.112h-6.92Z"
-    />
-  </svg>
-);
-
-const RocketIcon = () => (
-  <svg
-    className="w-[24px] h-[24px] text-gray-800 dark:text-white"
-    aria-hidden="true"
-    xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
-    fill="none"
-    viewBox="0 0 24 24"
-  >
-    <path
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="2"
-      d="m10.051 8.102-3.778.322-1.994 1.994a.94.94 0 0 0 .533 1.6l2.698.316m8.39 1.617-.322 3.78-1.994 1.994a.94.94 0 0 1-1.595-.533l-.4-2.652m8.166-11.174a1.366 1.366 0 0 0-1.12-1.12c-1.616-.279-4.906-.623-6.38.853-1.671 1.672-5.211 8.015-6.31 10.023a.932.932 0 0 0 .162 1.111l.828.835.833.832a.932.932 0 0 0 1.111.163c2.008-1.102 8.35-4.642 10.021-6.312 1.475-1.478 1.133-4.77.855-6.385Zm-2.961 3.722a1.88 1.88 0 1 1-3.76 0 1.88 1.88 0 0 1 3.76 0Z"
-    />
-  </svg>
-);
-
-const ExploreIcon = () => {
-  return (
-    <svg
-      className="w-6 h-6 text-gray-800 dark:text-white"
-      aria-hidden="true"
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
-      <path
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeWidth="2"
-        d="M4.37 7.657c2.063.528 2.396 2.806 3.202 3.87 1.07 1.413 2.075 1.228 3.192 2.644 1.805 2.289 1.312 5.705 1.312 6.705M20 15h-1a4 4 0 0 0-4 4v1M8.587 3.992c0 .822.112 1.886 1.515 2.58 1.402.693 2.918.351 2.918 2.334 0 .276 0 2.008 1.972 2.008 2.026.031 2.026-1.678 2.026-2.008 0-.65.527-.9 1.177-.9H20M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-      />
-    </svg>
-  );
-};
-
-const LogoutIcon = () => {
-  return (
-    <svg
-      className="w-[24px] h-[24px] text-gray-800 dark:text-white scale-x-[-1] translate-x-[2px]"
-      aria-hidden="true"
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
-      <path
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-        d="M16 12H4m12 0-4 4m4-4-4-4m3-4h2a3 3 0 0 1 3 3v10a3 3 0 0 1-3 3h-2"
-      />
-    </svg>
-  );
-};
-
-const LoginIcon = () => {
-  return (
-    <svg
-      className="w-[24px] h-[24px] text-gray-800 dark:text-white"
-      aria-hidden="true"
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      fill="none"
-      viewBox="0 0 24 24"
-    >
-      <path
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-        d="M16 12H4m12 0-4 4m4-4-4-4m3-4h2a3 3 0 0 1 3 3v10a3 3 0 0 1-3 3h-2"
-      />
-    </svg>
-  );
-};
-
-const _EditIcon = () => {
-  return (
-    <svg
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M10.779 17.779L4.361 19.918L6.5 13.5M10.779 17.779L19.143 9.13599C19.7101 8.56839 20.0287 7.79885 20.0287 6.99649C20.0287 6.19413 19.7101 5.42459 19.143 4.85699C18.5754 4.28987 17.8059 3.97131 17.0035 3.97131C16.2011 3.97131 15.4316 4.28987 14.864 4.85699L6.5 13.5M10.779 17.779L6.5 13.5M8.639 15.64L14.8518 9.13599M12.7511 7.04036L17 11.279"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
   );
 };
 

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -319,13 +319,19 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
                     onClick={turnOnEditMode}
                     size="icon"
                     variant="secondary"
+                    className="flex items-center justify-center w-12 h-12"
                   >
                     <div className="flex items-center p-1">
                       <FaPaintbrush />
                     </div>
                   </Button>
                 )}
-                <Button onClick={openCastModal} variant="primary" width="auto">
+                <Button
+                  onClick={openCastModal}
+                  variant="primary"
+                  width="auto"
+                  className="flex items-center justify-center w-12 h-12"
+                >
                   {shrunk ? <span className="sr-only">Cast</span> : "Cast"}
                   {shrunk && <span className="text-lg font-bold">+</span>}
                 </Button>

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -12,7 +12,12 @@ import { CgProfile } from "react-icons/cg";
 import { useLoadFarcasterUser } from "@/common/data/queries/farcaster";
 import { first } from "lodash";
 import { Button } from "../atoms/button";
-import { FaPaintbrush, FaDiscord } from "react-icons/fa6";
+import {
+  FaPaintbrush,
+  FaDiscord,
+  FaChevronLeft,
+  FaChevronRight,
+} from "react-icons/fa6";
 import { NOUNISH_LOWFI_URL } from "@/constants/nounishLowfi";
 import { UserTheme } from "@/common/lib/theme";
 import { useUserTheme } from "@/common/lib/theme/UserThemeProvider";
@@ -77,6 +82,10 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
   const isExplorerPage = pathname === "/explore";
 
   const [shrunk, setShrunk] = useState(true);
+
+  const toggleSidebar = () => {
+    setShrunk((prev) => !prev);
+  };
 
   function handleLogout() {
     router.push("/home");
@@ -181,8 +190,6 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
       id="logo-sidebar"
       className="w-full transition-transform -translate-x-full sm:translate-x-0 border-r-2 bg-white"
       aria-label="Sidebar"
-      onMouseEnter={() => setShrunk(false)}
-      onMouseLeave={() => setShrunk(true)}
     >
       <Modal
         open={showCastModal}
@@ -196,10 +203,22 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
       <div className="pt-12 pb-12 h-full md:block hidden">
         <div
           className={mergeClasses(
-            "flex flex-col h-full w-[270px] ml-auto transition-all duration-300",
+            "flex flex-col h-full ml-auto transition-all duration-300 relative",
             shrunk ? "w-[90px]" : "w-[270px]"
           )}
         >
+          <button
+            onClick={toggleSidebar}
+            className="absolute right-0 top-4 transform translate-x-1/2 bg-white rounded-full border border-gray-200 shadow-sm p-2 hover:bg-gray-50 z-10"
+            aria-label={shrunk ? "Expand sidebar" : "Collapse sidebar"}
+          >
+            {shrunk ? (
+              <FaChevronRight size={14} />
+            ) : (
+              <FaChevronLeft size={14} />
+            )}
+          </button>
+
           <BrandHeader />
           <div
             className={mergeClasses(


### PR DESCRIPTION
### Icon Component Refactoring:

* Added reusable icon components: `ExploreIcon`, `HomeIcon`, `LoginIcon`, `LogoutIcon`, `NotificationsIcon`, `RocketIcon`, and `SearchIcon`. Each component is defined in its own file under `src/common/components/atoms/icons/`. [[1]](diffhunk://#diff-1cd67c5ade3e4f8eb998a4bc7801e41cdec4b7ca0755fc0e01b3c004521142e8R1-R22) [[2]](diffhunk://#diff-827021c32ba13da7ffa260004482ea877d2e842f706ab16c6d706212f50a2ea7R1-R23) [[3]](diffhunk://#diff-78a0f4b99aa412936842fc56aa8b5e4eae0e8b96ee8fa31cf4a595ba8303a372R1-R23) [[4]](diffhunk://#diff-f962e953e3c9f7a78b21df01188eb26796f58a62ad27b2d720b36bc7167b75dcR1-R23) [[5]](diffhunk://#diff-fa362a9d676049589878281ea511b8e36335e88b9e1d56d2834a04c34a61ec39R1-R23) [[6]](diffhunk://#diff-43adf26d6c754f02d10de23a9f7c4b065e149832bb421176349d92da2bea401eR1-R23) [[7]](diffhunk://#diff-abb1f0c29a2f66f86c4c9adfc04d0813b9c3778dad4af0e65f8dfe69d04d486cR1-R22)
* Removed inline icon definitions from `Navigation.tsx` and replaced them with imports of the new reusable icon components.

### Navigation Sidebar Enhancements:

* Introduced a collapsible sidebar feature in the `Navigation` component. Added a `shrunk` state to toggle between expanded and collapsed views.
* Updated navigation item styles to adjust layout dynamically based on the `shrunk` state. Collapsed items display only icons, while expanded items show both icons and labels. [[1]](diffhunk://#diff-d63ecb533cb05c8741ddf1e1a0a951f842fa22cf003733a001301f036cd11f8fL123-R151) [[2]](diffhunk://#diff-d63ecb533cb05c8741ddf1e1a0a951f842fa22cf003733a001301f036cd11f8fL150-R177)
* Added a toggle button to expand or collapse the sidebar, with appropriate animations and accessibility attributes.