### PR TITLE
[CLIENT] Ensure mobile header visible after navigation

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,8 @@
 import bundlerAnalyzer from "@next/bundle-analyzer";
 import packageInfo from "./package.json" with { type: "json" };
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
 
 const withBundleAnalyzer = bundlerAnalyzer({
   enabled: process.env.ANALYZE === "true",
@@ -68,9 +71,18 @@ const nextConfig = {
     return [
       {
         source: "/home",
-        destination: "/home/Nouns", 
+        destination: "/home/Nouns",
       },
     ];
+  },
+
+  webpack: (config) => {
+    config.resolve = config.resolve || {};
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      "@noble/hashes/sha2": require.resolve("@noble/hashes/sha256.js"),
+    };
+    return config;
   },
   
   // async headers() {

--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -421,7 +421,7 @@ export default function PublicSpace({
 
             revalidatePath(getSpacePageUrl("Profile"));
             const newUrl = getSpacePageUrl("Profile");
-            router.replace(newUrl, { scroll: false });
+            router.replace(newUrl);
           }
 
           if (newSpaceId) {
@@ -448,7 +448,7 @@ export default function PublicSpace({
             // Update the URL to include the new space ID
             revalidatePath(getSpacePageUrl("Profile"));
             const newUrl = getSpacePageUrl("Profile");
-            router.replace(newUrl, { scroll: false });
+            router.replace(newUrl);
           }
         } catch (error) {
           console.error("Error during space registration:", error);
@@ -555,7 +555,7 @@ export default function PublicSpace({
       await saveLocalSpaceTab(currentSpaceId, currentTabName, resolvedConfig);
     }
     // Update the URL without triggering a full navigation
-    router.push(getSpacePageUrl(tabName), { scroll: false });
+    router.push(getSpacePageUrl(tabName));
   }
 
   const { editMode } = useSidebarContext();

--- a/src/app/(spaces)/t/[network]/MobileSpace.tsx
+++ b/src/app/(spaces)/t/[network]/MobileSpace.tsx
@@ -171,7 +171,7 @@ export const MobileContractDefinedSpace = ({
       <div className="flex flex-shrink-1 flex-row justify-center h-16 w-full z-30 bg-white">
         <TokenDataHeader />
       </div>
-      <div className="flex-1 overflow-y-scroll">
+      <div className="flex-1">
         <div
           className={cn(
             "w-full h-full overflow-hidden",

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -52,8 +52,8 @@ export default async function Explore() {
   const tokens = await fetchTokens(1);
 
   return (
-    <div className="min-h-screen max-w-screen max-h-screen h-screen w-screen p-5 overflow-y-scroll">
-      <Tabs defaultValue="spaces" className="max-h-full">
+    <div className="min-h-screen w-full p-5">
+      <Tabs defaultValue="spaces">
         <TabsList className={tabListClasses}>
           <TabsTrigger value="spaces" className={tabTriggerClasses}>
             Spaces
@@ -79,7 +79,7 @@ export default async function Explore() {
           </div>
         </TabsContent>
         <TabsContent value="tokens" className={tabContentClasses}>
-          <div className="transition-all duration-100 ease-out max-h-full overflow-y-scroll grid grid-rows-[auto_1fr]">
+          <div className="transition-all duration-100 ease-out grid grid-rows-[auto_1fr]">
             <ExploreHeader
               title="Explore Clanker Tokens"
               image="/images/clanker_galaxy.png"

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -424,8 +424,8 @@ function NotificationsPageContent() {
   );
 
   return (
-    <div className="w-full max-h-screen overflow-auto">
-      <Tabs value={tab} onValueChange={onTabChange} className="min-h-full">
+    <div className="min-h-screen w-full">
+      <Tabs value={tab} onValueChange={onTabChange}>
         <div className="py-4 px-4 border-b">
           <h1 className="text-xl font-bold mb-6">Notifications</h1>
           <TabsList className="grid w-full grid-cols-6 max-w-2xl">


### PR DESCRIPTION
## Summary
- remove `MobileScrollToTopProvider` and revert provider hierarchy
- allow Next.js to reset scroll position by removing `scroll: false`
- avoid page-level scroll containers so scroll resets on navigation
- alias `@noble/hashes/sha2` correctly in `next.config.mjs`

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn check-types` *(fails: package not present in lockfile)*