### PR TITLE
Fix fidget save race

### DIFF
--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -179,8 +179,10 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
       | typeof fidgetInstanceDatums
       | ((current: typeof fidgetInstanceDatums) => typeof fidgetInstanceDatums),
   ) => {
-    const datums =
-      typeof updater === "function" ? updater(fidgetInstanceDatums) : updater;
+    const currentDatums =
+      store.getState().homebase.homebaseConfig?.fidgetInstanceDatums ??
+      fidgetInstanceDatums;
+    const datums = typeof updater === "function" ? updater(currentDatums) : updater;
     return await saveConfig({
       fidgetInstanceDatums: datums,
     });


### PR DESCRIPTION
## Summary
- keep latest fidgetInstanceDatums when saving new config to avoid wiping data

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: Cannot find type definition file for 'node', 'react', 'react-dom')*