### PR TITLE
Fix TabBar reorder typing error

### DIFF
--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -202,11 +202,11 @@ function TabBar({
         )}
         <div className="flex w-64 flex-auto justify-start h-16 z-70 bg-white pr-8 md:pr-0 flex-nowrap overflow-y-scroll">
           {tabList && (
-            <Reorder.Group
+            <Reorder.Group<string>
               as="ol"
               axis="x"
               onReorder={updateTabOrder}
-              onReorderEnd={commitTabOrder}
+              onDragEnd={commitTabOrder}
               className="flex flex-row gap-5 md:gap-4 items-start m-4 tabs"
               values={tabList}
             >


### PR DESCRIPTION
## Summary
- correct `Reorder.Group` props in `TabBar`
- use `onDragEnd` for committing tab order
- specify `string` generic for the reorder group

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*