### PR TITLE
Mobile: prompt user to sign in if they interact with a Farcaster feed while not signed in

### DIFF
--- a/src/app/(spaces)/homebase/PrivateSpace.tsx
+++ b/src/app/(spaces)/homebase/PrivateSpace.tsx
@@ -37,7 +37,7 @@ function PrivateSpace({ tabName }: { tabName: string }) {
     setCurrentSpaceId,
     setCurrentTabName,
     loadTabNames,
-    getIsLoggedIn,
+    getIsAccountReady,
     loadTabOrder,
     updateTabOrder,
     createTab: originalCreateTab,
@@ -58,7 +58,7 @@ function PrivateSpace({ tabName }: { tabName: string }) {
     loadFeedConfig: state.homebase.loadHomebase,
     commitConfig: state.homebase.commitHomebaseToDatabase,
     resetConfig: state.homebase.resetHomebaseConfig,
-    getIsLoggedIn: state.getIsAccountReady,
+    getIsAccountReady: state.getIsAccountReady,
     setCurrentSpaceId: state.currentSpace.setCurrentSpaceId,
     setCurrentTabName: state.currentSpace.setCurrentTabName,
     loadTabNames: state.homebase.loadTabNames,
@@ -72,7 +72,7 @@ function PrivateSpace({ tabName }: { tabName: string }) {
   }));
 
   const router = useRouter(); // Hook for navigation
-  const isLoggedIn = getIsLoggedIn(); // Check if the user is logged in
+  const isLoggedIn = getIsAccountReady(); // Check if the user is logged in
   const currentFid = useCurrentFid(); // Get the current FID
 
   const { editMode } = useSidebarContext(); // Get the edit mode status from the sidebar context

