### PR TITLE
[FIDGET] Add Portfolio Fidget

### DIFF
--- a/src/common/components/organisms/FidgetSettingsEditor.tsx
+++ b/src/common/components/organisms/FidgetSettingsEditor.tsx
@@ -79,7 +79,7 @@ export const FidgetSettingsRow: React.FC<FidgetSettingsRowProps> = ({
       id={id}
     >
       <div className="md:mb-0 md:w-full flex items-center justify-between gap-2">
-        <label className="capitalize text-sm font-medium text-gray-900 dark:text-white">
+        <label className="text-sm font-medium text-gray-900 dark:text-white">
           {field.displayName || field.fieldName}
         </label>
         {field.displayNameHint && (

--- a/src/fidgets/index.ts
+++ b/src/fidgets/index.ts
@@ -16,6 +16,7 @@ import Swap from "./swap/Swap";
 import rss from "./ui/rss";
 import VideoFidget from "./ui/Video";
 import marketData from "./token/marketData";
+import Portfolio from "./token/Portfolio";
 import chat from "./ui/chat";
 import TabFullScreen from "./layout/tabFullScreen";
 // import iframely from "./ui/iframely";
@@ -45,6 +46,7 @@ export const CompleteFidgets = {
   Rss: rss,
   Video: VideoFidget,
   Market: marketData,
+  Portfolio: Portfolio,
   Chat: chat,
 };
 

--- a/src/fidgets/token/Portfolio.tsx
+++ b/src/fidgets/token/Portfolio.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+import TextInput from "@/common/components/molecules/TextInput";
+import SettingsSelector from "@/common/components/molecules/SettingsSelector";
+import {
+  FidgetArgs,
+  FidgetModule,
+  FidgetProperties,
+  type FidgetSettingsStyle,
+} from "@/common/fidgets";
+import { defaultStyleFields, WithMargin } from "@/fidgets/helpers";
+import { GiTwoCoins } from "react-icons/gi";
+
+export type PortfolioFidgetSettings = {
+  trackType: "farcaster" | "address";
+  farcasterUsername: string;
+  walletAddresses: string;
+} & FidgetSettingsStyle;
+
+const styleFields = defaultStyleFields.filter((field) =>
+  ["fidgetBorderColor", "fidgetBorderWidth", "fidgetShadow"].includes(
+    field.fieldName,
+  ),
+);
+
+const portfolioProperties: FidgetProperties = {
+  fidgetName: "Portfolio",
+  icon: 0x1f4b0, // 💰
+  mobileIcon: <GiTwoCoins size={20} />,
+  fields: [
+    {
+      fieldName: "trackType",
+      displayName: "Wallet(s) to track",
+      default: "farcaster",
+      required: true,
+      inputSelector: (props) => (
+        <WithMargin>
+          <SettingsSelector
+            {...props}
+            settings={[
+              { name: "Farcaster username", value: "farcaster" },
+              { name: "Wallet Address(es)", value: "address" },
+            ]}
+          />
+        </WithMargin>
+      ),
+      group: "settings",
+    },
+    {
+      fieldName: "farcasterUsername",
+      displayName: "Username",
+      default: "nounspaceTom",
+      required: false,
+      disabledIf: (settings) => settings.trackType !== "farcaster",
+      inputSelector: (props) => (
+        <WithMargin>
+          <TextInput {...props} />
+        </WithMargin>
+      ),
+      group: "settings",
+    },
+    {
+      fieldName: "walletAddresses",
+      displayName: "Address(es)",
+      default: "0x06AE622bF2029Db79Bdebd38F723f1f33f95F6C5",
+      required: false,
+      disabledIf: (settings) => settings.trackType !== "address",
+      inputSelector: (props) => (
+        <WithMargin>
+          <TextInput {...props} />
+        </WithMargin>
+      ),
+      group: "settings",
+    },
+    ...styleFields,
+  ],
+  size: {
+    minHeight: 2,
+    maxHeight: 36,
+    minWidth: 2,
+    maxWidth: 36,
+  },
+};
+
+const Portfolio: React.FC<FidgetArgs<PortfolioFidgetSettings>> = ({
+  settings,
+}) => {
+  const {
+    trackType,
+    farcasterUsername,
+    walletAddresses,
+    fidgetBorderColor,
+    fidgetBorderWidth,
+    fidgetShadow,
+  } = settings;
+
+  const baseUrl = "https://balance-fidget.replit.app";
+  const url =
+    trackType === "address"
+      ? `${baseUrl}/portfolio/${encodeURIComponent(walletAddresses)}`
+      : trackType === "farcaster"
+        ? `${baseUrl}/fc/${encodeURIComponent(farcasterUsername)}`
+        : baseUrl;
+
+  return (
+    <div
+      style={{
+        overflow: "hidden",
+        width: "100%",
+        height: "100%",
+        borderColor: fidgetBorderColor,
+        borderWidth: fidgetBorderWidth,
+        boxShadow: fidgetShadow,
+      }}
+    >
+      <iframe src={url} className="size-full" frameBorder="0" />
+    </div>
+  );
+};
+
+export default {
+  fidget: Portfolio,
+  properties: portfolioProperties,
+} as FidgetModule<FidgetArgs<PortfolioFidgetSettings>>;
+

--- a/src/fidgets/token/Portfolio.tsx
+++ b/src/fidgets/token/Portfolio.tsx
@@ -29,7 +29,7 @@ const portfolioProperties: FidgetProperties = {
   fields: [
     {
       fieldName: "trackType",
-      displayName: "Wallet(\u200Bs) to track",
+      displayName: "Wallet(\u2060s) to track",
       default: "farcaster",
       required: true,
       inputSelector: (props) => (
@@ -61,7 +61,7 @@ const portfolioProperties: FidgetProperties = {
     },
     {
       fieldName: "walletAddresses",
-      displayName: "Address(\u200Bes)",
+      displayName: "Address(\u2060es)",
       default: "0x06AE622bF2029Db79Bdebd38F723f1f33f95F6C5",
       required: false,
       disabledIf: (settings) => settings.trackType !== "address",

--- a/src/fidgets/token/Portfolio.tsx
+++ b/src/fidgets/token/Portfolio.tsx
@@ -35,8 +35,8 @@ const portfolioProperties: FidgetProperties = {
       inputSelector: (props) => (
         <WithMargin>
           <SettingsSelector
-            className="[&_label]:normal-case"
             {...props}
+            className="[&_label]:!normal-case"
             settings={[
               { name: "Farcaster username", value: "farcaster" },
               { name: "Wallet Address(es)", value: "address" },
@@ -56,7 +56,7 @@ const portfolioProperties: FidgetProperties = {
         <WithMargin>
           <TextInput
             {...props}
-            className="[&_label]:normal-case"
+            className="[&_label]:!normal-case"
           />
         </WithMargin>
       ),
@@ -72,7 +72,7 @@ const portfolioProperties: FidgetProperties = {
         <WithMargin>
           <TextInput
             {...props}
-            className="[&_label]:normal-case"
+            className="[&_label]:!normal-case"
           />
         </WithMargin>
       ),

--- a/src/fidgets/token/Portfolio.tsx
+++ b/src/fidgets/token/Portfolio.tsx
@@ -29,8 +29,7 @@ const portfolioProperties: FidgetProperties = {
   fields: [
     {
       fieldName: "trackType",
-      // wrap in a span that removes the inherited `capitalize`
-      displayName: <span className="normal-case">Wallet(s) to track</span>,
+      displayName: "Wallet(\u200Bs) to track",
       default: "farcaster",
       required: true,
       inputSelector: (props) => (
@@ -55,20 +54,20 @@ const portfolioProperties: FidgetProperties = {
       disabledIf: (settings) => settings.trackType !== "farcaster",
       inputSelector: (props) => (
         <WithMargin>
-           <TextInput {...props} className="normal-case" />
+          <TextInput {...props} />
         </WithMargin>
       ),
       group: "settings",
     },
     {
       fieldName: "walletAddresses",
-      displayName: "Address(es)",
+      displayName: "Address(\u200Bes)",
       default: "0x06AE622bF2029Db79Bdebd38F723f1f33f95F6C5",
       required: false,
       disabledIf: (settings) => settings.trackType !== "address",
       inputSelector: (props) => (
         <WithMargin>
-          <TextInput {...props} className="normal-case" />
+          <TextInput {...props} />
         </WithMargin>
       ),
       group: "settings",

--- a/src/fidgets/token/Portfolio.tsx
+++ b/src/fidgets/token/Portfolio.tsx
@@ -29,12 +29,14 @@ const portfolioProperties: FidgetProperties = {
   fields: [
     {
       fieldName: "trackType",
-      displayName: "Wallet(s) to track",
+      // wrap in a span that removes the inherited `capitalize`
+      displayName: <span className="normal-case">Wallet(s) to track</span>,
       default: "farcaster",
       required: true,
       inputSelector: (props) => (
         <WithMargin>
           <SettingsSelector
+            className="normal-case"
             {...props}
             settings={[
               { name: "Farcaster username", value: "farcaster" },
@@ -48,12 +50,12 @@ const portfolioProperties: FidgetProperties = {
     {
       fieldName: "farcasterUsername",
       displayName: "Username",
-      default: "nounspaceTom",
+      default: "nounspacetom",
       required: false,
       disabledIf: (settings) => settings.trackType !== "farcaster",
       inputSelector: (props) => (
         <WithMargin>
-          <TextInput {...props} />
+           <TextInput {...props} className="normal-case" />
         </WithMargin>
       ),
       group: "settings",
@@ -66,7 +68,7 @@ const portfolioProperties: FidgetProperties = {
       disabledIf: (settings) => settings.trackType !== "address",
       inputSelector: (props) => (
         <WithMargin>
-          <TextInput {...props} />
+          <TextInput {...props} className="normal-case" />
         </WithMargin>
       ),
       group: "settings",

--- a/src/fidgets/token/Portfolio.tsx
+++ b/src/fidgets/token/Portfolio.tsx
@@ -29,13 +29,13 @@ const portfolioProperties: FidgetProperties = {
   fields: [
     {
       fieldName: "trackType",
-      displayName: "Wallet(\u2060s) to track",
+      displayName: "Wallet(s) to track",
       default: "farcaster",
       required: true,
       inputSelector: (props) => (
         <WithMargin>
           <SettingsSelector
-            className="normal-case"
+            className="[&_label]:normal-case"
             {...props}
             settings={[
               { name: "Farcaster username", value: "farcaster" },
@@ -54,20 +54,26 @@ const portfolioProperties: FidgetProperties = {
       disabledIf: (settings) => settings.trackType !== "farcaster",
       inputSelector: (props) => (
         <WithMargin>
-          <TextInput {...props} />
+          <TextInput
+            {...props}
+            className="[&_label]:normal-case"
+          />
         </WithMargin>
       ),
       group: "settings",
     },
     {
       fieldName: "walletAddresses",
-      displayName: "Address(\u2060es)",
+      displayName: "Address(es)",
       default: "0x06AE622bF2029Db79Bdebd38F723f1f33f95F6C5",
       required: false,
       disabledIf: (settings) => settings.trackType !== "address",
       inputSelector: (props) => (
         <WithMargin>
-          <TextInput {...props} />
+          <TextInput
+            {...props}
+            className="[&_label]:normal-case"
+          />
         </WithMargin>
       ),
       group: "settings",
@@ -75,9 +81,9 @@ const portfolioProperties: FidgetProperties = {
     ...styleFields,
   ],
   size: {
-    minHeight: 2,
+    minHeight: 3,
     maxHeight: 36,
-    minWidth: 2,
+    minWidth: 3,
     maxWidth: 36,
   },
 };

--- a/src/fidgets/token/marketData.tsx
+++ b/src/fidgets/token/marketData.tsx
@@ -33,6 +33,7 @@ const frameConfig: FidgetProperties = {
   fields: [
     {
       fieldName: "chain",
+      displayName: "Chain",
       required: true,
       default: { id: "8453", name: "base" },
       inputSelector: (props) => (
@@ -46,6 +47,7 @@ const frameConfig: FidgetProperties = {
     },
     {
       fieldName: "token",
+      displayName: "Token",
       required: true,
       default: "0x0DF1B77aAFEc59E926315e5234db3Fdea419d4E4",
       inputSelector: (props) => (


### PR DESCRIPTION
The Portfolio fidget enables users to track the balance and performance of any wallet address(es) or any Farcaster user by username.

To track more than one wallet, you can enter a list of wallet addresses separated by commas. If you populate the Portfolio fidget with a Farcaster username, all of the verified addresses for that FID are automatically tracked.

To-do: add tooltip to the "Wallet Address(es)" setting explaining that users can track multiple wallets by inputting them as a CSV with no spaces. OR, even better, let users click 'Add Address' to add a new address, or an X button to delete addresses from the list (like the link fidget)

## Summary
- add Portfolio fidget for tracking balances
- export Portfolio fidget in fidget index

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*