### PR TITLE
Fix updateFidgetInstanceDatums for unknown IDs

### DIFF
--- a/src/fidgets/layout/updateFidgetInstanceDatums.js
+++ b/src/fidgets/layout/updateFidgetInstanceDatums.js
@@ -1,4 +1,8 @@
 export function updateFidgetInstanceDatums(current, id, newConfig) {
+  if (!current[id]) {
+    return current;
+  }
+
   return {
     ...current,
     [id]: {

--- a/tests/fidgetConfig.test.js
+++ b/tests/fidgetConfig.test.js
@@ -15,3 +15,8 @@ test('updateFidgetInstanceDatums only updates specified id', () => {
   assert.deepStrictEqual(updated.b.config, newConfig);
   assert.strictEqual(Object.keys(updated).length, 2);
 });
+
+test('updateFidgetInstanceDatums ignores missing id', () => {
+  const updated = updateFidgetInstanceDatums({ ...initialDatums }, 'missing', newConfig);
+  assert.deepStrictEqual(updated, { ...initialDatums });
+});


### PR DESCRIPTION
## Summary
- handle missing IDs in `updateFidgetInstanceDatums`
- add regression test for missing ID behavior

## Testing
- `node --test tests/fidgetConfig.test.js`