### PR TITLE
Fix framer motion type for TabBar

### DIFF
--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -206,7 +206,7 @@ function TabBar({
               as="ol"
               axis="x"
               onReorder={updateTabOrder}
-              onDragEnd={() => commitTabOrder()}
+              onReorderEnd={commitTabOrder}
               className="flex flex-row gap-5 md:gap-4 items-start m-4 tabs"
               values={tabList}
             >

--- a/src/common/types/framer-motion.d.ts
+++ b/src/common/types/framer-motion.d.ts
@@ -1,0 +1,9 @@
+import 'framer-motion';
+
+declare module 'framer-motion' {
+  namespace Reorder {
+    interface Props<V> {
+      onReorderEnd?: () => void;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- accept `onReorderEnd` in Framer Motion `Reorder` types
- use `onReorderEnd` in `TabBar` instead of `onDragEnd`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions for `node`, `react`, `react-dom`)*