### PR TITLE
fix: prevent accidental fidget clearing in space configs

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -442,7 +442,7 @@ export default function PublicSpace({
       }
       const saveableConfig = {
         ...spaceConfig,
-        fidgetInstanceDatums: mapValues(
+        fidgetInstanceDatums: spaceConfig.fidgetInstanceDatums ? mapValues(
           spaceConfig.fidgetInstanceDatums,
           (datum) => ({
             ...datum,
@@ -451,7 +451,7 @@ export default function PublicSpace({
               editable: datum.config.editable,
             },
           }),
-        ),
+        ) : undefined,
         isPrivate: false,
       };
       return saveLocalSpaceTab(currentSpaceId, currentTabName, saveableConfig);

--- a/src/app/api/venice/route.ts
+++ b/src/app/api/venice/route.ts
@@ -99,11 +99,11 @@ ${exampleCastsText}
       ) + userCast;
 
     // use for debug
-    if (DEBUG_PROMPTS) console.log(`\n\n---------SYSTEM-----------`);
-    console.log(system_prompt);
-    console.log(`\n\n---------USER-----------`);
-    console.log(user_prompt);
-    console.log(`--------------------`);
+    // if (DEBUG_PROMPTS) console.log(`\n\n---------SYSTEM-----------`);
+    // console.log(system_prompt);
+    // console.log(`\n\n---------USER-----------`);
+    // console.log(user_prompt);
+    // console.log(`--------------------`);
 
     // build the venice model options
     const getOptions = (messages: any) => ({

--- a/src/common/data/loaders/contractPagePropsLoader.ts
+++ b/src/common/data/loaders/contractPagePropsLoader.ts
@@ -101,8 +101,8 @@ export async function loadContractData(
   } else {
     owningIdentities = await loadOwnedItentitiesForFid(ownerId);
   }
-  console.log("Debug - Contract Address before query:", contractAddress);
-  console.log("Debug - Network:", network);
+  // console.log("Debug - Contract Address before query:", contractAddress);
+  // console.log("Debug - Network:", network);
 
   const { data, error } = await createSupabaseServerClient()
     .from("spaceRegistrations")
@@ -112,15 +112,14 @@ export async function loadContractData(
     .order("timestamp", { ascending: true })
     .limit(1)
   
-  console.log("Debug - Database Query Error:", error);
-  console.log("Debug - Raw Query Results:", data);
-  console.log("Debug - First Space ID:", data?.[0]?.spaceId);
-  console.log("Debug - Query Details:", {
-    table: "spaceRegistrations",
-    filter: { contractAddress, network },
-    order: "timestamp ASC",
-    resultCount: data?.length || 0
-  });
+  // console.log("Debug - Database Query Error:", error);
+  // console.log("Debug - Raw Query Results:", data);
+  // console.log("Debug - First Space ID:", data?.[0]?.spaceId);
+  // console.log("Debug - Query Details:", {
+  //   contractAddress,
+  //   network,
+  //   error: error?.message,
+  // });
   
   const spaceId = data?.[0]?.spaceId || null;
 

--- a/src/common/data/stores/app/homebase/homebaseStore.ts
+++ b/src/common/data/stores/app/homebase/homebaseStore.ts
@@ -134,33 +134,17 @@ export const createHomeBaseStoreFunc = (
   }, 1000),
   saveHomebaseConfig: async (config) => {
     const localCopy = cloneDeep(get().homebase.homebaseConfig) as SpaceConfig;
-    
-    // Only update fields that are explicitly provided in the config
-    const updatedConfig: SpaceConfig = {
-      ...localCopy,
-      // Only update fidgetInstanceDatums if provided
-      fidgetInstanceDatums: config.fidgetInstanceDatums ? 
-        cloneDeep(config.fidgetInstanceDatums) : 
-        localCopy.fidgetInstanceDatums,
-      // Only update layoutDetails if provided
-      layoutDetails: config.layoutDetails ? {
-        ...localCopy.layoutDetails,
-        ...config.layoutDetails,
-        layoutFidget: config.layoutDetails.layoutFidget || localCopy.layoutDetails.layoutFidget
-      } : localCopy.layoutDetails,
-      // Only update fidgetTrayContents if provided
-      fidgetTrayContents: config.fidgetTrayContents !== undefined ? 
-        cloneDeep(config.fidgetTrayContents) : 
-        localCopy.fidgetTrayContents,
-      // Only update theme if provided
-      theme: config.theme ? cloneDeep(config.theme) : localCopy.theme,
-      // Always update timestamp
-      timestamp: moment().toISOString()
-    };
-    
+    mergeWith(localCopy, config, (objValue, srcValue) => {
+      if (isArray(srcValue)) return srcValue;
+      if (typeof srcValue === 'object' && srcValue !== null) {
+        // For objects, return the source value to replace the target completely
+        return srcValue;
+      }
+    });
+    localCopy.timestamp = moment().toISOString();
     set(
       (draft) => {
-        draft.homebase.homebaseConfig = updatedConfig;
+        draft.homebase.homebaseConfig = localCopy;
       },
       "saveHomebaseConfig",
       false,

--- a/src/common/data/stores/app/homebase/homebaseTabsStore.ts
+++ b/src/common/data/stores/app/homebase/homebaseTabsStore.ts
@@ -492,50 +492,20 @@ export const createHomeBaseTabStoreFunc = (
       }
     }
   }, 1000),
-  async saveHomebaseTabConfig(tabName, config: SpaceConfigSaveDetails) {
-    // console.log('Saving tab config:', {
-    //   tabName,
-    //   timestamp: config.timestamp,
-    //   fidgetCount: Object.keys(config.fidgetInstanceDatums || {}).length,
-    //   hasLayoutDetails: !!config.layoutDetails,
-    //   hasFidgetTrayContents: !!config.fidgetTrayContents
-    // });
-    
+  async saveHomebaseTabConfig(tabName, config) {
     const localCopy = cloneDeep(
       get().homebase.tabs[tabName].config,
     ) as SpaceConfig;
-    
-    // Only update fields that are explicitly provided in the config
-    const updatedConfig: SpaceConfig = {
-      ...localCopy,
-      // Only update timestamp if provided
-      timestamp: config.timestamp || localCopy.timestamp,
-      // Only update fidgetInstanceDatums if provided
-      fidgetInstanceDatums: config.fidgetInstanceDatums ? 
-        cloneDeep(config.fidgetInstanceDatums) : 
-        localCopy.fidgetInstanceDatums,
-      // Only update layoutDetails if provided
-      layoutDetails: config.layoutDetails ? {
-        ...localCopy.layoutDetails,
-        ...config.layoutDetails,
-        layoutFidget: config.layoutDetails.layoutFidget || localCopy.layoutDetails.layoutFidget
-      } : localCopy.layoutDetails,
-      // Only update fidgetTrayContents if provided
-      fidgetTrayContents: config.fidgetTrayContents !== undefined ? 
-        cloneDeep(config.fidgetTrayContents) : 
-        localCopy.fidgetTrayContents
-    };
-    
-    // console.log('Updated tab config:', {
-    //   tabName,
-    //   fidgetCount: Object.keys(updatedConfig.fidgetInstanceDatums || {}).length,
-    //   layoutFidget: updatedConfig.layoutDetails.layoutFidget,
-    //   trayCount: updatedConfig.fidgetTrayContents?.length || 0
-    // });
-    
+    mergeWith(localCopy, config, (objValue, srcValue) => {
+      if (isArray(srcValue)) return srcValue;
+      if (typeof srcValue === 'object' && srcValue !== null) {
+        // For objects, return the source value to replace the target completely
+        return srcValue;
+      }
+    });
     set(
       (draft) => {
-        draft.homebase.tabs[tabName].config = updatedConfig;
+        draft.homebase.tabs[tabName].config = localCopy;
       },
       `saveHomebaseTab:${tabName}`,
       false,

--- a/src/common/lib/theme/UserThemeProvider.tsx
+++ b/src/common/lib/theme/UserThemeProvider.tsx
@@ -48,8 +48,8 @@ export const useUserTheme = () => {
       return homebaseTabs[currentTabName]?.config?.theme ?? defaultTheme;
     }
   } else {
-    // console.log( `Theme selected: Space tab - ${currentSpaceId}, ${currentTabName ?? "Profile"}`, );
-    // console.log("Theme:",currentSpace?.tabs[currentTabName ?? "Profile"]?.theme,);
+    // console.log(`Theme selected: Space tab - ${currentSpaceId}, ${currentTabName ?? "Profile"}`);
+    // console.log("Theme:", currentSpace?.tabs[currentTabName ?? "Profile"]?.theme);
     return (
       currentSpace?.tabs[currentTabName ?? "Profile"]?.theme ?? defaultTheme
     );

--- a/src/common/utils/spaceEditability.ts
+++ b/src/common/utils/spaceEditability.ts
@@ -31,43 +31,43 @@ export const createEditabilityChecker = (context: EditabilityContext) => {
     isTokenPage = false,
   } = context;
 
-  console.log('Editability check context:', {
-    currentUserFid,
-    spaceOwnerFid,
-    spaceOwnerAddress,
-    tokenData: tokenData ? {
-      hasClankerData: !!tokenData.clankerData,
-      requestorFid: tokenData.clankerData?.requestor_fid,
-    } : null,
-    walletAddresses: wallets.map(w => w.address),
-    isTokenPage,
-  });
+  // console.log('Editability check context:', {
+  //   currentUserFid,
+  //   spaceOwnerFid,
+  //   spaceOwnerAddress,
+  //   tokenData: tokenData ? {
+  //     hasClankerData: !!tokenData.clankerData,
+  //     requestorFid: tokenData.clankerData?.requestor_fid,
+  //   } : null,
+  //   walletAddresses: wallets.map(w => w.address),
+  //   isTokenPage,
+  // });
 
   // If we don't have a current user FID, we're definitely not editable
   if (isNil(currentUserFid)) {
-    console.log('Not editable: No current user FID');
+    // console.log('Not editable: No current user FID');
     return { isEditable: false, isLoading: false };
   }
 
   // For token spaces, check requestor and ownership
   if (isTokenPage) {
-    console.log('Checking token space editability');
+    // console.log('Checking token space editability');
     
     // Check if user is the owner by FID first (doesn't require clankerData)
     if (spaceOwnerFid && currentUserFid === spaceOwnerFid) {
-      console.log('Editable: User owns by FID', {
-        currentUserFid,
-        spaceOwnerFid,
-      });
+      // console.log('Editable: User owns by FID', {
+      //   currentUserFid,
+      //   spaceOwnerFid,
+      // });
       return { isEditable: true, isLoading: false };
     }
 
     // Check if user owns the wallet address (doesn't require clankerData)
     if (spaceOwnerAddress && wallets.some(w => w.address === spaceOwnerAddress)) {
-      console.log('Editable: User owns by address', {
-        spaceOwnerAddress,
-        matchingWallet: wallets.find(w => w.address === spaceOwnerAddress),
-      });
+      // console.log('Editable: User owns by address', {
+      //   spaceOwnerAddress,
+      //   matchingWallet: wallets.find(w => w.address === spaceOwnerAddress),
+      // });
       return { isEditable: true, isLoading: false };
     }
 
@@ -75,33 +75,33 @@ export const createEditabilityChecker = (context: EditabilityContext) => {
     if (tokenData && !isNil(tokenData.clankerData)) {
       const requestorFid = tokenData.clankerData?.requestor_fid;
       if (requestorFid && currentUserFid === Number(requestorFid)) {
-        console.log('Editable: User is the requestor', {
-          currentUserFid,
-          requestorFid: Number(requestorFid),
-        });
+        // console.log('Editable: User is the requestor', {
+        //   currentUserFid,
+        //   requestorFid: Number(requestorFid),
+        // });
         return { isEditable: true, isLoading: false };
       }
     } else {
-      console.log('Skipping requestor check: No clankerData available');
+      // console.log('Skipping requestor check: No clankerData available');
     }
 
-    console.log('Not editable: No matching ownership conditions met for token space');
+    // console.log('Not editable: No matching ownership conditions met for token space');
   } else {
     // For profile spaces, just check FID match
-    console.log('Checking profile space editability');
+    // console.log('Checking profile space editability');
     if (spaceOwnerFid && currentUserFid === spaceOwnerFid) {
-      console.log('Editable: User owns profile space', {
-        currentUserFid,
-        spaceOwnerFid,
-      });
+      // console.log('Editable: User owns profile space', {
+      //   currentUserFid,
+      //   spaceOwnerFid,
+      // });
       return { isEditable: true, isLoading: false };
     }
-    console.log('Not editable: FIDs do not match for profile space', {
-      currentUserFid,
-      spaceOwnerFid,
-    });
+    // console.log('Not editable: FIDs do not match for profile space', {
+    //   currentUserFid,
+    //   spaceOwnerFid,
+    // });
   }
 
-  console.log('Final result: Not editable');
+  // console.log('Final result: Not editable');
   return { isEditable: false, isLoading: false };
 }; 

--- a/src/fidgets/community/nouns-dao/components/ProposalListRowItem.tsx
+++ b/src/fidgets/community/nouns-dao/components/ProposalListRowItem.tsx
@@ -275,7 +275,7 @@ export const getProposalState = (
   // Only log for specific proposals or those with issues
   if (result === "DEFEATED" || result === "UPDATABLE" ||
     proposal.id === "771" || proposal.id === "772" || proposal.id === "773") {
-    console.log("Proposal Debug:", debug);
+    // console.log("Proposal Debug:", debug);
   }
 
   return result;
@@ -294,7 +294,7 @@ const ProposalListRowItem = ({
 
   // Additional logging for specific problematic proposals
   if (proposal.id === "772" || proposal.id === "773") {
-    console.log(`Proposal ${proposal.id} final status:`, proposalStatus);
+    // console.log(`Proposal ${proposal.id} final status:`, proposalStatus);
   }
 
   const getDateBadgeText = () => {

--- a/src/pages/api/space/registry/[spaceId]/index.ts
+++ b/src/pages/api/space/registry/[spaceId]/index.ts
@@ -94,10 +94,10 @@ async function updateSpaceTabOrder(
     return;
   }
 
-  console.log(
-    "[registry space] Updating tab order",
-    stringify(updateOrderRequest),
-  );
+  // console.log(
+  //   "[registry space] Updating tab order",
+  //   stringify(updateOrderRequest),
+  // );
 
   const supabase = createSupabaseServerClient();
   const { data, error } = await supabase.storage
@@ -109,7 +109,7 @@ async function updateSpaceTabOrder(
     );
 
   if (!isNull(error)) {
-    console.error(error);
+    // console.error(error);
     res.status(500).json({
       result: "error",
       error: {
@@ -128,12 +128,12 @@ export async function identitiesCanModifySpace(
   spaceId: string,
   network?: string,
 ) {
-  console.log(
-    "Checking identities that can modify space",
-    stringify(spaceId),
-    network,
-    "network",
-  );
+  // console.log(
+  //   "Checking identities that can modify space",
+  //   stringify(spaceId),
+  //   network,
+  //   "network",
+  // );
   const supabase = createSupabaseServerClient();
   const { data: spaceRegistrationData } = await supabase
     .from("spaceRegistrations")


### PR DESCRIPTION
- Made fidgetInstanceDatums optional in DatabaseWritableSpaceSaveConfig type
- Modified saveConfig in PublicSpace.tsx to handle undefined fidgetInstanceDatums properly
- Simplified redundant spreading in saveConfig function
- Standardized config merging across all space stores (spaceStore, homebaseStore, homebaseTabsStore)
- Removed explicit fidgetInstanceDatums handling in favor of mergeWith's natural undefined handling

This fix addresses an issue where fidgets were being cleared when saving space configs with undefined fidgetInstanceDatums. The changes ensure that existing fidgets are preserved when saving configs, while maintaining consistent behavior across all space-related stores. The code is now simpler and more maintainable with a unified approach to config merging.