### PR TITLE
Fix duplicate mentions on cast publish

### DIFF
--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -310,11 +310,20 @@ const CreateCast: React.FC<CreateCastProps> = ({
       );
 
       let mentionsToFids: { [key: string]: string } = {};
-      // Positions of each mention in the text
-      const mentionsPositions: number[] = usernamesWithPositions.map(
-        (u) => u.position,
-      );
-      const mentionsText = text; // Keep the original text intact
+
+      // Remove mentions from the text while tracking their positions so the
+      // sanitized text aligns with the positions used for publishing.
+      let mentionsText = text;
+      const mentionsPositions: number[] = [];
+      let offset = 0;
+      for (const { username, position } of usernamesWithPositions) {
+        const adjustedPos = position - offset;
+        mentionsPositions.push(adjustedPos);
+        mentionsText =
+          mentionsText.slice(0, adjustedPos) +
+          mentionsText.slice(adjustedPos + username.length + 1);
+        offset += username.length + 1;
+      }
 
       if (uniqueUsernames.length > 0) {
         try {


### PR DESCRIPTION
## Summary
- remove mention usernames from text while tracking their positions to avoid duplicates on publish

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*