### PR TITLE
Fix missing tab check in commitHomebaseTab

### DIFF
--- a/src/common/data/stores/app/homebase/homebaseTabsStore.ts
+++ b/src/common/data/stores/app/homebase/homebaseTabsStore.ts
@@ -40,12 +40,10 @@ async function _commitHomebaseTab(tabname: string, get: StoreGet<AppStore>, set:
   // ---------------------------------------------------------------
 
   commitInFlight = (async () => {
-  const layoutLen =
-    (get().homebase.tabs[tabname].config as any)?.layoutConfig?.layout?.length;
-
-  console.log('[commit] now', tabname, new Date().toISOString(), 'layoutSize=', layoutLen);
-
     const tab = get().homebase.tabs[tabname];
+    const layoutLen = tab?.config?.layoutConfig?.layout?.length;
+
+    console.log('[commit] now', tabname, new Date().toISOString(), 'layoutSize=', layoutLen);
     if (!tab?.config) return;
 
     const localCopy = cloneDeep(tab.config);


### PR DESCRIPTION
## Summary
- avoid undefined errors when committing a deleted tab

## Testing
- `yarn lint` *(fails: package doesn't seem to be present in lockfile)*
- `yarn install` *(fails: RequestError tunneling socket could not be established)*