--- a/src/app/home/[tabname]/page.tsx
+++ b/src/app/home/[tabname]/page.tsx
@@ -27,11 +27,11 @@ const getTabConfig = (tabName: string) => {
 const Home = () => {
   const router = useRouter();
   const params = useParams();
-  const { getIsLoggedIn, getIsInitializing } = useAppStore((state) => ({
-    getIsLoggedIn: state.getIsAccountReady,
+  const { getIsAccountReady, getIsInitializing } = useAppStore((state) => ({
+    getIsAccountReady: state.getIsAccountReady,
     getIsInitializing: state.getIsInitializing,
   }));
-  const isLoggedIn = getIsLoggedIn();
+  const isLoggedIn = getIsAccountReady();
   const isInitializing = getIsInitializing();
 
   // Local state to manage current tab name and ordering

--- a/src/common/components/organisms/InfoBanner.tsx
+++ b/src/common/components/organisms/InfoBanner.tsx
@@ -28,10 +28,10 @@ function InfoToastContent() {
   const { data } = useLoadFarcasterUser(fid);
   const user = useMemo(() => first(data?.users), [data]);
   const username = useMemo(() => user?.username, [user]);
-  const { getIsLoggedIn } = useAppStore((state) => ({
-    getIsLoggedIn: state.getIsAccountReady,
+  const { getIsAccountReady } = useAppStore((state) => ({
+    getIsAccountReady: state.getIsAccountReady,
   }));
-  const isLoggedIn = getIsLoggedIn();
+  const isLoggedIn = getIsAccountReady();
 
   const checkPageType = (pathname, spaceFarcasterName, username) => {
     if (pathname === "/homebase") {

--- a/src/common/components/organisms/MobileHeader.tsx
+++ b/src/common/components/organisms/MobileHeader.tsx
@@ -16,9 +16,9 @@ import LoginIcon from "../atoms/icons/LoginIcon";
 import { useSidebarContext } from "./Sidebar";
 
 const MobileHeader: React.FC = () => {
-  const { setModalOpen, getIsLoggedIn } = useAppStore((state) => ({
+  const { setModalOpen, getIsAccountReady } = useAppStore((state) => ({
     setModalOpen: state.setup.setModalOpen,
-    getIsLoggedIn: state.getIsAccountReady,
+    getIsAccountReady: state.getIsAccountReady,
   }));
 
   const { setEditMode, sidebarEditable } = useSidebarContext();
@@ -53,7 +53,7 @@ const MobileHeader: React.FC = () => {
     };
   }, []);
 
-  const isLoggedIn = getIsLoggedIn();
+  const isLoggedIn = getIsAccountReady();
 
   return (
     <header className="relative flex items-center justify-between h-14 px-4 border-b bg-white">

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -67,10 +67,10 @@ const NavIconBadge = ({ children }) => {
 
 const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode, mobile = false }) => {
   const searchRef = useRef<HTMLInputElement>(null);
-  const { setModalOpen, getIsLoggedIn, getIsInitializing } = useAppStore(
+  const { setModalOpen, getIsAccountReady, getIsInitializing } = useAppStore(
     (state) => ({
       setModalOpen: state.setup.setModalOpen,
-      getIsLoggedIn: state.getIsAccountReady,
+      getIsAccountReady: state.getIsAccountReady,
       getIsInitializing: state.getIsInitializing,
     })
   );
@@ -105,7 +105,7 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode, mobile = fa
     setShowCastModal(true);
   }
   const { fid } = useFarcasterSigner("navigation");
-  const isLoggedIn = getIsLoggedIn();
+  const isLoggedIn = getIsAccountReady();
   const isInitializing = getIsInitializing();
   const { data } = useLoadFarcasterUser(fid);
   const user = useMemo(() => first(data?.users), [data]);

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -64,9 +64,9 @@ function TabBar({
 }: TabBarProps) {
   const isMobile = useIsMobile();
 
-  const { getIsLoggedIn, getIsInitializing } = useAppStore((state) => ({
+  const { getIsAccountReady, getIsInitializing } = useAppStore((state) => ({
     setModalOpen: state.setup.setModalOpen,
-    getIsLoggedIn: state.getIsAccountReady,
+    getIsAccountReady: state.getIsAccountReady,
     getIsInitializing: state.getIsInitializing,
   }));
 
@@ -179,7 +179,7 @@ function TabBar({
     }
   }
 
-  const isLoggedIn = getIsLoggedIn();
+  const isLoggedIn = getIsAccountReady();
 
   return (
     <TooltipProvider>

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -32,6 +32,7 @@ import ExpandableText from "@/common/components/molecules/ExpandableText";
 import { trackAnalyticsEvent } from "@/common/lib/utils/analyticsUtils";
 import { AnalyticsEvent } from "@/common/providers/AnalyticsProvider";
 import { FaReply } from "react-icons/fa6";
+import { useAppStore } from "@/common/data/stores/app";
 
 function isEmbedUrl(maybe: unknown): maybe is EmbedUrl {
   return isObject(maybe) && typeof maybe["url"] === "string";
@@ -243,6 +244,10 @@ const CastReactions = ({ cast }: { cast: CastWithInteractions }) => {
   const [didLike, setDidLike] = useState(false);
   const [didRecast, setDidRecast] = useState(false);
   const { signer, fid: userFid } = useFarcasterSigner("render-cast");
+  const { setModalOpen, getIsAccountReady } = useAppStore((state) => ({
+    setModalOpen: state.setup.setModalOpen,
+    getIsAccountReady: state.getIsAccountReady,
+  }));
 
   const authorFid = cast.author.fid;
   const castHashBytes = hexToBytes(cast.hash.slice(2));
@@ -278,6 +283,11 @@ const CastReactions = ({ cast }: { cast: CastWithInteractions }) => {
 
   const onClickReaction = async (key: CastReactionType, isActive: boolean) => {
     if (key === CastReactionType.links) {
+      return;
+    }
+
+    if (!getIsAccountReady()) {
+      setModalOpen(true);
       return;
     }
 


### PR DESCRIPTION
## Summary
- rename various `getIsLoggedIn` calls to `getIsAccountReady`
- open sign in modal from MobileHeader
- use AppStore in Navigation, TabBar and InfoBanner
- guard Farcaster actions when unauthenticated

## Testing
- `yarn lint` *(fails: package missing from lockfile)*
- `yarn build` *(fails: package missing from lockfile)*