### PR TITLE
Fix Swap fidget default settings

### DIFF
--- a/src/fidgets/swap/Swap.tsx
+++ b/src/fidgets/swap/Swap.tsx
@@ -32,7 +32,7 @@ const matchaProperties: FidgetProperties = {
   fields: [
     ...mobileStyleSettings,
     {
-      fieldName: "Default Sell Token",
+      fieldName: "defaultSellToken",
       default: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       required: true,
       inputSelector: (props) => (
@@ -45,7 +45,7 @@ const matchaProperties: FidgetProperties = {
       group: "settings",
     },
     {
-      fieldName: "Default Buy Token",
+      fieldName: "defaultBuyToken",
       default: "0x48c6740bcf807d6c47c864faeea15ed4da3910ab",
       required: true,
       inputSelector: (props) => (
@@ -59,7 +59,7 @@ const matchaProperties: FidgetProperties = {
       group: "settings",
     },
     {
-      fieldName: "From Chain",
+      fieldName: "fromChain",
       default: { id: "8453", name: "Base" },
       required: false,
       inputSelector: (props) => (
@@ -89,7 +89,7 @@ const matchaProperties: FidgetProperties = {
       group: "style",
     },
     {
-      fieldName: "To Chain",
+      fieldName: "toChain",
       default: { id: "8453", name: "Base" },
       required: false,
       inputSelector: (props) => (


### PR DESCRIPTION
This fixes an issue where the swap fidget on token spaces wasn't being autopopulated with the token + chain. the issue was due to incorrect fidget field names (ie. Default Sell Token instead of DefaultSellToken)

## Summary
- correct Swap fidget field names so saved settings map correctly

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: Cannot find type definition file for 'node')*