### PR TITLE
Allow tab bar to scroll away on mobile

### DIFF
--- a/src/app/(spaces)/MobileView.tsx
+++ b/src/app/(spaces)/MobileView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Tabs, TabsContent } from "@/common/components/atoms/tabs";
-import { MOBILE_PADDING, TAB_HEIGHT } from "@/constants/layout";
+import { MOBILE_PADDING } from "@/constants/layout";
 import { FidgetConfig, FidgetBundle, FidgetInstanceData } from "@/common/fidgets";
 import { UserTheme } from "@/common/lib/theme";
 import { createFidgetBundle } from "@/fidgets/layout/tabFullScreen/utils";
@@ -111,13 +111,8 @@ const MobileView: React.FC<MobileViewProps> = ({
   
   return (
     <div className="flex flex-col h-full relative">
-      {/* Main content area with padding-bottom to make space for fixed navbar */}
-      <div 
-        className="w-full h-full overflow-hidden" 
-        style={{ 
-          paddingBottom: processedFidgetIds.length > 1 ? `${TAB_HEIGHT}px` : '0',
-        }}
-      >
+      {/* Main content area */}
+      <div className="w-full h-full overflow-hidden">
         <Tabs 
           value={selectedTab}
           className="w-full h-full"

--- a/src/common/components/organisms/MobileNavbar.tsx
+++ b/src/common/components/organisms/MobileNavbar.tsx
@@ -25,7 +25,7 @@ interface MobileNavbarProps {
 }
 
 /**
- * A responsive mobile navigation bar that displays as a fixed bar at the bottom of the screen
+ * A responsive mobile navigation bar that sits at the bottom of the screen
  * with scrollable tabs. Features accessibility support and theme integration.
  * 
  * @param props.tabs - Array of tab items to render
@@ -297,7 +297,7 @@ const MobileNavbar: React.FC<MobileNavbarProps> = ({
       value={selected}
       onValueChange={onSelect}
       className={mergeClasses(
-        "fixed bottom-0 left-0 right-0 w-full h-[72px] bg-white border-t border-gray-200 z-50",
+        "w-full h-[72px] bg-white border-t border-gray-200 z-50",
         className
       )}
       style={{

--- a/src/fidgets/layout/tabFullScreen/index.tsx
+++ b/src/fidgets/layout/tabFullScreen/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect } from "react";
 import { TabsContent, Tabs } from "@/common/components/atoms/tabs";
-import { MOBILE_PADDING, TAB_HEIGHT } from "@/constants/layout";
+import { MOBILE_PADDING } from "@/constants/layout";
 import useIsMobile from "@/common/lib/hooks/useIsMobile";
 import { usePathname } from "next/navigation";
 import { 
@@ -120,13 +120,8 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
 
   return (
     <div className="flex flex-col h-full relative">
-      {/* Main content area with padding-bottom to make space for fixed tabs */}
-      <div 
-        className="w-full h-full overflow-hidden" 
-        style={{ 
-          paddingBottom: processedFidgetIds.length > 1 ? `${TAB_HEIGHT}px` : '0',
-        }}
-      >
+      {/* Main content area */}
+      <div className="w-full h-full overflow-hidden">
         <Tabs 
           value={selectedTab}
           className="w-full h-full"


### PR DESCRIPTION
## Summary
- allow mobile tab bar to scroll with content instead of being fixed
- remove unnecessary bottom padding from mobile views

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*