### PR TITLE
[CLIENT] Ensure mobile header visible after navigation

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,5 @@
 import bundlerAnalyzer from "@next/bundle-analyzer";
+import { createRequire } from "node:module";
 import packageInfo from "./package.json" with { type: "json" };
 
 const withBundleAnalyzer = bundlerAnalyzer({
@@ -90,6 +91,15 @@ const nextConfig = {
   //     },
   //   ];
   // },
+  webpack: (config) => {
+    const require = createRequire(import.meta.url);
+    config.resolve = config.resolve || {};
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      "@noble/hashes/sha2": require.resolve("@noble/hashes/sha256.js"),
+    };
+    return config;
+  },
 };
 
 export default withBundleAnalyzer(nextConfig);

--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -421,7 +421,7 @@ export default function PublicSpace({
 
             revalidatePath(getSpacePageUrl("Profile"));
             const newUrl = getSpacePageUrl("Profile");
-            router.replace(newUrl, { scroll: false });
+            router.replace(newUrl);
           }
 
           if (newSpaceId) {
@@ -448,7 +448,7 @@ export default function PublicSpace({
             // Update the URL to include the new space ID
             revalidatePath(getSpacePageUrl("Profile"));
             const newUrl = getSpacePageUrl("Profile");
-            router.replace(newUrl, { scroll: false });
+            router.replace(newUrl);
           }
         } catch (error) {
           console.error("Error during space registration:", error);
@@ -555,7 +555,7 @@ export default function PublicSpace({
       await saveLocalSpaceTab(currentSpaceId, currentTabName, resolvedConfig);
     }
     // Update the URL without triggering a full navigation
-    router.push(getSpacePageUrl(tabName), { scroll: false });
+    router.push(getSpacePageUrl(tabName));
   }
 
   const { editMode } = useSidebarContext();

--- a/src/app/(spaces)/t/[network]/MobileSpace.tsx
+++ b/src/app/(spaces)/t/[network]/MobileSpace.tsx
@@ -171,7 +171,7 @@ export const MobileContractDefinedSpace = ({
       <div className="flex flex-shrink-1 flex-row justify-center h-16 w-full z-30 bg-white">
         <TokenDataHeader />
       </div>
-      <div className="flex-1 overflow-y-scroll">
+      <div className="flex-1">
         <div
           className={cn(
             "w-full h-full overflow-hidden",

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -52,8 +52,8 @@ export default async function Explore() {
   const tokens = await fetchTokens(1);
 
   return (
-    <div className="min-h-screen max-w-screen max-h-screen h-screen w-screen p-5 overflow-y-scroll">
-      <Tabs defaultValue="spaces" className="max-h-full">
+    <div className="min-h-screen w-screen p-5">
+      <Tabs defaultValue="spaces">
         <TabsList className={tabListClasses}>
           <TabsTrigger value="spaces" className={tabTriggerClasses}>
             Spaces
@@ -63,8 +63,8 @@ export default async function Explore() {
           </TabsTrigger>
         </TabsList>
         <TabsContent value="spaces" className={tabContentClasses}>
-          <div className="flex w-full h-full">
-            <div className="w-full transition-all duration-100 ease-out h-full grid grid-rows-[auto_1fr]">
+          <div className="flex w-full">
+            <div className="w-full transition-all duration-100 ease-out grid grid-rows-[auto_1fr]">
               <ExploreHeader
                 title="Explore Featured Spaces"
                 image="/images/rainforest.png"
@@ -79,7 +79,7 @@ export default async function Explore() {
           </div>
         </TabsContent>
         <TabsContent value="tokens" className={tabContentClasses}>
-          <div className="transition-all duration-100 ease-out max-h-full overflow-y-scroll grid grid-rows-[auto_1fr]">
+          <div className="transition-all duration-100 ease-out grid grid-rows-[auto_1fr]">
             <ExploreHeader
               title="Explore Clanker Tokens"
               image="/images/clanker_galaxy.png"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,7 +72,7 @@ export default function RootLayout({
 const sidebarLayout = (page: React.ReactNode) => {
   return (
     <>
-      <div className="min-h-screen max-w-screen h-screen w-screen flex flex-col">
+      <div className="min-h-screen w-screen flex flex-col">
         {/* App Navigation Bar */}
         <div className="w-full flex-shrink-0">
           <ClientHeaderWrapper />

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -424,8 +424,8 @@ function NotificationsPageContent() {
   );
 
   return (
-    <div className="w-full max-h-screen overflow-auto">
-      <Tabs value={tab} onValueChange={onTabChange} className="min-h-full">
+    <div className="w-full min-h-screen">
+      <Tabs value={tab} onValueChange={onTabChange}>
         <div className="py-4 px-4 border-b">
           <h1 className="text-xl font-bold mb-6">Notifications</h1>
           <TabsList className="grid w-full grid-cols-6 max-w-2xl">

--- a/src/common/providers/MobileScrollToTopProvider.tsx
+++ b/src/common/providers/MobileScrollToTopProvider.tsx
@@ -1,0 +1,17 @@
+"use client";
+import React, { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import useIsMobile from "@/common/lib/hooks/useIsMobile";
+
+export default function MobileScrollToTopProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    if (isMobile) {
+      window.scrollTo({ top: 0 });
+    }
+  }, [pathname, isMobile]);
+
+  return <>{children}</>;
+}

--- a/src/common/providers/index.tsx
+++ b/src/common/providers/index.tsx
@@ -9,6 +9,7 @@ import { AppStoreProvider } from "@/common/data/stores/app";
 import UserThemeProvider from "@/common/lib/theme/UserThemeProvider";
 import LoggedInStateProvider from "./LoggedInStateProvider";
 import AnalyticsProvider from "./AnalyticsProvider";
+import MobileScrollToTopProvider from "./MobileScrollToTopProvider";
 import VersionCheckProivder from "./VersionCheckProvider";
 import { SidebarContextProvider } from "@/common/components/organisms/Sidebar";
 import { ToastProvider } from "../components/atoms/Toast";
@@ -27,9 +28,11 @@ export default function Providers({ children }: { children: React.ReactNode }) {
                     <LoggedInStateProvider>
                       <SidebarContextProvider>
                         <AnalyticsProvider>
-                          <MiniAppSdkProvider>
-                            <ToastProvider>{children}</ToastProvider>
-                          </MiniAppSdkProvider>
+                          <MobileScrollToTopProvider>
+                            <MiniAppSdkProvider>
+                              <ToastProvider>{children}</ToastProvider>
+                            </MiniAppSdkProvider>
+                          </MobileScrollToTopProvider>
                         </AnalyticsProvider>
                       </SidebarContextProvider>
                     </LoggedInStateProvider>


### PR DESCRIPTION
## Summary
- add webpack alias using `createRequire` for `@noble/hashes/sha2`
- remove scroll suppression in PublicSpace
- let mobile pages use window scroll instead of fixed containers
- remove full-screen wrappers on pages so header starts at top

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn check-types` *(fails: package not present in lockfile)*