### PR TITLE
Make cast button blue in cast modal (to match cast button in nav)

### DIFF
--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -635,8 +635,9 @@ const CreateCast: React.FC<CreateCastProps> = ({
           <div className="flex flex-row pt-0 justify-end">
             <Button
               size="lg"
+              variant="primary"
               type="submit"
-              className="line-clamp-1 min-w-40 max-w-xs truncate"
+              className="bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white line-clamp-1 min-w-40 max-w-xs truncate"
               disabled={isPublishing || isLoadingSigner}
             >
               {getButtonText()}


### PR DESCRIPTION
## Summary
- apply explicit blue background classes to the Cast button inside the modal

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition file)*