### PR TITLE
Fix homebase tab order persistence

### DIFF
--- a/src/common/data/stores/app/homebase/homebaseTabsStore.ts
+++ b/src/common/data/stores/app/homebase/homebaseTabsStore.ts
@@ -116,13 +116,11 @@ export const createHomeBaseTabStoreFunc = (
 ): HomeBaseTabStore => ({
   ...homeBaseStoreDefaults,
   updateTabOrdering(newOrdering, commit = false) {
-    // console.log('Updating tab ordering:', {
-    //   newOrder: newOrdering,
-    //   commit
-    // });
-    
+    const filtered = newOrdering.filter((name, index) => {
+      return name !== "Feed" && newOrdering.indexOf(name) === index;
+    });
     set((draft) => {
-      draft.homebase.tabOrdering.local = newOrdering;
+      draft.homebase.tabOrdering.local = filtered;
     }, "updateTabOrdering");
     if (commit) {
       get().homebase.commitTabOrderingToDatabase();
@@ -173,7 +171,11 @@ export const createHomeBaseTabStoreFunc = (
     }
   },
   commitTabOrderingToDatabase: debounce(async () => {
-    const localCopy = cloneDeep(get().homebase.tabOrdering.local);
+    const localCopy = cloneDeep(
+      get().homebase.tabOrdering.local.filter((name, i, arr) =>
+        name !== "Feed" && arr.indexOf(name) === i,
+      ),
+    );
     if (localCopy) {
       // console.log('Committing tab ordering to database:', {
       //   tabCount: localCopy.length,


### PR DESCRIPTION
## Summary
- prevent the `Feed` tab from being saved in `tabOrdering`
- filter permanent tabs when committing homebase tab order

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing `node`/`react` type definitions)*