### PR TITLE
Fix loadHomebaseTab config merge logic

### DIFF
--- a/src/common/data/stores/app/homebase/homebaseTabsStore.ts
+++ b/src/common/data/stores/app/homebase/homebaseTabsStore.ts
@@ -498,19 +498,21 @@ export const createHomeBaseTabStoreFunc = (
       // });
       
       set((draft) => {
-        draft.homebase.tabs[tabName].config = cloneDeep(spaceConfig);
-        draft.homebase.tabs[tabName].remoteConfig = cloneDeep(spaceConfig);
+        const tabState = draft.homebase.tabs[tabName];
+        tabState.remoteConfig = cloneDeep(spaceConfig);
+        if (tabState.config === undefined) {
+          tabState.config = cloneDeep(spaceConfig);
+        }
       }, `loadHomebaseTab:${tabName}-found`);
       return spaceConfig;
     } catch (e) {
       // console.log('Failed to load tab config, using default:', { tabName });
       set((draft) => {
-        draft.homebase.tabs[tabName].config = cloneDeep(
-          INITIAL_HOMEBASE_CONFIG,
-        );
-        draft.homebase.tabs[tabName].remoteConfig = cloneDeep(
-          INITIAL_HOMEBASE_CONFIG,
-        );
+        const tabState = draft.homebase.tabs[tabName];
+        tabState.remoteConfig = cloneDeep(INITIAL_HOMEBASE_CONFIG);
+        if (tabState.config === undefined) {
+          tabState.config = cloneDeep(INITIAL_HOMEBASE_CONFIG);
+        }
       }, "loadHomebase-default");
       return cloneDeep(INITIAL_HOMEBASE_CONFIG);
     }


### PR DESCRIPTION
## Summary
- avoid overwriting existing config when loading a Homebase tab

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn check-types` *(fails: package not present in lockfile)*
- `node --test tests/fidgetConfig.test.js`