### PR TITLE
Fix mobile tab bar click-through

### DIFF
--- a/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
+++ b/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
@@ -205,9 +205,10 @@ const TabNavigation: React.FC<TabNavigationProps> = ({
           const fidgetName = getFidgetName(fidgetId);
           
           return (
-            <TabsTrigger 
-              key={fidgetId} 
+            <TabsTrigger
+              key={fidgetId}
               value={fidgetId}
+              onClick={(e) => e.stopPropagation()}
               className={`
                 flex flex-col items-center justify-center
                 min-w-[72px] h-full py-2 px-0


### PR DESCRIPTION
## Summary
- prevent click-through by stopping propagation on mobile TabNavigation buttons

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*