### PR TITLE
Add vitest and helper tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,12 @@ a protocol for decentralized social apps: https://www.farcaster.xyz
   f. get a Youtube API key https://developers.google.com/youtube/v3 -> 'YOUTUBE_API_KEY' <br>
   g. get your Farcaster account FID and mnemonic -> `NEXT_PUBLIC_APP_FID` + `APP_MNENOMIC`<br>
   h. launch local copy of Supabase with `supabase start` (in the root directory of this repo), use the info provided -> <br>
- `API URL`:`NEXT_PUBLIC_SUPABASE_URL` + `anon key`:`NEXT_PUBLIC_SUPABASE_ANON_KEY`
+`API URL`:`NEXT_PUBLIC_SUPABASE_URL` + `anon key`:`NEXT_PUBLIC_SUPABASE_ANON_KEY`
+
+8. Run the test suite
+   ```bash
+   yarn test
+   ```
 
 ## Contributing and making Fidgets
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint:fix": "eslint --fix --ext .js,.jsx,.ts,.tsx src",
     "check-types": "tsc",
     "prettier": "prettier src --write",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test": "vitest"
   },
   "lint-staged": {
     "src/**/*": "prettier --write --ignore-unknown"
@@ -189,6 +190,7 @@
     "postcss": "^8.4.38",
     "prettier": "3.3.1",
     "ramda": "^0.29.1",
-    "supabase": "^1.123.0"
+    "supabase": "^1.123.0",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/pages/api/search/users.ts
+++ b/src/pages/api/search/users.ts
@@ -161,3 +161,5 @@ const get = async (req: NextApiRequest, res: NextApiResponse) => {
 export default requestHandler({
   get: get,
 });
+
+export { QuerySchema, _isMaybeFid, _isMaybeAddress, _validateQueryParams };

--- a/tests/searchHelpers.test.ts
+++ b/tests/searchHelpers.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import type { NextApiRequest } from 'next/types'
+import { _isMaybeFid, _isMaybeAddress, _validateQueryParams, QuerySchema } from '../src/pages/api/search/users'
+
+describe('_isMaybeFid', () => {
+  it('returns true for numeric strings', () => {
+    expect(_isMaybeFid('123')).toBe(true)
+    expect(_isMaybeFid('-45')).toBe(true)
+  })
+
+  it('returns false for non-numeric strings', () => {
+    expect(_isMaybeFid('abc')).toBe(false)
+  })
+})
+
+describe('_isMaybeAddress', () => {
+  it('returns true for valid address', () => {
+    expect(_isMaybeAddress('0x' + 'a'.repeat(40))).toBe(true)
+  })
+
+  it('returns false for invalid address', () => {
+    expect(_isMaybeAddress('0x1234')).toBe(false)
+  })
+})
+
+describe('_validateQueryParams', () => {
+  it('returns params for valid input', () => {
+    const req = { query: { q: 'hello', limit: '5' } } as unknown as NextApiRequest
+    const [params, error] = _validateQueryParams(req, QuerySchema)
+    expect(error).toBeNull()
+    expect(params).not.toBeNull()
+    expect(params!.q).toBe('hello')
+    expect(params!.limit).toBe(5)
+  })
+
+  it('returns error for invalid input', () => {
+    const req = { query: { q: 'a'.repeat(21) } } as unknown as NextApiRequest
+    const [params, error] = _validateQueryParams(req, QuerySchema)
+    expect(params).toBeNull()
+    expect(error).not.toBeNull()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
- add vitest dev dependency and test script
- export internal helper functions for testing
- create test suite for search helper utilities
- configure vitest
- document how to run the tests

## Testing
- `yarn install` *(fails: could not download packages)*
- `yarn test` *(fails: package not in lockfile)*