### PR TITLE
Implement saveId debugging for space saves

### DIFF
--- a/src/common/data/stores/app/space/__tests__/spaceStore.test.ts
+++ b/src/common/data/stores/app/space/__tests__/spaceStore.test.ts
@@ -1,0 +1,55 @@
+import assert from "assert";
+import { create as mutativeCreate } from "mutative";
+import { createSpaceStoreFunc, spaceStoreprofiles } from "../spaceStore";
+
+function createTestStore(initialState: any) {
+  let state = { space: { ...spaceStoreprofiles, ...initialState } } as any;
+  const set = (fn: any) => {
+    state = mutativeCreate(fn)(state);
+  };
+  const get = () => state;
+  return { actions: createSpaceStoreFunc(set, get), getState: () => state };
+}
+
+test("merge concurrent saves", async () => {
+  const initial = {
+    localSpaces: {
+      space1: {
+        id: "space1",
+        updatedAt: "",
+        tabs: {
+          Tab1: {
+            layoutID: "grid",
+            layoutDetails: { layoutFidget: "grid", layoutConfig: { layout: [{ i: "fid1", x: 0, y: 0 }] } },
+            theme: {},
+            fidgetInstanceDatums: {
+              fid1: { id: "fid1", fidgetType: "test", config: { editable: true, settings: {}, data: {} } },
+            },
+            fidgetTrayContents: [],
+            isPrivate: false,
+          },
+        },
+        order: ["Tab1"],
+        changedNames: {},
+      },
+    },
+  };
+
+  const { actions, getState } = createTestStore(initial);
+
+  await actions.saveLocalSpaceTab("space1", "Tab1", {
+    fidgetInstanceDatums: {
+      fid1: { id: "fid1", fidgetType: "test", config: { editable: true, settings: { foo: 1 }, data: {} } },
+    },
+    debugSaveId: 1,
+  });
+
+  await actions.saveLocalSpaceTab("space1", "Tab1", {
+    layoutConfig: { layout: [{ i: "fid1", x: 1, y: 1 }] },
+    debugSaveId: 2,
+  });
+
+  const final = getState().space.localSpaces.space1.tabs.Tab1;
+  assert.strictEqual(final.layoutConfig.layout[0].x, 1);
+  assert.strictEqual((final.fidgetInstanceDatums as any).fid1.config.settings.foo, 1);
+});

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -153,6 +153,8 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     useState<React.ReactNode>(<></>);
   const [isPickingFidget, setIsPickingFidget] = useState(false);
 
+  const saveId = useRef(0);
+
   const gridDetails = useMemo(
     () => makeGridDetails(hasProfile, hasFeed),
     [hasProfile, hasFeed],
@@ -169,6 +171,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   ) => {
     return await saveConfig({
       fidgetInstanceDatums: datums,
+      debugSaveId: saveId.current,
     });
   };
 
@@ -179,15 +182,28 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   };
 
   const saveLayout = async (newLayout: PlacedGridItem[]) => {
+    saveId.current += 1;
+    console.log("saveLayout", {
+      saveId: saveId.current,
+      layoutIds: newLayout.map((i) => i.i),
+      fidgetKeys: Object.keys(fidgetInstanceDatums),
+    });
     return await saveConfig({
       layoutConfig: {
         layout: newLayout,
       },
+      debugSaveId: saveId.current,
     });
   };
 
   const saveFidgetConfig = useCallback(
     (id: string) => async (newInstanceConfig: FidgetConfig<FidgetSettings>) => {
+      saveId.current += 1;
+      console.log("saveFidgetConfig", {
+        saveId: saveId.current,
+        layoutIds: layoutConfig.layout.map((i) => i.i),
+        fidgetKeys: Object.keys(fidgetInstanceDatums),
+      });
       return await saveFidgetInstanceDatums({
         ...fidgetInstanceDatums,
         [id]: {
@@ -196,15 +212,21 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
         },
       });
     },
-    [fidgetInstanceDatums, saveFidgetInstanceDatums],
+    [fidgetInstanceDatums, saveFidgetInstanceDatums, layoutConfig.layout],
   );
 
   // Debounced save function
   const debouncedSaveConfig = useCallback(
     debounce((config) => {
-      saveConfig(config);
+      saveId.current += 1;
+      console.log("debouncedSaveConfig", {
+        saveId: saveId.current,
+        layoutIds: layoutConfig.layout.map((i) => i.i),
+        fidgetKeys: Object.keys(fidgetInstanceDatums),
+      });
+      saveConfig({ ...config, debugSaveId: saveId.current });
     }, 100),
-    [saveConfig]
+    [saveConfig, layoutConfig.layout, fidgetInstanceDatums]
   );
 
   function unselectFidget() {
@@ -276,6 +298,12 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
       e.dataTransfer.getData("text/plain"),
     );
 
+    saveId.current += 1;
+    console.log("saveFidgetConfig", {
+      saveId: saveId.current,
+      layoutIds: layoutConfig.layout.map((i) => i.i),
+      fidgetKeys: Object.keys(fidgetInstanceDatums),
+    });
     saveFidgetInstanceDatums({
       ...fidgetInstanceDatums,
       [fidgetData.id]: fidgetData,
@@ -330,6 +358,12 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
       // New set of instances - use computed property name to remove the correct fidget
       const { [fidgetId]: removed, ...newFidgetInstanceDatums } = fidgetInstanceDatums;
 
+      saveId.current += 1;
+      console.log("saveFidgetConfig", {
+        saveId: saveId.current,
+        layoutIds: layoutConfig.layout.map((i) => i.i),
+        fidgetKeys: Object.keys(newFidgetInstanceDatums),
+      });
       saveFidgetInstanceDatums(newFidgetInstanceDatums);
   }
 


### PR DESCRIPTION
## Summary
- track a sequential `saveId` in `Grid` and log layout/fidget info on saves
- forward `saveId` to space store and log merged result
- merge config updates within `saveLocalSpaceTab` using draft state
- add a regression test skeleton for quick successive saves

## Testing
- `npm test` *(fails: Missing script "test")*