### PR TITLE
Fix framer-motion Group type

### DIFF
--- a/src/common/types/framer-motion.d.ts
+++ b/src/common/types/framer-motion.d.ts
@@ -2,7 +2,7 @@ import 'framer-motion';
 
 declare module 'framer-motion' {
   namespace Reorder {
-    interface Props<V> {
+    interface GroupProps<V> {
       onReorderEnd?: () => void;
     }
   }


### PR DESCRIPTION
## Summary
- fix type augmentation for `Reorder.Group` so custom `onReorderEnd` prop compiles

## Testing
- `npm run check-types` *(fails: Cannot find type definition file for 'node', 'react', 'react-dom')*
- `npm run lint` *(fails: `next` not found)*