### PR TITLE
Fix: default config flashing when visiting uncached tabs

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -661,6 +661,9 @@ export default function PublicSpace({
       <div className="user-theme-background w-full h-full relative flex-col">
         <div className="w-full transition-all duration-100 ease-out">
           <div className="flex flex-col h-full">
+            {profile ? (
+              <div className="z-50 bg-white md:h-40">{profile}</div>
+            ) : null}
             <TabBarSkeleton />
             <div className="flex h-full">
               <div className="grow">

--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -223,7 +223,7 @@ export default function PublicSpace({
   // Loads and sets up the user's space tab when providedSpaceId or providedTabName changes
   useEffect(() => {
     const currentSpaceId = getCurrentSpaceId();
-    const currentTabName = getCurrentTabName();
+    const currentTabName = getCurrentTabName() ?? "Profile";
 
     console.log("Loading space tab:", {
       currentSpaceId,
@@ -232,8 +232,17 @@ export default function PublicSpace({
     });
 
     if (!isNil(currentSpaceId)) {
-      setLoading(true);
-      // First, load the space tab order
+      const hasCachedTab = !!localSpaces[currentSpaceId]?.tabs[currentTabName];
+      const hasCachedOrder =
+        !!localSpaces[currentSpaceId]?.order &&
+        localSpaces[currentSpaceId].order.length > 0;
+
+      if (!hasCachedTab || !hasCachedOrder) {
+        setLoading(true);
+      } else {
+        setLoading(false);
+      }
+
       loadSpaceTabOrder(currentSpaceId)
         .then(() => {
           console.log("Loaded space tab order");
@@ -241,8 +250,7 @@ export default function PublicSpace({
         })
         .then(() => {
           console.log("Loaded editable spaces");
-          // Load the specific tab
-          return loadSpaceTab(currentSpaceId, currentTabName ?? "Profile");
+          return loadSpaceTab(currentSpaceId, currentTabName);
         })
         .then(() => {
           console.log("Loaded space tab");
@@ -253,7 +261,7 @@ export default function PublicSpace({
           setLoading(false);
         });
     }
-  }, [getCurrentSpaceId, getCurrentTabName]);
+  }, [getCurrentSpaceId, getCurrentTabName, localSpaces]);
 
   // Function to load remaining tabs
   const loadRemainingTabs = useCallback(

--- a/src/app/(spaces)/p/[proposalId]/ProposalDefinedSpace.tsx
+++ b/src/app/(spaces)/p/[proposalId]/ProposalDefinedSpace.tsx
@@ -28,9 +28,9 @@ const ProposalDefinedSpace = ({
       createInitalProposalSpaceConfigForProposalId(
         proposalId as Address,
         ownerId as Address,
-        proposalData?.proposer.id as Address
+        proposalData?.proposer.id as Address,
       ),
-    [proposalId, proposalData]
+    [proposalId, proposalData],
   );
 
   const getSpacePageUrl = (tabName: string) => `/p/${proposalId}/${tabName}`;
@@ -38,8 +38,8 @@ const ProposalDefinedSpace = ({
   return (
     <div className="w-full">
       <PublicSpace
-        spaceId={spaceId || ""} // Ensure spaceId is a string
-        tabName={tabName || "Profile"} // Ensure tabName is a string
+        spaceId={spaceId ?? null}
+        tabName={tabName || "Profile"}
         initialConfig={INITIAL_SPACE_CONFIG}
         getSpacePageUrl={getSpacePageUrl}
         isTokenPage={false}

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -311,9 +311,14 @@ export const createSpaceStoreFunc = (
 
     console.log("NewConfig", config);
     let localCopy;
+    const newTimestamp = moment().toISOString();
+
     // If the tab doesn't exist yet, use the new config directly
     if (!get().space.localSpaces[spaceId]?.tabs[tabName]) {
-      localCopy = cloneDeep(config);
+      localCopy = {
+        ...cloneDeep(config),
+        timestamp: newTimestamp,
+      };
     } else {
       // Otherwise merge with existing config
       localCopy = cloneDeep(get().space.localSpaces[spaceId].tabs[tabName]);
@@ -324,6 +329,7 @@ export const createSpaceStoreFunc = (
           return srcValue;
         }
       });
+      localCopy.timestamp = newTimestamp;
       console.log("localCopy", localCopy);
     }
 
@@ -335,8 +341,8 @@ export const createSpaceStoreFunc = (
       } else {
         draft.space.localSpaces[spaceId].tabs[tabName] = localCopy;
       }
-      const newTimestamp = moment().toISOString();
-      draft.space.localSpaces[spaceId].updatedAt = newTimestamp;
+      const newSpaceTimestamp = moment().toISOString();
+      draft.space.localSpaces[spaceId].updatedAt = newSpaceTimestamp;
     }, "saveLocalSpaceTab");
   },
   deleteSpaceTab: debounce(


### PR DESCRIPTION
Fixes #684 

Note: there's still an issue where the default config for the Feed tab on homebase will be displayed for a while before the saved version loads. This issue is already present in canary though, so will create a separate PR to fix