### PR TITLE
Fix upload handler type

### DIFF
--- a/src/pages/api/images/upload.ts
+++ b/src/pages/api/images/upload.ts
@@ -1,24 +1,35 @@
 import { NextApiRequest, NextApiResponse } from "next/types";
-import requestHandler from "@/common/data/api/requestHandler";
+import requestHandler, {
+  NounspaceResponse,
+} from "@/common/data/api/requestHandler";
 
-export type ImageUploadResponse = {
-  url?: string;
-  error?: string;
-};
+export type ImageUploadResponse = NounspaceResponse<{ url: string }>;
 
-async function uploadImage(req: NextApiRequest, res: NextApiResponse<ImageUploadResponse>) {
+async function uploadImage(
+  req: NextApiRequest,
+  res: NextApiResponse<ImageUploadResponse>,
+) {
   if (req.method !== "POST") {
-    return res.status(405).json({ error: "Method not allowed" });
+    return res.status(405).json({
+      result: "error",
+      error: { message: "Method not allowed" },
+    });
   }
 
   const { image } = req.body as { image?: string };
   if (!image) {
-    return res.status(400).json({ error: "Missing image" });
+    return res.status(400).json({
+      result: "error",
+      error: { message: "Missing image" },
+    });
   }
 
   const apiKey = process.env.NEXT_PUBLIC_IMGBB_API_KEY;
   if (!apiKey) {
-    return res.status(500).json({ error: "ImgBB API key not configured" });
+    return res.status(500).json({
+      result: "error",
+      error: { message: "ImgBB API key not configured" },
+    });
   }
 
   const formData = new FormData();
@@ -32,14 +43,21 @@ async function uploadImage(req: NextApiRequest, res: NextApiResponse<ImageUpload
 
     const data = (await response.json()) as any;
     if (data.success) {
-      return res.status(200).json({ url: data.data.display_url || data.data.url });
+      return res.status(200).json({
+        result: "success",
+        value: { url: data.data.display_url || data.data.url },
+      });
     }
-    return res
-      .status(500)
-      .json({ error: data.error?.message || "Failed to upload image" });
+    return res.status(500).json({
+      result: "error",
+      error: { message: data.error?.message || "Failed to upload image" },
+    });
   } catch (err) {
     console.error("Error uploading image:", err);
-    return res.status(500).json({ error: "Error uploading image" });
+    return res.status(500).json({
+      result: "error",
+      error: { message: "Error uploading image" },
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- use `NounspaceResponse` for the image upload API route

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition file for 'node')*