### PR TITLE
Update Node.js setup to actions/setup-node@v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18.16
         cache: yarn


### PR DESCRIPTION
Using setup-node@v4 brings performance improvements, better caching behavior, updated compatibility with Node.js versions, and continued support from GitHub Actions maintainers.
Official documentation: 
Release notes for v4:
https://github.com/actions/setup-node/releases/tag/v4.0.0