### PR TITLE
Fix loading crash for uncached spaces

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -5,7 +5,9 @@ import { useAuthenticatorManager } from "@/authenticators/AuthenticatorManager";
 import { useAppStore } from "@/common/data/stores/app";
 import { useSidebarContext } from "@/common/components/organisms/Sidebar";
 import TabBar from "@/common/components/organisms/TabBar";
+import TabBarSkeleton from "@/common/components/organisms/TabBarSkeleton";
 import SpacePage from "./SpacePage";
+import SpaceLoading from "./SpaceLoading";
 import { SpaceConfigSaveDetails } from "./Space";
 import { indexOf, isNil, mapValues, noop } from "lodash";
 import { useRouter } from "next/navigation";
@@ -146,7 +148,7 @@ export default function PublicSpace({
     (userFid: number) => {
       return editabilityCheck.isEditable;
     },
-    [editabilityCheck]
+    [editabilityCheck],
   );
 
   // Determine the page type if not explicitly provided
@@ -164,14 +166,14 @@ export default function PublicSpace({
   useEffect(() => {
     console.log(
       "Setting current space and tab for page type:",
-      resolvedPageType
+      resolvedPageType,
     );
 
     if (resolvedPageType === "token" && contractAddress && tokenData?.network) {
       const existingSpace = Object.values(localSpaces).find(
         (space) =>
           space.contractAddress === contractAddress &&
-          space.network === tokenData.network
+          space.network === tokenData.network,
       );
 
       if (existingSpace) {
@@ -186,7 +188,7 @@ export default function PublicSpace({
       }
     } else if (resolvedPageType === "person" && spaceOwnerFid) {
       const existingSpace = Object.values(localSpaces).find(
-        (space) => space.fid === spaceOwnerFid
+        (space) => space.fid === spaceOwnerFid,
       );
 
       if (existingSpace) {
@@ -262,14 +264,14 @@ export default function PublicSpace({
         }
       }
     },
-    [localSpaces, getCurrentTabName, loadSpaceTab]
+    [localSpaces, getCurrentTabName, loadSpaceTab],
   );
 
   // Checks if the user is signed into Farcaster
   useEffect(() => {
     authManagerGetInitializedAuthenticators().then((authNames) => {
       setIsSignedIntoFarcaster(
-        indexOf(authNames, FARCASTER_NOUNSPACE_AUTHENTICATOR_NAME) > -1
+        indexOf(authNames, FARCASTER_NOUNSPACE_AUTHENTICATOR_NAME) > -1,
       );
     });
   }, [authManagerLastUpdatedAt]);
@@ -293,6 +295,8 @@ export default function PublicSpace({
   if (!currentConfig) {
     console.error("Current space config is undefined");
   }
+
+  const currentTabName = getCurrentTabName();
 
   const config = {
     ...(currentConfig?.tabs[getCurrentTabName() ?? "Profile"]
@@ -357,7 +361,7 @@ export default function PublicSpace({
             const existingSpace = Object.values(localSpaces).find(
               (space) =>
                 space.contractAddress === contractAddress &&
-                space.network === tokenData.network
+                space.network === tokenData.network,
             );
 
             if (existingSpace) {
@@ -372,7 +376,7 @@ export default function PublicSpace({
             }
           } else if (!isTokenPage) {
             const existingSpace = Object.values(localSpaces).find(
-              (space) => space.fid === currentUserFid
+              (space) => space.fid === currentUserFid,
             );
 
             if (existingSpace) {
@@ -397,7 +401,7 @@ export default function PublicSpace({
               "Profile",
               currentUserFid,
               initialConfig,
-              tokenData.network
+              tokenData.network,
             );
             console.log("Contract space registration result:", {
               success: !!newSpaceId,
@@ -411,7 +415,7 @@ export default function PublicSpace({
             newSpaceId = await registerSpaceFid(
               currentUserFid,
               "Profile",
-              getSpacePageUrl("Profile")
+              getSpacePageUrl("Profile"),
             );
             console.log("User space registration result:", {
               success: !!newSpaceId,
@@ -499,7 +503,7 @@ export default function PublicSpace({
       };
       return saveLocalSpaceTab(currentSpaceId, currentTabName, saveableConfig);
     },
-    [getCurrentSpaceId, getCurrentTabName]
+    [getCurrentSpaceId, getCurrentTabName],
   );
 
   const commitConfig = useCallback(async () => {
@@ -534,7 +538,7 @@ export default function PublicSpace({
       saveLocalSpaceTab(
         currentSpaceId,
         currentTabName,
-        remoteSpaces[currentSpaceId].tabs[currentTabName]
+        remoteSpaces[currentSpaceId].tabs[currentTabName],
       );
     }
   }, [getCurrentSpaceId, initialConfig, remoteSpaces, getCurrentTabName]);
@@ -586,7 +590,7 @@ export default function PublicSpace({
           ? deleteSpaceTab(
               currentSpaceId,
               tabName,
-              tokenData?.network as EtherScanChainName
+              tokenData?.network as EtherScanChainName,
             )
           : undefined;
       }}
@@ -597,7 +601,7 @@ export default function PublicSpace({
               currentSpaceId,
               tabName,
               INITIAL_SPACE_CONFIG_EMPTY,
-              tokenData?.network as EtherScanChainName
+              tokenData?.network as EtherScanChainName,
             )
           : undefined;
       }}
@@ -609,7 +613,7 @@ export default function PublicSpace({
             currentSpaceId,
             oldName,
             resolvedConfig,
-            newName
+            newName,
           );
         }
         return undefined;
@@ -625,7 +629,7 @@ export default function PublicSpace({
         return currentSpaceId
           ? commitSpaceTabOrder(
               currentSpaceId,
-              tokenData?.network as EtherScanChainName
+              tokenData?.network as EtherScanChainName,
             )
           : undefined;
       }}
@@ -645,6 +649,26 @@ export default function PublicSpace({
 
   if (!profile) {
     console.warn("Profile component is undefined");
+  }
+
+  if (loading || !currentConfig?.tabs[currentTabName ?? "Profile"]) {
+    return (
+      <div className="user-theme-background w-full h-full relative flex-col">
+        <div className="w-full transition-all duration-100 ease-out">
+          <div className="flex flex-col h-full">
+            <TabBarSkeleton />
+            <div className="flex h-full">
+              <div className="grow">
+                <SpaceLoading
+                  hasProfile={!isTokenPage && !!spaceOwnerFid && pageType !== "proposal"}
+                  hasFeed={false}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- avoid returning before hooks finish running in `PublicSpace`
- render skeleton UI only after all hooks execute to prevent React 310 crash

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*