### PR TITLE
Fix grid state when adding fidgets

### DIFF
--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -34,6 +34,7 @@ import AddFidgetIcon from "@/common/components/atoms/icons/AddFidget";
 import FidgetSettingsEditor from "@/common/components/organisms/FidgetSettingsEditor";
 import { debounce } from "lodash";
 import { updateFidgetInstanceDatums } from "./updateFidgetInstanceDatums";
+import { useAppStore } from "@/common/data/stores/app";
 
 export const resizeDirections = ["s", "w", "e", "n", "sw", "nw", "se", "ne"];
 export type ResizeDirection = (typeof resizeDirections)[number];
@@ -136,6 +137,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   hasFeed,
   fid,
 }) => {
+  const store = useAppStore;
   // State to handle selecting, dragging, and Grid edit functionality
   const [element, setElement] = useState<HTMLDivElement | null>(
     portalRef.current,
@@ -394,6 +396,13 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   const addFidgetToGrid = (fidget: FidgetBundle): boolean => {
     const { fidgetType, id } = fidget;
 
+    const existingLayout =
+      store.getState().homebase.homebaseConfig?.layoutDetails.layoutConfig
+        .layout ?? layoutConfig.layout;
+    const existingDatums =
+      store.getState().homebase.homebaseConfig?.fidgetInstanceDatums ??
+      fidgetInstanceDatums;
+
     // Prevent duplicates
     const alreadyPlaced = layoutConfig.layout.some((item) => item.i === id);
     if (alreadyPlaced) {
@@ -443,8 +452,8 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
 
           // Save both layout and fidgetInstanceDatums in a single operation
           debouncedSaveConfig({
-            layoutConfig: { layout: [...layoutConfig.layout, newItem] },
-            fidgetInstanceDatums: { ...fidgetInstanceDatums, [id]: fidget },
+            layoutConfig: { layout: [...existingLayout, newItem] },
+            fidgetInstanceDatums: { ...existingDatums, [id]: fidget },
           });
 
           analytics.track(AnalyticsEvent.ADD_FIDGET, {


### PR DESCRIPTION
## Summary
- pull latest layout and datums from the store when adding a fidget

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*