### PR TITLE
Fix mobile tab bar click-through

### DIFF
--- a/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
+++ b/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
@@ -188,7 +188,12 @@ const TabNavigation: React.FC<TabNavigationProps> = ({
   };
 
   return (
-    <div className="relative w-full h-full">
+    <div
+      className="relative w-full h-full"
+      onClick={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+      onTouchStart={(e) => e.stopPropagation()}
+    >
       <TabsList 
         ref={tabsListRef}
         className={`
@@ -205,9 +210,10 @@ const TabNavigation: React.FC<TabNavigationProps> = ({
           const fidgetName = getFidgetName(fidgetId);
           
           return (
-            <TabsTrigger 
-              key={fidgetId} 
+            <TabsTrigger
+              key={fidgetId}
               value={fidgetId}
+              onClick={(e) => e.stopPropagation()}
               className={`
                 flex flex-col items-center justify-center
                 min-w-[72px] h-full py-2 px-0


### PR DESCRIPTION
## Summary
- prevent pointer events from reaching fidgets under the mobile TabNavigation

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*