### PR TITLE
Fix Farcaster link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nounspace
 
-**Highly customizable [Farcaster]([url](https://farcaster.xyz/)) client, initially funded by a grant from [Nouns DAO](https://nouns.wtf/).** Customize the look, sound, content, and functionality of your public profile space and personal feed/homebase with **Themes**, **Tabs**, and a growing library of mini-apps called **Fidgets**.
+**Highly customizable [Farcaster](https://farcaster.xyz/) client, initially funded by a grant from [Nouns DAO](https://nouns.wtf/).** Customize the look, sound, content, and functionality of your public profile space and personal feed/homebase with **Themes**, **Tabs**, and a growing library of mini-apps called **Fidgets**.
 
 
 Forked from [herocast](https://github.com/hellno/herocast/) in April 2024.


### PR DESCRIPTION
## Summary
- fix the introduction link syntax for Farcaster

## Testing
- `node -e "const fs=require('fs');const md=fs.readFileSync('README.md','utf8');console.log(md.includes('[Farcaster](https://farcaster.xyz/)') ? 'link ok' : 'link missing')"`
- `node - <<'EOF'
const fs=require('fs');
const md=fs.readFileSync('README.md','utf8');
const firstLines = md.split('\n').slice(0,4).join('\n');
const html=firstLines.replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2">$1</a>');
console.log(html);
EOF`