### PR TITLE
Fix draggable tabs in TabBar

### DIFF
--- a/src/common/components/atoms/reorderable-tab.tsx
+++ b/src/common/components/atoms/reorderable-tab.tsx
@@ -45,7 +45,11 @@ export const Tab = ({
       onPointerDown={onClick}
       dragListener={draggable}
     >
-      <Link href={getSpacePageUrl(tabName)}>
+      <Link
+        href={getSpacePageUrl(tabName)}
+        draggable={false}
+        onDragStart={(e) => e.preventDefault()}
+      >
         <div
           className={`static flex md:p-2 items-center transition-colors duration-300 group 
             ${

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -202,11 +202,13 @@ function TabBar({
         )}
         <div className="flex w-64 flex-auto justify-start h-16 z-70 bg-white pr-8 md:pr-0 flex-nowrap overflow-y-scroll">
           {tabList && (
-            <Reorder.Group<string>
+            <Reorder.Group
               as="ol"
               axis="x"
-              onReorder={updateTabOrder}
-              onDragEnd={commitTabOrder}
+              onReorder={async (newOrder) => {
+                await updateTabOrder(newOrder);
+                await commitTabOrder();
+              }}
               className="flex flex-row gap-5 md:gap-4 items-start m-4 tabs"
               values={tabList}
             >

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -206,6 +206,7 @@ function TabBar({
               as="ol"
               axis="x"
               onReorder={updateTabOrder}
+              onReorderEnd={commitTabOrder}
               className="flex flex-row gap-5 md:gap-4 items-start m-4 tabs"
               values={tabList}
             >

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -202,11 +202,11 @@ function TabBar({
         )}
         <div className="flex w-64 flex-auto justify-start h-16 z-70 bg-white pr-8 md:pr-0 flex-nowrap overflow-y-scroll">
           {tabList && (
-            <Reorder.Group
+            <Reorder.Group<string>
               as="ol"
               axis="x"
               onReorder={updateTabOrder}
-              onReorderEnd={commitTabOrder}
+              onDragEnd={commitTabOrder}
               className="flex flex-row gap-5 md:gap-4 items-start m-4 tabs"
               values={tabList}
             >

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -206,7 +206,7 @@ function TabBar({
               as="ol"
               axis="x"
               onReorder={updateTabOrder}
-              onReorderEnd={commitTabOrder}
+              onDragEnd={commitTabOrder}
               className="flex flex-row gap-5 md:gap-4 items-start m-4 tabs"
               values={tabList}
             >

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -206,7 +206,7 @@ function TabBar({
               as="ol"
               axis="x"
               onReorder={updateTabOrder}
-              onDragEnd={commitTabOrder}
+              onReorderEnd={commitTabOrder}
               className="flex flex-row gap-5 md:gap-4 items-start m-4 tabs"
               values={tabList}
             >

--- a/src/common/data/stores/app/homebase/homebaseTabsStore.ts
+++ b/src/common/data/stores/app/homebase/homebaseTabsStore.ts
@@ -116,11 +116,8 @@ export const createHomeBaseTabStoreFunc = (
 ): HomeBaseTabStore => ({
   ...homeBaseStoreDefaults,
   updateTabOrdering(newOrdering, commit = false) {
-    const filtered = newOrdering.filter((name, index) => {
-      return name !== "Feed" && newOrdering.indexOf(name) === index;
-    });
     set((draft) => {
-      draft.homebase.tabOrdering.local = filtered;
+      draft.homebase.tabOrdering.local = newOrdering;
     }, "updateTabOrdering");
     if (commit) {
       get().homebase.commitTabOrderingToDatabase();

--- a/src/common/data/stores/app/homebase/homebaseTabsStore.ts
+++ b/src/common/data/stores/app/homebase/homebaseTabsStore.ts
@@ -116,13 +116,11 @@ export const createHomeBaseTabStoreFunc = (
 ): HomeBaseTabStore => ({
   ...homeBaseStoreDefaults,
   updateTabOrdering(newOrdering, commit = false) {
-    // console.log('Updating tab ordering:', {
-    //   newOrder: newOrdering,
-    //   commit
-    // });
-    
+    const filtered = newOrdering.filter((name, index) => {
+      return name !== "Feed" && newOrdering.indexOf(name) === index;
+    });
     set((draft) => {
-      draft.homebase.tabOrdering.local = newOrdering;
+      draft.homebase.tabOrdering.local = filtered;
     }, "updateTabOrdering");
     if (commit) {
       get().homebase.commitTabOrderingToDatabase();
@@ -173,7 +171,11 @@ export const createHomeBaseTabStoreFunc = (
     }
   },
   commitTabOrderingToDatabase: debounce(async () => {
-    const localCopy = cloneDeep(get().homebase.tabOrdering.local);
+    const localCopy = cloneDeep(
+      get().homebase.tabOrdering.local.filter((name, i, arr) =>
+        name !== "Feed" && arr.indexOf(name) === i,
+      ),
+    );
     if (localCopy) {
       // console.log('Committing tab ordering to database:', {
       //   tabCount: localCopy.length,

--- a/src/common/data/stores/app/homebase/homebaseTabsStore.ts
+++ b/src/common/data/stores/app/homebase/homebaseTabsStore.ts
@@ -139,7 +139,10 @@ export const createHomeBaseTabStoreFunc = (
         `${homebaseTabOrderPath(get().account.currentSpaceIdentityPublicKey!)}`,
       );
     try {
-      const { data } = await axios.get<Blob>(publicUrl, {
+      const t = Math.random().toString(36).substring(2);
+      const urlWithParam = `${publicUrl}?t=${t}`;
+
+      const { data } = await axios.get<Blob>(urlWithParam, {
         responseType: "blob",
         headers: {
           "Cache-Control": "no-cache",

--- a/src/common/types/framer-motion.d.ts
+++ b/src/common/types/framer-motion.d.ts
@@ -1,0 +1,9 @@
+import 'framer-motion';
+
+declare module 'framer-motion' {
+  namespace Reorder {
+    interface Props<V> {
+      onReorderEnd?: () => void;
+    }
+  }
+}

--- a/src/common/types/framer-motion.d.ts
+++ b/src/common/types/framer-motion.d.ts
@@ -1,9 +1,0 @@
-import 'framer-motion';
-
-declare module 'framer-motion' {
-  namespace Reorder {
-    interface Props<V> {
-      onReorderEnd?: () => void;
-    }
-  }
-}


### PR DESCRIPTION
## Summary
- disable anchor drag events in `ReorderableTab`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*