### PR TITLE
Fix grid save merging

### DIFF
--- a/src/common/data/stores/app/index.ts
+++ b/src/common/data/stores/app/index.ts
@@ -80,8 +80,11 @@ export function createAppStore() {
   });
 }
 
-const { useStore: useAppStore, provider: AppStoreProvider } =
-  createStoreBindings<AppStore>("AppStore", createAppStore);
+const {
+  useStore: useAppStore,
+  provider: AppStoreProvider,
+  context: AppStoreContext,
+} = createStoreBindings<AppStore>("AppStore", createAppStore);
 
 function useLogout() {
   const { logout: privyLogout } = usePrivy();
@@ -97,4 +100,4 @@ function useLogout() {
   return logout;
 }
 
-export { useAppStore, AppStoreProvider, useLogout };
+export { useAppStore, AppStoreProvider, AppStoreContext, useLogout };

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -5,6 +5,7 @@ import React, {
   useState,
   useCallback,
   useRef,
+  useContext,
 } from "react";
 import useWindowSize from "@/common/lib/hooks/useWindowSize";
 import RGL, { WidthProvider } from "react-grid-layout";
@@ -34,6 +35,7 @@ import AddFidgetIcon from "@/common/components/atoms/icons/AddFidget";
 import FidgetSettingsEditor from "@/common/components/organisms/FidgetSettingsEditor";
 import { debounce } from "lodash";
 import { updateFidgetInstanceDatums } from "./updateFidgetInstanceDatums";
+import { AppStoreContext } from "@/common/data/stores/app";
 
 export const resizeDirections = ["s", "w", "e", "n", "sw", "nw", "se", "ne"];
 export type ResizeDirection = (typeof resizeDirections)[number];
@@ -136,6 +138,11 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   hasFeed,
   fid,
 }) => {
+  const store = useContext(AppStoreContext);
+
+  if (!store) {
+    throw new Error("AppStoreContext not found");
+  }
   // State to handle selecting, dragging, and Grid edit functionality
   const [element, setElement] = useState<HTMLDivElement | null>(
     portalRef.current,
@@ -170,8 +177,11 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
       | typeof fidgetInstanceDatums
       | ((current: typeof fidgetInstanceDatums) => typeof fidgetInstanceDatums),
   ) => {
+    const existingDatums =
+      store.getState().homebase.homebaseConfig?.fidgetInstanceDatums ||
+      fidgetInstanceDatums;
     const datums =
-      typeof updater === "function" ? updater(fidgetInstanceDatums) : updater;
+      typeof updater === "function" ? updater(existingDatums) : updater;
     return await saveConfig({
       fidgetInstanceDatums: datums,
     });

--- a/tests/fidgetConfig.test.js
+++ b/tests/fidgetConfig.test.js
@@ -20,3 +20,27 @@ test('updateFidgetInstanceDatums ignores missing id', () => {
   const updated = updateFidgetInstanceDatums({ ...initialDatums }, 'missing', newConfig);
   assert.deepStrictEqual(updated, { ...initialDatums });
 });
+
+test('add then edit retains id', () => {
+  const store = {
+    state: { homebase: { homebaseConfig: { fidgetInstanceDatums: { ...initialDatums } } } },
+    getState() { return this.state; },
+  };
+
+  const saveFidgetInstanceDatums = (updater) => {
+    const existing =
+      store.getState().homebase.homebaseConfig?.fidgetInstanceDatums || {};
+    const datums = typeof updater === 'function' ? updater(existing) : updater;
+    store.state.homebase.homebaseConfig.fidgetInstanceDatums = datums;
+  };
+
+  const newDatum = { id: 'c', fidgetType: 'baz', config: { settings: {}, editable: true, data: {} } };
+
+  // Add
+  saveFidgetInstanceDatums((current) => ({ ...current, c: newDatum }));
+
+  // Edit immediately
+  saveFidgetInstanceDatums((current) => updateFidgetInstanceDatums(current, 'c', newConfig));
+
+  assert.ok(store.getState().homebase.homebaseConfig.fidgetInstanceDatums.c);
+});


### PR DESCRIPTION
## Summary
- export `AppStoreContext`
- use context within `Grid` layout
- merge fidget datum updates with latest store state
- test regression for add-edit flow

## Testing
- `node --test tests/fidgetConfig.test.js`