### PR TITLE
Update build.yaml – bump setup-node to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18.16
         cache: yarn


### PR DESCRIPTION
v4 is the latest release with improved support and maintenance.
🔗 [Official release notes](https://github.com/actions/setup-node/releases/tag/v4.0.0)