### PR TITLE
Fix homebase tab order persistence

### DIFF
--- a/src/common/components/atoms/reorderable-tab.tsx
+++ b/src/common/components/atoms/reorderable-tab.tsx
@@ -45,7 +45,11 @@ export const Tab = ({
       onPointerDown={onClick}
       dragListener={draggable}
     >
-      <Link href={getSpacePageUrl(tabName)}>
+      <Link
+        href={getSpacePageUrl(tabName)}
+        draggable={false}
+        onDragStart={(e) => e.preventDefault()}
+      >
         <div
           className={`static flex md:p-2 items-center transition-colors duration-300 group 
             ${

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -206,6 +206,7 @@ function TabBar({
               as="ol"
               axis="x"
               onReorder={updateTabOrder}
+              onDragEnd={() => commitTabOrder()}
               className="flex flex-row gap-5 md:gap-4 items-start m-4 tabs"
               values={tabList}
             >


### PR DESCRIPTION
## Summary
- prevent anchor dragging in tabs so they reorder properly
- commit homebase tab order after drag ends

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*