### PR TITLE
Fix mobile nav animations and centering

### DIFF
--- a/src/common/components/atoms/drawer.tsx
+++ b/src/common/components/atoms/drawer.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Cross2Icon } from "@radix-ui/react-icons";
+
+import { mergeClasses } from "@/common/lib/utils/mergeClasses";
+
+const Drawer = DialogPrimitive.Root;
+const DrawerTrigger = DialogPrimitive.Trigger;
+const DrawerPortal = DialogPrimitive.Portal;
+const DrawerClose = DialogPrimitive.Close;
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={mergeClasses(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+DrawerOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    showCloseButton?: boolean;
+  }
+>(({ className, children, showCloseButton = true, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={mergeClasses(
+        "fixed left-0 top-0 z-50 h-full w-[270px] translate-x-[-100%] border-r bg-background p-6 shadow-lg transition-transform duration-300 data-[state=open]:translate-x-0 data-[state=closed]:-translate-x-full",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DrawerClose className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <Cross2Icon className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DrawerClose>
+      )}
+    </DialogPrimitive.Content>
+  </DrawerPortal>
+));
+DrawerContent.displayName = "DrawerContent";
+
+export {
+  Drawer,
+  DrawerTrigger,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerClose,
+  DrawerContent,
+};

--- a/src/common/components/molecules/BrandHeader.tsx
+++ b/src/common/components/molecules/BrandHeader.tsx
@@ -25,7 +25,7 @@ const BrandHeader = () => {
             <TooltipTrigger asChild>
               <Image
                 src="/images/noggles.svg"
-                className="h-13 me-3 mb-4"
+                className="h-13 me-3 "
                 alt="Nounspace Logo"
                 width={60}
                 height={40}

--- a/src/common/components/organisms/MobileHeader.tsx
+++ b/src/common/components/organisms/MobileHeader.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import BrandHeader from "../molecules/BrandHeader";
 import { Button } from "../atoms/button";
-import { Dialog, DialogContent } from "../atoms/dialog";
+import { Drawer, DrawerContent } from "../atoms/drawer";
 import Modal from "../molecules/Modal";
 import CreateCast from "@/fidgets/farcaster/components/CreateCast";
 import Navigation from "./Navigation";
@@ -80,7 +80,7 @@ const MobileHeader: React.FC = () => {
           </Button>
         )}
       </div>
-      <div className="absolute left-1/2 -translate-x-1/2">
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
         <BrandHeader />
       </div>
       <Button
@@ -91,18 +91,16 @@ const MobileHeader: React.FC = () => {
       >
         <span className="text-lg font-bold">+</span>
       </Button>
-      <Dialog open={navOpen} onOpenChange={setNavOpen}>
-        <DialogContent
-          className="p-0 max-w-none w-[270px] h-full rounded-none left-0 top-0 translate-x-0 translate-y-0"
-          showCloseButton={false}
-        >
+      <Drawer open={navOpen} onOpenChange={setNavOpen}>
+        <DrawerContent className="p-0" showCloseButton={false}>
           <Navigation
             isEditable={sidebarEditable}
             enterEditMode={enterEditMode}
             mobile
+            onNavigate={() => setNavOpen(false)}
           />
-        </DialogContent>
-      </Dialog>
+        </DrawerContent>
+      </Drawer>
       <Modal
         open={castOpen}
         setOpen={setCastOpen}

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -52,6 +52,7 @@ type NavProps = {
   isEditable: boolean;
   enterEditMode: () => void;
   mobile?: boolean;
+  onNavigate?: () => void;
 };
 
 const NavIconBadge = ({ children }) => {
@@ -65,7 +66,12 @@ const NavIconBadge = ({ children }) => {
   );
 };
 
-const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode, mobile = false }) => {
+const Navigation: React.FC<NavProps> = ({
+  isEditable,
+  enterEditMode,
+  mobile = false,
+  onNavigate,
+}) => {
   const searchRef = useRef<HTMLInputElement>(null);
   const { setModalOpen, getIsLoggedIn, getIsInitializing } = useAppStore(
     (state) => ({
@@ -135,6 +141,10 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode, mobile = fa
     openInNewTab = false,
     badgeText = null,
   }) => {
+    const handleClick = useCallback(() => {
+      onClick?.();
+      onNavigate?.();
+    }, [onClick, onNavigate]);
     return (
       <li>
         <Link
@@ -144,7 +154,7 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode, mobile = fa
             href === pathname ? "bg-gray-100" : "",
             shrunk ? "justify-center" : ""
           )}
-          onClick={onClick}
+          onClick={handleClick}
           rel={openInNewTab ? "noopener noreferrer" : undefined}
           target={openInNewTab ? "_blank" : undefined}
         >


### PR DESCRIPTION
## Summary
- implement Drawer component for sliding mobile navigation
- animate mobile nav sliding from the left
- close mobile nav when navigating
- vertically center brand logo in mobile header

## Testing
- `yarn lint` *(fails: yarn not installed)*
- `yarn check-types` *(fails: yarn not installed)*