### PR TITLE
await flush operations before editing

### DIFF
--- a/src/common/components/organisms/EditorPanel.tsx
+++ b/src/common/components/organisms/EditorPanel.tsx
@@ -41,7 +41,7 @@ export interface EditorPanelProps {
   isPickingFidget: boolean;
   setIsPickingFidget: React.Dispatch<React.SetStateAction<boolean>>;
   openFidgetPicker(): void;
-  selectFidget(fidgetBundle: FidgetBundle): void;
+  selectFidget(fidgetBundle: FidgetBundle): Promise<void>;
   addFidgetToGrid(fidget: FidgetInstanceData): boolean;
 }
 

--- a/src/common/components/organisms/FidgetTray.tsx
+++ b/src/common/components/organisms/FidgetTray.tsx
@@ -21,7 +21,7 @@ export interface FidgetTrayProps {
   removeFidget(fidgetId: string): void;
   setCurrentlyDragging: React.Dispatch<React.SetStateAction<boolean>>;
   selectedFidgetID: string | null;
-  selectFidget: (fidgetBundle: FidgetBundle) => void;
+  selectFidget: (fidgetBundle: FidgetBundle) => Promise<void>;
 }
 
 export const FidgetTray: React.FC<FidgetTrayProps> = ({

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -30,7 +30,7 @@ export type FidgetWrapperProps = {
   bundle: FidgetBundle;
   context?: FidgetRenderContext;
   saveConfig: (conf: FidgetConfig) => Promise<void>;
-  flushPendingSaves: () => void;
+  flushPendingSaves: () => Promise<void> | void;
   setCurrentFidgetSettings: (currentFidgetSettings: React.ReactNode) => void;
   setSelectedFidgetID: (selectedFidgetID: string) => void;
   selectedFidgetID: string;
@@ -70,8 +70,8 @@ export function FidgetWrapper({
     homebaseConfig: state.homebase.homebaseConfig,
   }));
 
-  function onClickEdit() {
-    flushPendingSaves();
+  async function onClickEdit() {
+    await flushPendingSaves();
     setSelectedFidgetID(bundle.id);
     setCurrentFidgetSettings(
       <FidgetSettingsEditor

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -216,7 +216,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   // Debounced save function stored in a ref to ensure one instance
   const debouncedSaveConfigRef = useRef(
     debounce((patch: Parameters<typeof saveConfig>[0]) => {
-      saveConfigRef.current(patch);
+      return saveConfigRef.current(patch);
     }, 250, {
       leading: false,
       trailing: true,
@@ -224,7 +224,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   );
 
   const flushPendingSaves = useCallback(() => {
-    debouncedSaveConfigRef.current.flush();
+    return debouncedSaveConfigRef.current.flush();
   }, []);
 
   function unselectFidget() {
@@ -237,8 +237,8 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     unselectFidget();
   }
 
-  function selectFidget(bundle: FidgetBundle) {
-    flushPendingSaves();
+  async function selectFidget(bundle: FidgetBundle) {
+    await flushPendingSaves();
     const settingsWithDefaults = getSettingsWithDefaults(
       bundle.config.settings,
       bundle.properties,


### PR DESCRIPTION
## Summary
- await `flushPendingSaves` in fidget edit handlers
- return flush promise from `flushPendingSaves`
- update wrapper and tray prop types for async functions

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*