### PR TITLE
Fix grid save merging

### DIFF
--- a/src/common/data/stores/app/index.ts
+++ b/src/common/data/stores/app/index.ts
@@ -80,8 +80,11 @@ export function createAppStore() {
   });
 }
 
-const { useStore: useAppStore, provider: AppStoreProvider } =
-  createStoreBindings<AppStore>("AppStore", createAppStore);
+const {
+  useStore: useAppStore,
+  provider: AppStoreProvider,
+  context: AppStoreContext,
+} = createStoreBindings<AppStore>("AppStore", createAppStore);
 
 function useLogout() {
   const { logout: privyLogout } = usePrivy();
@@ -97,4 +100,4 @@ function useLogout() {
   return logout;
 }
 
-export { useAppStore, AppStoreProvider, useLogout };
+export { useAppStore, AppStoreProvider, AppStoreContext, useLogout };

--- a/tests/fidgetConfig.test.js
+++ b/tests/fidgetConfig.test.js
@@ -20,3 +20,21 @@ test('updateFidgetInstanceDatums ignores missing id', () => {
   const updated = updateFidgetInstanceDatums({ ...initialDatums }, 'missing', newConfig);
   assert.deepStrictEqual(updated, { ...initialDatums });
 });
+
+test('add then edit retains id', () => {
+  let datums = { ...initialDatums };
+
+  const saveFidgetInstanceDatums = (updater) => {
+    datums = typeof updater === 'function' ? updater(datums) : updater;
+  };
+
+  const newDatum = { id: 'c', fidgetType: 'baz', config: { settings: {}, editable: true, data: {} } };
+
+  // Add
+  saveFidgetInstanceDatums((current) => ({ ...current, c: newDatum }));
+
+  // Edit immediately
+  saveFidgetInstanceDatums((current) => updateFidgetInstanceDatums(current, 'c', newConfig));
+
+  assert.ok(datums.c);
+});


### PR DESCRIPTION
## Summary
- revert saveFidgetInstanceDatums to rely on passed datums
- stop using AppStoreContext inside Grid
- keep regression test for quick add+edit

## Testing
- `node --test tests/fidgetConfig.test.js`
