### PR TITLE
Update TabBar reorder handler

### DIFF
--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -206,7 +206,7 @@ function TabBar({
               as="ol"
               axis="x"
               onReorder={updateTabOrder}
-              onDragEnd={commitTabOrder}
+              onReorderEnd={commitTabOrder}
               className="flex flex-row gap-5 md:gap-4 items-start m-4 tabs"
               values={tabList}
             >

--- a/src/common/types/framer-motion.d.ts
+++ b/src/common/types/framer-motion.d.ts
@@ -1,0 +1,9 @@
+import 'framer-motion';
+
+declare module 'framer-motion' {
+  interface Props<T> {
+    onReorderEnd?: () => void;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- trigger `commitTabOrder` on `onReorderEnd`
- extend framer-motion Props type to support `onReorderEnd`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*