### PR TITLE
Speed up homebase feed tab loading

### DIFF
--- a/src/common/data/stores/app/homebase/homebaseTabsStore.ts
+++ b/src/common/data/stores/app/homebase/homebaseTabsStore.ts
@@ -237,12 +237,13 @@ export const createHomeBaseTabStoreFunc = (
           });
         }, "loadTabNames");
 
-        // Load remote state for any tabs that don't have it
-        for (const tabName of validTabNames) {
+        // Load remote state for any tabs that don't have it. Don't block on
+        // these network requests so the feed can render quickly.
+        validTabNames.forEach((tabName) => {
           if (!get().homebase.tabs[tabName]?.remoteConfig) {
-            await get().homebase.loadHomebaseTab(tabName);
+            void get().homebase.loadHomebaseTab(tabName);
           }
-        }
+        });
 
         return validTabNames;
       }


### PR DESCRIPTION
## Summary
- stop waiting for every tab config before loading the feed tab

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*