### PR TITLE
Fix framer motion type

### DIFF
--- a/src/common/types/framer-motion.d.ts
+++ b/src/common/types/framer-motion.d.ts
@@ -2,7 +2,7 @@ import 'framer-motion';
 
 declare module 'framer-motion' {
   namespace Reorder {
-    interface Props<V> {
+    interface GroupProps<V> {
       onReorderEnd?: () => void;
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -45,7 +45,8 @@
     "**/*.ts",
     "**/*.tsx",
     "**/*.d.ts",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    "src/common/types/**/*.d.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- update framer motion declaration to extend `GroupProps` instead of `Props`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition file for 'node')*