### PR TITLE
Fix saving homebase tab order

### DIFF
--- a/src/common/data/stores/app/homebase/homebaseTabsStore.ts
+++ b/src/common/data/stores/app/homebase/homebaseTabsStore.ts
@@ -183,7 +183,7 @@ export const createHomeBaseTabStoreFunc = (
         { useRootKey: true },
       );
       try {
-        await axiosBackend.post(`/api/space/homebase/tabOrder/`, file);
+        await axiosBackend.post(`/api/space/homebase/tabOrder`, file);
         set((draft) => {
           draft.homebase.tabOrdering.remote = localCopy;
         }, "commitHomebaseTabOrderToDatabase");


### PR DESCRIPTION
## Summary
- ensure homebase tab order is posted to the correct API path

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*