### PR TITLE
Fix overlapping fidgets on tab load

### DIFF
--- a/src/common/lib/utils/layout.ts
+++ b/src/common/lib/utils/layout.ts
@@ -1,0 +1,67 @@
+export interface GridLayoutItem {
+  i: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * Determine whether two grid items intersect.
+ * This is used to weed out items that occupy the same grid cells.
+ */
+function rectanglesOverlap(a: GridLayoutItem, b: GridLayoutItem): boolean {
+  return (
+    a.x < b.x + b.w &&
+    a.x + a.w > b.x &&
+    a.y < b.y + b.h &&
+    a.y + a.h > b.y
+  );
+}
+
+export function removeOverlappingGridItems(config: {
+  layoutDetails?: { layoutConfig?: { layout: GridLayoutItem[] } };
+  fidgetInstanceDatums?: Record<string, unknown>;
+}): void {
+  const layout = config.layoutDetails?.layoutConfig?.layout;
+  if (!Array.isArray(layout)) return;
+
+  const filtered: GridLayoutItem[] = [];
+  const removedIds: string[] = [];
+  const occupied = new Set<string>();
+
+  for (const item of layout) {
+    let hasOverlap = false;
+    // Check each grid cell the item would occupy
+    for (let x = item.x; x < item.x + item.w && !hasOverlap; x++) {
+      for (let y = item.y; y < item.y + item.h && !hasOverlap; y++) {
+        const key = `${x}-${y}`;
+        if (occupied.has(key)) {
+          hasOverlap = true;
+        }
+      }
+    }
+
+    if (hasOverlap) {
+      removedIds.push(item.i);
+    } else {
+      for (let x = item.x; x < item.x + item.w; x++) {
+        for (let y = item.y; y < item.y + item.h; y++) {
+          occupied.add(`${x}-${y}`);
+        }
+      }
+      filtered.push(item);
+    }
+  }
+
+  if (removedIds.length > 0) {
+    if (config.layoutDetails?.layoutConfig) {
+      config.layoutDetails.layoutConfig.layout = filtered;
+    }
+    if (config.fidgetInstanceDatums) {
+      for (const id of removedIds) {
+        delete config.fidgetInstanceDatums[id];
+      }
+    }
+  }
+}

--- a/tests/layoutUtils.test.ts
+++ b/tests/layoutUtils.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { removeOverlappingGridItems } from '../src/common/lib/utils/layout'
+
+describe('removeOverlappingGridItems', () => {
+  it('removes overlapping items and matching fidgets', () => {
+    const config = {
+      layoutDetails: { layoutConfig: { layout: [
+        { i: 'a', x: 0, y: 0, w: 2, h: 2 },
+        { i: 'b', x: 1, y: 1, w: 2, h: 2 },
+        { i: 'c', x: 3, y: 3, w: 1, h: 1 },
+      ] } },
+      fidgetInstanceDatums: { a: {}, b: {}, c: {} },
+    } as any
+
+    removeOverlappingGridItems(config)
+
+    expect(config.layoutDetails!.layoutConfig!.layout.map((l: any) => l.i)).toEqual(['a', 'c'])
+    expect(config.fidgetInstanceDatums!.b).toBeUndefined()
+  })
+
+  it('does nothing when no overlap', () => {
+    const config = {
+      layoutDetails: { layoutConfig: { layout: [
+        { i: 'a', x: 0, y: 0, w: 2, h: 2 },
+        { i: 'b', x: 2, y: 0, w: 2, h: 2 },
+      ] } },
+      fidgetInstanceDatums: { a: {}, b: {} },
+    } as any
+
+    removeOverlappingGridItems(config)
+
+    expect(config.layoutDetails!.layoutConfig!.layout.length).toBe(2)
+    expect(config.fidgetInstanceDatums!.a).toBeDefined()
+    expect(config.fidgetInstanceDatums!.b).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary
- clean up overlapping grid items when loading a tab
- util to remove overlapping grid layout items
- add tests for overlap cleanup

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*