### PR TITLE
Fix layout cleanup for missing fidget data

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -103,6 +103,18 @@ export default function Space({
       config.layoutDetails.layoutConfig.layout.map((item) => item.i)
     );
 
+    // Identify layout items that reference missing fidget data
+    const orphanedLayoutItems = config.layoutDetails.layoutConfig.layout.filter(
+      (item) => !config.fidgetInstanceDatums[item.i]
+    );
+
+    // Remove orphaned layout items
+    const layoutWithoutOrphans = config.layoutDetails.layoutConfig.layout.filter(
+      (item) => !!config.fidgetInstanceDatums[item.i]
+    );
+
+    const orphanedIds = orphanedLayoutItems.map((item) => item.i);
+
     // Find unused fidgets
     const unusedFidgetIds = Object.keys(config.fidgetInstanceDatums).filter(
       (id) => !layoutFidgetIds.has(id)
@@ -126,16 +138,19 @@ export default function Space({
       }
     }
 
-    // Check for and handle overlapping fidgets
-    const { cleanedLayout, removedFidgetIds } = cleanupLayout(
-      config.layoutDetails.layoutConfig.layout,
+    // Check for and handle overlapping fidgets on the filtered layout
+    const { cleanedLayout: cleanedAfterOverlap, removedFidgetIds } = cleanupLayout(
+      layoutWithoutOrphans,
       config.fidgetInstanceDatums,
       !isNil(profile),
       !isNil(feed)
     );
 
+    const cleanedLayout = cleanedAfterOverlap;
+    const allRemovedIds = [...removedFidgetIds, ...orphanedIds];
+
     const cleanedFidgetInstanceDatums = { ...config.fidgetInstanceDatums };
-    removedFidgetIds.forEach(id => {
+    allRemovedIds.forEach(id => {
       delete cleanedFidgetInstanceDatums[id];
     });
     
@@ -150,19 +165,21 @@ export default function Space({
         delete settings["fidget Shadow"];
         settingsChanged = true;
       }
-      if (settings && "fidget Shadow" in settings) {
-        settings.fidgetShadow = settings["fidget Shadow"];
-        delete settings["fidget Shadow"];
-        settingsChanged = true;
-      }
     });
 
     // Make Queued Changes
-    if (removedFidgetIds.length > 0 || 
-      cleanedLayout.some((item, i) => item.x !== config.layoutDetails.layoutConfig.layout[i].x || 
-      item.y !== config.layoutDetails.layoutConfig.layout[i].y) ||
-      settingsChanged) {
+    const layoutChanged =
+      cleanedLayout.length !== config.layoutDetails.layoutConfig.layout.length ||
+      cleanedLayout.some(
+        (item, i) =>
+          item.x !== config.layoutDetails.layoutConfig.layout[i]?.x ||
+          item.y !== config.layoutDetails.layoutConfig.layout[i]?.y ||
+          item.i !== config.layoutDetails.layoutConfig.layout[i]?.i ||
+          item.w !== config.layoutDetails.layoutConfig.layout[i]?.w ||
+          item.h !== config.layoutDetails.layoutConfig.layout[i]?.h
+      );
 
+    if (allRemovedIds.length > 0 || layoutChanged || settingsChanged) {
       saveConfig({
         layoutDetails: {
           layoutConfig: {


### PR DESCRIPTION
## Summary
- filter layout items that don't have matching fidget data
- commit updated layout if orphans were removed
- address lint warning about const usage

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*
- `npm test` *(fails: vitest not found)*