### PR TITLE
Fix: fidgets disappearing when edited

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -553,6 +553,7 @@ export default function PublicSpace({
     if (currentSpaceId && shouldSave) {
       const resolvedConfig = await config;
       await saveLocalSpaceTab(currentSpaceId, currentTabName, resolvedConfig);
+      await commitSpaceTab(currentSpaceId, currentTabName, tokenData?.network);
     }
     // Update the URL without triggering a full navigation
     router.push(getSpacePageUrl(tabName), { scroll: false });


### PR DESCRIPTION
Somehow this one line change fixes the bug where fidgets intermittently disappear when edited.

It's still possible to reproduce this if you add a new tab and then very quickly add a fidget (before the tab exists in the db?), but even in this case the tab does not get into a bad state, and users can just add the fidget again and it will work.

## Summary
- commit space tab when switching tabs

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*