### PR TITLE
Mobile: Ensure header is visible after navigation

### DIFF
--- a/src/app/(spaces)/t/[network]/MobileSpace.tsx
+++ b/src/app/(spaces)/t/[network]/MobileSpace.tsx
@@ -171,7 +171,7 @@ export const MobileContractDefinedSpace = ({
       <div className="flex flex-shrink-1 flex-row justify-center h-16 w-full z-30 bg-white">
         <TokenDataHeader />
       </div>
-      <div className="flex-1 overflow-y-scroll">
+      <div className="flex-1">
         <div
           className={cn(
             "w-full h-full overflow-hidden",

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -52,8 +52,8 @@ export default async function Explore() {
   const tokens = await fetchTokens(1);
 
   return (
-    <div className="min-h-screen max-w-screen max-h-screen h-screen w-screen p-5 overflow-y-scroll">
-      <Tabs defaultValue="spaces" className="max-h-full">
+    <div className="min-h-screen w-full p-5">
+      <Tabs defaultValue="spaces">
         <TabsList className={tabListClasses}>
           <TabsTrigger value="spaces" className={tabTriggerClasses}>
             Spaces
@@ -79,7 +79,7 @@ export default async function Explore() {
           </div>
         </TabsContent>
         <TabsContent value="tokens" className={tabContentClasses}>
-          <div className="transition-all duration-100 ease-out max-h-full overflow-y-scroll grid grid-rows-[auto_1fr]">
+          <div className="transition-all duration-100 ease-out grid grid-rows-[auto_1fr]">
             <ExploreHeader
               title="Explore Clanker Tokens"
               image="/images/clanker_galaxy.png"

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -424,7 +424,7 @@ function NotificationsPageContent() {
   );
 
   return (
-    <div className="w-full max-h-screen overflow-auto">
+    <div className="w-full min-h-screen">
       <Tabs value={tab} onValueChange={onTabChange} className="min-h-full">
         <div className="py-4 px-4 border-b">
           <h1 className="text-xl font-bold mb-6">Notifications</h1>


### PR DESCRIPTION
## Summary
- remove MobileScrollToTopProvider and revert provider wrapping
- allow document scrolling by removing custom `max-h-screen` containers
- adjust explore, notifications, and token pages to rely on normal page scroll

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn check-types` *(fails: package not present in lockfile)*