### PR TITLE
Fix duplicate mentions on cast publish

### DIFF
--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -388,10 +388,21 @@ const CreateCast: React.FC<CreateCastProps> = ({
       }
     }
 
-    const mentions = draft.mentionsToFids
-      ? Object.values(draft.mentionsToFids).map(Number)
-      : [];
-    const mentionsPositions = draft.mentionsPositions || [];
+    // Recompute mentions and their positions from the final text to ensure
+    // both arrays match in length and order. This prevents duplicated mentions
+    // when publishing.
+    const usernamePattern = /(?:^|[^a-zA-Z0-9_.-])@([a-zA-Z0-9_.-]+)/g;
+    const mentionMatches = [...draft.text.matchAll(usernamePattern)];
+    const mentions: number[] = [];
+    const mentionsPositions: number[] = [];
+    for (const match of mentionMatches) {
+      const username = match[1];
+      const fid = draft.mentionsToFids?.[username];
+      if (fid) {
+        mentions.push(Number(fid));
+        mentionsPositions.push(match.index! + match[0].indexOf("@"));
+      }
+    }
 
     const castBody: CastAddBody = {
       type: CastType.CAST,


### PR DESCRIPTION
## Summary
- recompute mentions and positions from final text before publishing

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*