### PR TITLE
Fix homebase tab order storage path

### DIFF
--- a/src/constants/supabase.ts
+++ b/src/constants/supabase.ts
@@ -19,5 +19,5 @@ export function homebaseTabsPath(identityPublicKey: string, tabName: string) {
 }
 
 export function homebaseTabOrderPath(key: string) {
-  return `${homebasePath(key)}TabOrder`;
+  return `${homebasePath(key)}/tabOrder`;
 }


### PR DESCRIPTION
## Summary
- update `homebaseTabOrderPath` helper to return `${homebasePath(key)}/tabOrder`
- keep `homebaseTabsStore` and API route using the helper

## Testing
- `npm run lint` *(fails: `next` command not found)*
- `npm run check-types` *(fails: missing type definition files for `node`, `react`, `react-dom`)*