### PR TITLE
Fix homepage tab bar scroll

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -170,10 +170,10 @@ export default function Space({
   [config?.layoutDetails?.layoutConfig]);
 
   return (
-    <div className="user-theme-background w-full h-full relative flex-col">
+    <div className="user-theme-background w-full min-h-screen relative flex-col">
       <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
       <div className="w-full transition-all duration-100 ease-out">
-        <div className="flex flex-col h-full">
+        <div className="flex flex-col min-h-screen">
           <div style={{ position: "fixed", zIndex: 9999 }}>
             <InfoToast />
           </div>
@@ -185,12 +185,12 @@ export default function Space({
             <Suspense fallback={<TabBarSkeleton />}>{tabBar}</Suspense>
           </div>
 
-          <div className={isMobile ? "w-full h-full" : "flex h-full"}>
+          <div className={isMobile ? "w-full" : "flex h-full"}>
             {!isUndefined(feed) && !isMobile ? (
               <div className="w-6/12 h-[calc(100vh-64px)]">{feed}</div>
             ) : null}
 
-            <div className={isMobile ? "w-full h-full" : "grow"}>
+            <div className={isMobile ? "w-full" : "grow"}>
               <Suspense
                 fallback={
                   <SpaceLoading

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -194,7 +194,12 @@ function TabBar({
 
   return (
     <TooltipProvider>
-      <div className="flex flex-col md:flex-row justify-start md:h-16 z-50 bg-white">
+      {/*
+       * Ensure the tab bar container does not remain fixed when scrolling on
+       * mobile. Explicitly use `static` positioning so it can scroll out of
+       * view on pages like the homepage.
+       */}
+      <div className="static flex flex-col md:flex-row justify-start md:h-16 z-50 bg-white">
         {isTokenPage && contractAddress && (
           <div className="flex flex-row justify-start h-16 overflow-y-scroll w-full z-30 bg-white">
             <TokenDataHeader />


### PR DESCRIPTION
## Summary
- prevent the homepage tab bar from sticking during scroll by allowing the page to grow taller than the viewport

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definition files)*