### PR TITLE
Fix tab bar scrolling

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -170,10 +170,10 @@ export default function Space({
   [config?.layoutDetails?.layoutConfig]);
 
   return (
-    <div className="user-theme-background w-full h-full relative flex-col">
+    <div className="user-theme-background w-full min-h-screen relative flex-col">
       <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
       <div className="w-full transition-all duration-100 ease-out">
-        <div className="flex flex-col h-full">
+        <div className="flex flex-col min-h-screen">
           <div style={{ position: "fixed", zIndex: 9999 }}>
             <InfoToast />
           </div>
@@ -185,12 +185,12 @@ export default function Space({
             <Suspense fallback={<TabBarSkeleton />}>{tabBar}</Suspense>
           </div>
 
-          <div className={isMobile ? "w-full h-full" : "flex h-full"}>
+          <div className={isMobile ? "w-full" : "flex"}>
             {!isUndefined(feed) && !isMobile ? (
-              <div className="w-6/12 h-[calc(100vh-64px)]">{feed}</div>
+              <div className="w-6/12">{feed}</div>
             ) : null}
 
-            <div className={isMobile ? "w-full h-full" : "grow"}>
+            <div className={isMobile ? "w-full" : "grow"}>
               <Suspense
                 fallback={
                   <SpaceLoading

--- a/src/app/(spaces)/SpaceLoading.tsx
+++ b/src/app/(spaces)/SpaceLoading.tsx
@@ -16,9 +16,9 @@ export default function SpaceLoading({ hasProfile, hasFeed }) {
 
   return (
     <>
-      <div className="user-theme-background w-full h-full relative flex-col">
+      <div className="user-theme-background w-full min-h-screen relative flex-col">
         <div className="w-full transition-all duration-100 ease-out">
-          <div className="h-full flex flex-col">
+          <div className="flex flex-col min-h-screen">
             <div className="flex-1 grid-container grow">
               <div
                 className="relative grid-overlap w-full h-full opacity-50"

--- a/src/app/(spaces)/homebase/PrivateSpace.tsx
+++ b/src/app/(spaces)/homebase/PrivateSpace.tsx
@@ -227,11 +227,11 @@ function PrivateSpace({ tabName }: { tabName: string }) {
   // If not logged in, show a loading state with the login modal
   if (!isLoggedIn) {
     return (
-      <div className="user-theme-background w-full h-full relative flex-col">
+      <div className="user-theme-background w-full min-h-screen relative flex-col">
         <div className="w-full transition-all duration-100 ease-out">
-          <div className="flex flex-col h-full">
+          <div className="flex flex-col min-h-screen">
             <TabBarSkeleton />
-            <div className="flex h-full">
+            <div className="flex">
               <div className={"grow"}>
                 <SpaceLoading hasProfile={false} hasFeed={tabName === "Feed"} />
               </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -79,7 +79,7 @@ const sidebarLayout = (page: React.ReactNode) => {
         </div>
 
         {/* Main Content with Sidebar */}
-        <div className="flex w-full h-full flex-grow">
+        <div className="flex w-full flex-grow">
           <div className="mx-auto transition-all duration-100 ease-out z-10 hidden md:block">
             <ClientSidebarWrapper />
           </div>

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -194,13 +194,15 @@ function TabBar({
 
   return (
     <TooltipProvider>
-      <div className="flex flex-col md:flex-row justify-start md:h-16 z-50 bg-white">
+      <div
+        className="sticky top-14 md:static z-40 flex flex-col md:flex-row justify-start md:h-16 bg-white"
+      >
         {isTokenPage && contractAddress && (
           <div className="flex flex-row justify-start h-16 overflow-y-scroll w-full z-30 bg-white">
             <TokenDataHeader />
           </div>
         )}
-        <div className="flex w-64 flex-auto justify-start h-16 z-70 bg-white pr-8 md:pr-0 flex-nowrap overflow-y-scroll">
+        <div className="flex w-64 flex-auto justify-start h-16 z-40 bg-white pr-8 md:pr-0 flex-nowrap overflow-y-scroll">
           {tabList && (
             <Reorder.Group
               as="ol"

--- a/src/common/components/organisms/TabBarSkeleton.tsx
+++ b/src/common/components/organisms/TabBarSkeleton.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const TabBarSkeleton: React.FC = () => {
   return (
-    <div className="flex flex-row justify-center h-16 overflow-y-scroll w-full z-50 bg-white">
+    <div className="sticky top-14 md:static z-40 flex flex-row justify-center h-16 overflow-y-scroll w-full bg-white">
       <div className="flex flex-row gap-4 grow items-start m-4 tabs">
         {Array.from({ length: 5 }).map((_, index) => (
           <div


### PR DESCRIPTION
## Summary
- let TabBar stick with its contents using `sticky top-14`
- keep skeleton layout consistent with sticky behavior

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition file)*