### PR TITLE
[CLIENT] mobile header

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import "@/styles/globals.css";
 import Providers from "@/common/providers";
 import ClientSidebarWrapper from "@/common/components/organisms/ClientSidebarWrapper";
-import ClientNavbarWrapper from "@/common/components/organisms/ClientNavbarWrapper";
+import ClientHeaderWrapper from "@/common/components/organisms/ClientHeaderWrapper";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import Head from "next/head";
 import { defaultFrame } from "@/common/lib/frames/metadata";
@@ -43,7 +43,7 @@ export const metadata = {
     apple: "/images/apple-touch-icon.png",
   },
   other: {
-    'fc:frame': JSON.stringify(defaultFrame),
+    "fc:frame": JSON.stringify(defaultFrame),
   },
 };
 
@@ -59,16 +59,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <Head>
-        <meta
-          name="fc:frame"
-          content={JSON.stringify(defaultFrame)}
-        />
+        <meta name="fc:frame" content={JSON.stringify(defaultFrame)} />
       </Head>
       <body>
         <SpeedInsights />
-        <Providers>
-          {sidebarLayout(children)}
-        </Providers>
+        <Providers>{sidebarLayout(children)}</Providers>
       </body>
     </html>
   );
@@ -80,9 +75,9 @@ const sidebarLayout = (page: React.ReactNode) => {
       <div className="min-h-screen max-w-screen h-screen w-screen flex flex-col">
         {/* App Navigation Bar */}
         <div className="w-full flex-shrink-0">
-          <ClientNavbarWrapper />
+          <ClientHeaderWrapper />
         </div>
-        
+
         {/* Main Content with Sidebar */}
         <div className="flex w-full h-full flex-grow">
           <div className="mx-auto transition-all duration-100 ease-out z-10">

--- a/src/common/components/organisms/ClientHeaderWrapper.tsx
+++ b/src/common/components/organisms/ClientHeaderWrapper.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import React from "react";
+import useIsMobile from "@/common/lib/hooks/useIsMobile";
+import ClientNavbarWrapper from "./ClientNavbarWrapper";
+import ClientMobileHeaderWrapper from "./ClientMobileHeaderWrapper";
+
+const ClientHeaderWrapper: React.FC = () => {
+  const isMobile = useIsMobile();
+  return isMobile ? <ClientMobileHeaderWrapper /> : <ClientNavbarWrapper />;
+};
+
+export default ClientHeaderWrapper;

--- a/src/common/components/organisms/ClientMobileHeaderWrapper.tsx
+++ b/src/common/components/organisms/ClientMobileHeaderWrapper.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import React from "react";
+import MobileHeader from "./MobileHeader";
+import Sidebar from "./Sidebar";
+
+export const ClientMobileHeaderWrapper: React.FC = () => {
+  return (
+    <Sidebar.ContextProvider>
+      <MobileHeader />
+    </Sidebar.ContextProvider>
+  );
+};
+
+export default ClientMobileHeaderWrapper;

--- a/src/common/components/organisms/MobileHeader.tsx
+++ b/src/common/components/organisms/MobileHeader.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import BrandHeader from "../molecules/BrandHeader";
+import { Button } from "../atoms/button";
+import { Dialog, DialogContent } from "../atoms/dialog";
+import Modal from "../molecules/Modal";
+import CreateCast from "@/fidgets/farcaster/components/CreateCast";
+import Navigation from "./Navigation";
+import { useAppStore } from "@/common/data/stores/app";
+import { useFarcasterSigner } from "@/fidgets/farcaster";
+import { useLoadFarcasterUser } from "@/common/data/queries/farcaster";
+import { first } from "lodash";
+import { CgProfile } from "react-icons/cg";
+import LoginIcon from "../atoms/icons/LoginIcon";
+import { useSidebarContext } from "./Sidebar";
+
+const MobileHeader: React.FC = () => {
+  const { setModalOpen, getIsLoggedIn } = useAppStore((state) => ({
+    setModalOpen: state.setup.setModalOpen,
+    getIsLoggedIn: state.getIsAccountReady,
+  }));
+
+  const { setEditMode, sidebarEditable } = useSidebarContext();
+
+  const [navOpen, setNavOpen] = useState(false);
+  const [castOpen, setCastOpen] = useState(false);
+
+  const { fid } = useFarcasterSigner("mobile-header");
+  const { data } = useLoadFarcasterUser(fid);
+  const user = useMemo(() => first(data?.users), [data]);
+
+  const openLogin = useCallback(() => setModalOpen(true), [setModalOpen]);
+  const openNav = useCallback(() => setNavOpen(true), []);
+  const enterEditMode = useCallback(() => setEditMode(true), [setEditMode]);
+
+  useEffect(() => {
+    let startX: number | null = null;
+    function handleTouchStart(e: TouchEvent) {
+      startX = e.touches[0].clientX;
+    }
+    function handleTouchEnd(e: TouchEvent) {
+      if (startX !== null && e.changedTouches[0].clientX - startX > 50) {
+        setNavOpen(true);
+      }
+      startX = null;
+    }
+    document.addEventListener("touchstart", handleTouchStart);
+    document.addEventListener("touchend", handleTouchEnd);
+    return () => {
+      document.removeEventListener("touchstart", handleTouchStart);
+      document.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, []);
+
+  const isLoggedIn = getIsLoggedIn();
+
+  return (
+    <header className="relative flex items-center justify-between h-14 px-4 border-b bg-white">
+      <div className="flex items-center gap-2">
+        {isLoggedIn ? (
+          <button
+            onClick={openNav}
+            className="rounded-full overflow-hidden w-8 h-8 bg-gray-200 flex items-center justify-center"
+          >
+            {user?.pfp_url ? (
+              <img
+                src={user.pfp_url}
+                alt={user?.username}
+                className="object-cover w-full h-full"
+              />
+            ) : (
+              <CgProfile />
+            )}
+          </button>
+        ) : (
+          <Button variant="primary" size="sm" onClick={openLogin} withIcon>
+            <LoginIcon />
+            Sign In
+          </Button>
+        )}
+      </div>
+      <div className="absolute left-1/2 -translate-x-1/2">
+        <BrandHeader />
+      </div>
+      <Button
+        variant="secondary"
+        size="icon"
+        onClick={() => setCastOpen(true)}
+        aria-label="Cast"
+      >
+        <span className="text-lg font-bold">+</span>
+      </Button>
+      <Dialog open={navOpen} onOpenChange={setNavOpen}>
+        <DialogContent
+          className="p-0 max-w-none w-[270px] h-full rounded-none left-0 top-0 translate-x-0 translate-y-0"
+          showCloseButton={false}
+        >
+          <Navigation
+            isEditable={sidebarEditable}
+            enterEditMode={enterEditMode}
+            mobile
+          />
+        </DialogContent>
+      </Dialog>
+      <Modal
+        open={castOpen}
+        setOpen={setCastOpen}
+        focusMode={false}
+        showClose={false}
+      >
+        <CreateCast afterSubmit={() => setCastOpen(false)} />
+      </Modal>
+    </header>
+  );
+};
+
+export default MobileHeader;

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -51,6 +51,7 @@ type NavButtonProps = Omit<NavItemProps, "href" | "openInNewTab">;
 type NavProps = {
   isEditable: boolean;
   enterEditMode: () => void;
+  mobile?: boolean;
 };
 
 const NavIconBadge = ({ children }) => {
@@ -64,7 +65,7 @@ const NavIconBadge = ({ children }) => {
   );
 };
 
-const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
+const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode, mobile = false }) => {
   const searchRef = useRef<HTMLInputElement>(null);
   const { setModalOpen, getIsLoggedIn, getIsInitializing } = useAppStore(
     (state) => ({
@@ -81,9 +82,10 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
   const isNotificationsPage = pathname === "/notifications";
   const isExplorerPage = pathname === "/explore";
 
-  const [shrunk, setShrunk] = useState(true);
+  const [shrunk, setShrunk] = useState(mobile ? false : true);
 
   const toggleSidebar = () => {
+    if (mobile) return;
     setShrunk((prev) => !prev);
   };
 
@@ -188,7 +190,12 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
   return (
     <aside
       id="logo-sidebar"
-      className="w-full transition-transform -translate-x-full sm:translate-x-0 border-r-2 bg-white"
+      className={mergeClasses(
+        "border-r-2 bg-white",
+        mobile
+          ? "w-[270px]"
+          : "w-full transition-transform -translate-x-full sm:translate-x-0"
+      )}
       aria-label="Sidebar"
     >
       <Modal
@@ -200,24 +207,35 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
         <CreateCast afterSubmit={() => setShowCastModal(false)} />
       </Modal>
       <SearchModal ref={searchRef} />
-      <div className="pt-12 pb-12 h-full md:block hidden">
+      <div
+        className={mergeClasses(
+          "pt-12 pb-12 h-full",
+          mobile ? "block" : "md:block hidden"
+        )}
+      >
         <div
           className={mergeClasses(
-            "flex flex-col h-full ml-auto transition-all duration-300 relative",
-            shrunk ? "w-[90px]" : "w-[270px]"
+            "flex flex-col h-full transition-all duration-300 relative",
+            mobile
+              ? "w-[270px]"
+              : shrunk
+                ? "w-[90px] ml-auto"
+                : "w-[270px] ml-auto"
           )}
         >
-          <button
-            onClick={toggleSidebar}
-            className="absolute right-0 top-4 transform translate-x-1/2 bg-white rounded-full border border-gray-200 shadow-sm p-2 hover:bg-gray-50 z-10"
-            aria-label={shrunk ? "Expand sidebar" : "Collapse sidebar"}
-          >
-            {shrunk ? (
-              <FaChevronRight size={14} />
-            ) : (
-              <FaChevronLeft size={14} />
-            )}
-          </button>
+          {!mobile && (
+            <button
+              onClick={toggleSidebar}
+              className="absolute right-0 top-4 transform translate-x-1/2 bg-white rounded-full border border-gray-200 shadow-sm p-2 hover:bg-gray-50 z-10"
+              aria-label={shrunk ? "Expand sidebar" : "Collapse sidebar"}
+            >
+              {shrunk ? (
+                <FaChevronRight size={14} />
+              ) : (
+                <FaChevronLeft size={14} />
+              )}
+            </button>
+          )}
 
           <BrandHeader />
           <div


### PR DESCRIPTION
## Summary
- refine MobileHeader layout for avatar-left, centered brand, and cast button right
- show expanded Navigation on mobile with sidebar width only 270px
- remove collapse toggle and adjust left-justification for mobile nav

## Testing
- `yarn lint:fix` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn check-types` *(fails: This package doesn't seem to be present in your lockfile)*