### PR TITLE
Flush fidget config saves before editing

### DIFF
--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -35,6 +35,7 @@ export type FidgetWrapperProps = {
   selectedFidgetID: string;
   removeFidget: (fidgetId: string) => void;
   minimizeFidget: (fidgetId: string) => void;
+  flushPendingSaves?: () => void;
 };
 
 export const getSettingsWithDefaults = (
@@ -63,12 +64,16 @@ export function FidgetWrapper({
   selectedFidgetID,
   removeFidget,
   minimizeFidget,
+  flushPendingSaves,
 }: FidgetWrapperProps) {
   const { homebaseConfig } = useAppStore((state) => ({
     homebaseConfig: state.homebase.homebaseConfig,
   }));
 
   function onClickEdit() {
+    if (flushPendingSaves) {
+      flushPendingSaves();
+    }
     setSelectedFidgetID(bundle.id);
     setCurrentFidgetSettings(
       <FidgetSettingsEditor

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -208,6 +208,10 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     [saveConfig],
   );
 
+  const flushPendingSaves = useCallback(() => {
+    debouncedSaveConfig.flush();
+  }, [debouncedSaveConfig]);
+
   function unselectFidget() {
     setSelectedFidgetID("");
     setCurrentFidgetSettings(<></>);
@@ -567,6 +571,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
                     setCurrentFidgetSettings={setCurrentFidgetSettings}
                     setSelectedFidgetID={setSelectedFidgetID}
                     selectedFidgetID={selectedFidgetID}
+                    flushPendingSaves={flushPendingSaves}
                     bundle={{
                       ...fidgetDatum,
                       properties: fidgetModule.properties,

--- a/src/fidgets/layout/tabFullScreen/components/ConsolidatedMediaContent.tsx
+++ b/src/fidgets/layout/tabFullScreen/components/ConsolidatedMediaContent.tsx
@@ -51,6 +51,7 @@ const ConsolidatedMediaContent: React.FC<ConsolidatedMediaContentProps> = ({
                 selectedFidgetID=""
                 removeFidget={dummyFunctions.removeFidget}
                 minimizeFidget={dummyFunctions.minimizeFidget}
+                flushPendingSaves={dummyFunctions.flushPendingSaves}
               />
             </div>
           </div>

--- a/src/fidgets/layout/tabFullScreen/components/ConsolidatedPinnedContent.tsx
+++ b/src/fidgets/layout/tabFullScreen/components/ConsolidatedPinnedContent.tsx
@@ -45,6 +45,7 @@ const ConsolidatedPinnedContent: React.FC<ConsolidatedPinnedContentProps> = ({
               selectedFidgetID=""
               removeFidget={dummyFunctions.removeFidget}
               minimizeFidget={dummyFunctions.minimizeFidget}
+              flushPendingSaves={dummyFunctions.flushPendingSaves}
             />
           </div>
         );

--- a/src/fidgets/layout/tabFullScreen/components/FidgetContent.tsx
+++ b/src/fidgets/layout/tabFullScreen/components/FidgetContent.tsx
@@ -43,6 +43,7 @@ const FidgetContent: React.FC<FidgetContentProps> = ({
         selectedFidgetID=""
         removeFidget={dummyFunctions.removeFidget}
         minimizeFidget={dummyFunctions.minimizeFidget}
+        flushPendingSaves={dummyFunctions.flushPendingSaves}
       />
     </div>
   );

--- a/src/fidgets/layout/tabFullScreen/utils.ts
+++ b/src/fidgets/layout/tabFullScreen/utils.ts
@@ -209,4 +209,5 @@ export const dummyFunctions = {
   setSelectedFidgetID: () => {},
   removeFidget: () => {},
   minimizeFidget: () => {},
+  flushPendingSaves: () => {},
 };


### PR DESCRIPTION
## Summary
- add optional `flushPendingSaves` prop to `FidgetWrapper`
- create `flushPendingSaves` callback in `Grid` to flush debounced saves
- call the callback before opening settings in `FidgetWrapper`
- pass dummy `flushPendingSaves` for view-only tab components

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `node --test`