### PR TITLE
[CLIENT] mobile header

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import "@/styles/globals.css";
 import Providers from "@/common/providers";
 import ClientSidebarWrapper from "@/common/components/organisms/ClientSidebarWrapper";
-import ClientNavbarWrapper from "@/common/components/organisms/ClientNavbarWrapper";
+import ClientHeaderWrapper from "@/common/components/organisms/ClientHeaderWrapper";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import Head from "next/head";
 import { defaultFrame } from "@/common/lib/frames/metadata";
@@ -43,7 +43,7 @@ export const metadata = {
     apple: "/images/apple-touch-icon.png",
   },
   other: {
-    'fc:frame': JSON.stringify(defaultFrame),
+    "fc:frame": JSON.stringify(defaultFrame),
   },
 };
 
@@ -59,16 +59,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <Head>
-        <meta
-          name="fc:frame"
-          content={JSON.stringify(defaultFrame)}
-        />
+        <meta name="fc:frame" content={JSON.stringify(defaultFrame)} />
       </Head>
       <body>
         <SpeedInsights />
-        <Providers>
-          {sidebarLayout(children)}
-        </Providers>
+        <Providers>{sidebarLayout(children)}</Providers>
       </body>
     </html>
   );
@@ -80,9 +75,9 @@ const sidebarLayout = (page: React.ReactNode) => {
       <div className="min-h-screen max-w-screen h-screen w-screen flex flex-col">
         {/* App Navigation Bar */}
         <div className="w-full flex-shrink-0">
-          <ClientNavbarWrapper />
+          <ClientHeaderWrapper />
         </div>
-        
+
         {/* Main Content with Sidebar */}
         <div className="flex w-full h-full flex-grow">
           <div className="mx-auto transition-all duration-100 ease-out z-10">

--- a/src/common/components/organisms/ClientHeaderWrapper.tsx
+++ b/src/common/components/organisms/ClientHeaderWrapper.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import React from "react";
+import useIsMobile from "@/common/lib/hooks/useIsMobile";
+import ClientNavbarWrapper from "./ClientNavbarWrapper";
+import ClientMobileHeaderWrapper from "./ClientMobileHeaderWrapper";
+
+const ClientHeaderWrapper: React.FC = () => {
+  const isMobile = useIsMobile();
+  return isMobile ? <ClientMobileHeaderWrapper /> : <ClientNavbarWrapper />;
+};
+
+export default ClientHeaderWrapper;

--- a/src/common/components/organisms/ClientMobileHeaderWrapper.tsx
+++ b/src/common/components/organisms/ClientMobileHeaderWrapper.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import React from "react";
+import MobileHeader from "./MobileHeader";
+import Sidebar from "./Sidebar";
+
+export const ClientMobileHeaderWrapper: React.FC = () => {
+  return (
+    <Sidebar.ContextProvider>
+      <MobileHeader />
+    </Sidebar.ContextProvider>
+  );
+};
+
+export default ClientMobileHeaderWrapper;

--- a/src/common/components/organisms/MobileHeader.tsx
+++ b/src/common/components/organisms/MobileHeader.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import BrandHeader from "../molecules/BrandHeader";
+import { Button } from "../atoms/button";
+import { Dialog, DialogContent } from "../atoms/dialog";
+import Modal from "../molecules/Modal";
+import CreateCast from "@/fidgets/farcaster/components/CreateCast";
+import Navigation from "./Navigation";
+import { useAppStore } from "@/common/data/stores/app";
+import { useFarcasterSigner } from "@/fidgets/farcaster";
+import { useLoadFarcasterUser } from "@/common/data/queries/farcaster";
+import { first } from "lodash";
+import { CgProfile } from "react-icons/cg";
+import LoginIcon from "../atoms/icons/LoginIcon";
+import { useSidebarContext } from "./Sidebar";
+
+const MobileHeader: React.FC = () => {
+  const { setModalOpen, getIsLoggedIn } = useAppStore((state) => ({
+    setModalOpen: state.setup.setModalOpen,
+    getIsLoggedIn: state.getIsAccountReady,
+  }));
+
+  const { setEditMode, sidebarEditable } = useSidebarContext();
+
+  const [navOpen, setNavOpen] = useState(false);
+  const [castOpen, setCastOpen] = useState(false);
+
+  const { fid } = useFarcasterSigner("mobile-header");
+  const { data } = useLoadFarcasterUser(fid);
+  const user = useMemo(() => first(data?.users), [data]);
+
+  const openLogin = useCallback(() => setModalOpen(true), [setModalOpen]);
+  const openNav = useCallback(() => setNavOpen(true), []);
+  const enterEditMode = useCallback(() => setEditMode(true), [setEditMode]);
+
+  useEffect(() => {
+    let startX: number | null = null;
+    function handleTouchStart(e: TouchEvent) {
+      startX = e.touches[0].clientX;
+    }
+    function handleTouchEnd(e: TouchEvent) {
+      if (startX !== null && e.changedTouches[0].clientX - startX > 50) {
+        setNavOpen(true);
+      }
+      startX = null;
+    }
+    document.addEventListener("touchstart", handleTouchStart);
+    document.addEventListener("touchend", handleTouchEnd);
+    return () => {
+      document.removeEventListener("touchstart", handleTouchStart);
+      document.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, []);
+
+  const isLoggedIn = getIsLoggedIn();
+
+  return (
+    <header className="flex items-center justify-between h-14 px-4 border-b bg-white">
+      <BrandHeader />
+      <div className="flex items-center gap-2">
+        {isLoggedIn ? (
+          <button
+            onClick={openNav}
+            className="rounded-full overflow-hidden w-8 h-8 bg-gray-200 flex items-center justify-center"
+          >
+            {user?.pfp_url ? (
+              <img
+                src={user.pfp_url}
+                alt={user?.username}
+                className="object-cover w-full h-full"
+              />
+            ) : (
+              <CgProfile />
+            )}
+          </button>
+        ) : (
+          <Button variant="primary" size="sm" onClick={openLogin} withIcon>
+            <LoginIcon />
+            Sign In
+          </Button>
+        )}
+        <Button
+          variant="secondary"
+          size="icon"
+          onClick={() => setCastOpen(true)}
+          aria-label="Cast"
+        >
+          <span className="text-lg font-bold">+</span>
+        </Button>
+      </div>
+      <Dialog open={navOpen} onOpenChange={setNavOpen}>
+        <DialogContent className="p-0 max-w-none w-full h-full rounded-none">
+          <Navigation
+            isEditable={sidebarEditable}
+            enterEditMode={enterEditMode}
+          />
+        </DialogContent>
+      </Dialog>
+      <Modal
+        open={castOpen}
+        setOpen={setCastOpen}
+        focusMode={false}
+        showClose={false}
+      >
+        <CreateCast afterSubmit={() => setCastOpen(false)} />
+      </Modal>
+    </header>
+  );
+};
+
+export default MobileHeader;


### PR DESCRIPTION
## Summary
- create `MobileHeader` for mobile navigation
- switch layout to display mobile or desktop header via `ClientHeaderWrapper`
- wrap the mobile header with `ClientMobileHeaderWrapper`

## Testing
- `yarn lint:fix` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn check-types` *(fails: This package doesn't seem to be present in your lockfile)*