### PR TITLE
Fix framer-motion type augmentation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,6 +44,7 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
+    "**/*.d.ts",
     ".next/types/**/*.ts"
   ],
   "exclude": [


### PR DESCRIPTION
## Summary
- include project `.d.ts` files in TypeScript compilation
- ensure Reorder.Group supports `onReorderEnd` via type augmentation

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*