### PR TITLE
Fix fidget vanish after quick edit

### DIFF
--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -30,6 +30,7 @@ export type FidgetWrapperProps = {
   bundle: FidgetBundle;
   context?: FidgetRenderContext;
   saveConfig: (conf: FidgetConfig) => Promise<void>;
+  flushPendingSaves: () => void;
   setCurrentFidgetSettings: (currentFidgetSettings: React.ReactNode) => void;
   setSelectedFidgetID: (selectedFidgetID: string) => void;
   selectedFidgetID: string;
@@ -58,6 +59,7 @@ export function FidgetWrapper({
   fidget,
   bundle,
   saveConfig,
+  flushPendingSaves,
   setCurrentFidgetSettings,
   setSelectedFidgetID,
   selectedFidgetID,
@@ -69,6 +71,7 @@ export function FidgetWrapper({
   }));
 
   function onClickEdit() {
+    flushPendingSaves();
     setSelectedFidgetID(bundle.id);
     setCurrentFidgetSettings(
       <FidgetSettingsEditor
@@ -186,7 +189,7 @@ export function FidgetWrapper({
             : "size-full overflow-hidden"
         }
         style={{
-          background: settingsWithDefaults.useDefaultColors 
+          background: settingsWithDefaults.useDefaultColors
             ? homebaseConfig?.theme?.properties.fidgetBackground
             : settingsWithDefaults.background,
           borderColor: settingsWithDefaults.useDefaultColors

--- a/src/fidgets/layout/tabFullScreen/components/ConsolidatedMediaContent.tsx
+++ b/src/fidgets/layout/tabFullScreen/components/ConsolidatedMediaContent.tsx
@@ -20,24 +20,24 @@ const ConsolidatedMediaContent: React.FC<ConsolidatedMediaContentProps> = ({
   mediaFidgetIds,
   fidgetBundles,
   theme,
-  saveFidgetConfig
+  saveFidgetConfig,
 }) => {
   if (mediaFidgetIds.length === 0) return null;
-  
+
   return (
     <div className="flex flex-col gap-4 h-full overflow-y-auto pb-16">
       {mediaFidgetIds.map((fidgetId) => {
         const bundle = fidgetBundles[fidgetId];
         if (!bundle) return null;
-        
-        const aspectRatioClass = 
-          bundle.properties.fidgetName === "Image" ? 
-          "aspect-[4/3] w-full overflow-hidden" : 
-          "aspect-square w-full overflow-hidden";
-        
+
+        const aspectRatioClass =
+          bundle.properties.fidgetName === "Image"
+            ? "aspect-[4/3] w-full overflow-hidden"
+            : "aspect-square w-full overflow-hidden";
+
         return (
-          <div 
-            key={fidgetId} 
+          <div
+            key={fidgetId}
             className={`${aspectRatioClass} relative rounded-lg`}
           >
             <div className="absolute inset-0">
@@ -46,7 +46,10 @@ const ConsolidatedMediaContent: React.FC<ConsolidatedMediaContentProps> = ({
                 context={{ theme }}
                 bundle={bundle}
                 saveConfig={saveFidgetConfig(fidgetId)}
-                setCurrentFidgetSettings={dummyFunctions.setCurrentFidgetSettings}
+                flushPendingSaves={dummyFunctions.flushPendingSaves}
+                setCurrentFidgetSettings={
+                  dummyFunctions.setCurrentFidgetSettings
+                }
                 setSelectedFidgetID={dummyFunctions.setSelectedFidgetID}
                 selectedFidgetID=""
                 removeFidget={dummyFunctions.removeFidget}

--- a/src/fidgets/layout/tabFullScreen/components/ConsolidatedPinnedContent.tsx
+++ b/src/fidgets/layout/tabFullScreen/components/ConsolidatedPinnedContent.tsx
@@ -20,26 +20,24 @@ const ConsolidatedPinnedContent: React.FC<ConsolidatedPinnedContentProps> = ({
   pinnedCastIds,
   fidgetBundles,
   theme,
-  saveFidgetConfig
+  saveFidgetConfig,
 }) => {
   if (pinnedCastIds.length === 0) return null;
-  
+
   return (
     <div className="flex flex-col gap-4 h-full overflow-y-auto pb-16">
       {pinnedCastIds.map((fidgetId) => {
         const bundle = fidgetBundles[fidgetId];
         if (!bundle) return null;
-        
+
         return (
-          <div 
-            key={fidgetId} 
-            className="w-full h-fit"
-          >
+          <div key={fidgetId} className="w-full h-fit">
             <FidgetWrapper
               fidget={CompleteFidgets[bundle.fidgetType]?.fidget}
               context={{ theme }}
               bundle={bundle}
               saveConfig={saveFidgetConfig(fidgetId)}
+              flushPendingSaves={dummyFunctions.flushPendingSaves}
               setCurrentFidgetSettings={dummyFunctions.setCurrentFidgetSettings}
               setSelectedFidgetID={dummyFunctions.setSelectedFidgetID}
               selectedFidgetID=""

--- a/src/fidgets/layout/tabFullScreen/components/FidgetContent.tsx
+++ b/src/fidgets/layout/tabFullScreen/components/FidgetContent.tsx
@@ -23,21 +23,26 @@ const FidgetContent: React.FC<FidgetContentProps> = ({
   theme,
   saveFidgetConfig,
   isMobile,
-  mobilePadding
-}) => {  
+  mobilePadding,
+}) => {
   return (
     <div
       className="h-full w-full"
-      style={isMobile ? { 
-        paddingInline: `${mobilePadding}px`, 
-        paddingTop: `${mobilePadding - 16}px`,
-      } : {}}
+      style={
+        isMobile
+          ? {
+              paddingInline: `${mobilePadding}px`,
+              paddingTop: `${mobilePadding - 16}px`,
+            }
+          : {}
+      }
     >
       <FidgetWrapper
         fidget={CompleteFidgets[fidgetBundle.fidgetType]?.fidget}
         context={{ theme }}
         bundle={fidgetBundle}
         saveConfig={saveFidgetConfig(fidgetId)}
+        flushPendingSaves={dummyFunctions.flushPendingSaves}
         setCurrentFidgetSettings={dummyFunctions.setCurrentFidgetSettings}
         setSelectedFidgetID={dummyFunctions.setSelectedFidgetID}
         selectedFidgetID=""

--- a/src/fidgets/layout/tabFullScreen/utils.ts
+++ b/src/fidgets/layout/tabFullScreen/utils.ts
@@ -5,12 +5,12 @@ import { CompleteFidgets } from "@/fidgets";
  * Checks if a fidget is a media-type fidget (text, gallery, video)
  */
 export const isMediaFidget = (fidgetType: string): boolean => {
-  return ['text', 'gallery', 'Video'].includes(fidgetType);
+  return ["text", "gallery", "Video"].includes(fidgetType);
 };
 
 /**
  * Gets the appropriate display name for a fidget based on settings and context
- * 
+ *
  * @param fidgetData The fidget instance data
  * @param isMobile Whether the display is on mobile
  * @param specialId Optional special ID for consolidated views
@@ -25,27 +25,32 @@ export const getFidgetDisplayName = (
   specialId?: string,
   customTabNames?: string[],
   fidgetIds?: string[],
-  fidgetIdIndex?: number
+  fidgetIdIndex?: number,
 ): string => {
   // Handle special consolidated views
-  if (specialId === 'consolidated-media') {
+  if (specialId === "consolidated-media") {
     return "Media";
   }
-  
-  if (specialId === 'consolidated-pinned') {
+
+  if (specialId === "consolidated-pinned") {
     return "Pinned";
   }
-  
-  if (!fidgetData) return 'Unknown';
-  
+
+  if (!fidgetData) return "Unknown";
+
   // Use custom tab name if available
-  if (customTabNames && fidgetIds && typeof fidgetIdIndex === 'number' && fidgetIdIndex >= 0) {
+  if (
+    customTabNames &&
+    fidgetIds &&
+    typeof fidgetIdIndex === "number" &&
+    fidgetIdIndex >= 0
+  ) {
     const customName = customTabNames[fidgetIdIndex];
     if (customName) return customName;
   }
-  
+
   const fidgetModule = CompleteFidgets[fidgetData.fidgetType];
-  if (!fidgetModule) return 'Unknown';
+  if (!fidgetModule) return "Unknown";
 
   if (isMobile) {
     // First check for user-defined custom mobile display name
@@ -57,7 +62,7 @@ export const getFidgetDisplayName = (
       return fidgetModule.properties.mobileFidgetName;
     }
   }
-  
+
   return fidgetModule.properties.fidgetName;
 };
 
@@ -72,19 +77,19 @@ export const shouldShowMobileSettings = (fidgetType: string): boolean => {
  * Checks if a fidget is a pinned cast
  */
 export const isPinnedCast = (
-  fidgetId: string, 
-  fidgetInstanceDatums: { [key: string]: FidgetInstanceData }
+  fidgetId: string,
+  fidgetInstanceDatums: { [key: string]: FidgetInstanceData },
 ): boolean => {
   const fidgetData = fidgetInstanceDatums[fidgetId];
-  return fidgetData?.fidgetType === 'cast';
+  return fidgetData?.fidgetType === "cast";
 };
 
 /**
  * Creates a FidgetBundle object from a FidgetInstanceData
  */
 export const createFidgetBundle = (
-  fidgetData: FidgetInstanceData, 
-  isEditable: boolean = false
+  fidgetData: FidgetInstanceData,
+  isEditable: boolean = false,
 ): FidgetBundle | null => {
   if (!fidgetData) return null;
 
@@ -104,29 +109,29 @@ export const createFidgetBundle = (
 export const processTabFidgetIds = (
   fidgetIds: string[],
   fidgetInstanceDatums: { [key: string]: FidgetInstanceData },
-  isMobile: boolean
+  isMobile: boolean,
 ): string[] => {
   if (!isMobile) {
     // On desktop, use all fidgets as is
-    return fidgetIds.filter(id => {
+    return fidgetIds.filter((id) => {
       const fidgetData = fidgetInstanceDatums[id];
       return !!fidgetData;
     });
   }
-  
+
   // For mobile, process and potentially consolidate media fidgets
   const mediaFidgetIds: string[] = [];
   const pinnedCastIds: string[] = [];
   const nonMediaFidgetIds: string[] = [];
-  
+
   // First separate media, pinned casts, and non-media fidgets
-  fidgetIds.forEach(id => {
+  fidgetIds.forEach((id) => {
     const fidgetData = fidgetInstanceDatums[id];
     if (!fidgetData) return;
-    
+
     // Skip fidgets that should be hidden on mobile
     if (fidgetData.config.settings.showOnMobile === false) return;
-    
+
     if (isPinnedCast(id, fidgetInstanceDatums)) {
       pinnedCastIds.push(id);
     } else if (isMediaFidget(fidgetData.fidgetType)) {
@@ -135,23 +140,23 @@ export const processTabFidgetIds = (
       nonMediaFidgetIds.push(id);
     }
   });
-  
+
   const consolidatedIds: string[] = [];
-  
+
   // If we have multiple pinned casts, return them under a special id
   if (pinnedCastIds.length > 1) {
-    consolidatedIds.push('consolidated-pinned');
+    consolidatedIds.push("consolidated-pinned");
   } else {
     consolidatedIds.push(...pinnedCastIds);
   }
-  
+
   // If we have multiple media fidgets, add them under a special id
   if (mediaFidgetIds.length > 1) {
-    consolidatedIds.push('consolidated-media');
+    consolidatedIds.push("consolidated-media");
   } else {
     consolidatedIds.push(...mediaFidgetIds);
   }
-  
+
   return [...consolidatedIds, ...nonMediaFidgetIds];
 };
 
@@ -161,19 +166,19 @@ export const processTabFidgetIds = (
 export const getValidFidgetIds = (
   fidgetIds: string[],
   fidgetInstanceDatums: { [key: string]: FidgetInstanceData },
-  isMobile: boolean
+  isMobile: boolean,
 ): string[] => {
-  return fidgetIds.filter(id => {
+  return fidgetIds.filter((id) => {
     const fidgetData = fidgetInstanceDatums[id];
     if (!fidgetData) return false;
-    
+
     // On mobile, check showOnMobile setting
     if (isMobile) {
       const showOnMobile = fidgetData.config.settings.showOnMobile;
       // If showOnMobile is explicitly false, hide the fidget
       if (showOnMobile === false) return false;
     }
-    
+
     return true;
   });
 };
@@ -183,9 +188,9 @@ export const getValidFidgetIds = (
  */
 export const getMediaFidgetIds = (
   fidgetIds: string[],
-  fidgetInstanceDatums: { [key: string]: FidgetInstanceData }
+  fidgetInstanceDatums: { [key: string]: FidgetInstanceData },
 ): string[] => {
-  return fidgetIds.filter(id => {
+  return fidgetIds.filter((id) => {
     const fidgetData = fidgetInstanceDatums[id];
     return isMediaFidget(fidgetData.fidgetType);
   });
@@ -196,9 +201,9 @@ export const getMediaFidgetIds = (
  */
 export const getPinnedCastIds = (
   fidgetIds: string[],
-  fidgetInstanceDatums: { [key: string]: FidgetInstanceData }
+  fidgetInstanceDatums: { [key: string]: FidgetInstanceData },
 ): string[] => {
-  return fidgetIds.filter(id => isPinnedCast(id, fidgetInstanceDatums));
+  return fidgetIds.filter((id) => isPinnedCast(id, fidgetInstanceDatums));
 };
 
 /**
@@ -209,4 +214,5 @@ export const dummyFunctions = {
   setSelectedFidgetID: () => {},
   removeFidget: () => {},
   minimizeFidget: () => {},
+  flushPendingSaves: () => {},
 };


### PR DESCRIPTION
## Summary
- flush debounced grid saves before opening settings
- expose flush function to FidgetWrapper
- update TabFullScreen helpers and components

## Testing
- `node --test tests/fidgetConfig.test.js`