### PR TITLE
[CLIENT] Ensure mobile header visible after navigation

### DIFF
--- a/src/common/providers/MobileScrollToTopProvider.tsx
+++ b/src/common/providers/MobileScrollToTopProvider.tsx
@@ -1,0 +1,17 @@
+"use client";
+import React, { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import useIsMobile from "@/common/lib/hooks/useIsMobile";
+
+export default function MobileScrollToTopProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    if (isMobile) {
+      window.scrollTo({ top: 0 });
+    }
+  }, [pathname, isMobile]);
+
+  return <>{children}</>;
+}

--- a/src/common/providers/index.tsx
+++ b/src/common/providers/index.tsx
@@ -9,6 +9,7 @@ import { AppStoreProvider } from "@/common/data/stores/app";
 import UserThemeProvider from "@/common/lib/theme/UserThemeProvider";
 import LoggedInStateProvider from "./LoggedInStateProvider";
 import AnalyticsProvider from "./AnalyticsProvider";
+import MobileScrollToTopProvider from "./MobileScrollToTopProvider";
 import VersionCheckProivder from "./VersionCheckProvider";
 import { SidebarContextProvider } from "@/common/components/organisms/Sidebar";
 import { ToastProvider } from "../components/atoms/Toast";
@@ -27,9 +28,11 @@ export default function Providers({ children }: { children: React.ReactNode }) {
                     <LoggedInStateProvider>
                       <SidebarContextProvider>
                         <AnalyticsProvider>
-                          <MiniAppSdkProvider>
-                            <ToastProvider>{children}</ToastProvider>
-                          </MiniAppSdkProvider>
+                          <MobileScrollToTopProvider>
+                            <MiniAppSdkProvider>
+                              <ToastProvider>{children}</ToastProvider>
+                            </MiniAppSdkProvider>
+                          </MobileScrollToTopProvider>
                         </AnalyticsProvider>
                       </SidebarContextProvider>
                     </LoggedInStateProvider>


### PR DESCRIPTION
## Summary
- add `MobileScrollToTopProvider` to reset scroll when the path changes on mobile
- wrap providers with the new provider to ensure `window.scrollTo` triggers on page navigation

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn check-types` *(fails: package not present in lockfile)*