### PR TITLE
Add pending-save flush before fidget edit

### DIFF
--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -223,6 +223,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   }
 
   function selectFidget(bundle: FidgetBundle) {
+    flushPendingSaves();
     const settingsWithDefaults = getSettingsWithDefaults(
       bundle.config.settings,
       bundle.properties,


### PR DESCRIPTION
## Summary
- flush pending saves at the start of `selectFidget`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definition files)*