### PR TITLE
Fix misnamed fidget fieldNames

### DIFF
--- a/src/fidgets/farcaster/Channel.tsx
+++ b/src/fidgets/farcaster/Channel.tsx
@@ -59,7 +59,8 @@ const channelFidgetProperties: FidgetProperties = {
   fidgetName: "Farcaster Channels",
   fields: [
     {
-      fieldName: "Channel Feed",
+      fieldName: "channel",
+      displayName: "Channel Feed",
       default: "A channel Feed!",
       required: true,
       inputSelector: TextInput,

--- a/src/fidgets/snapshot/SnapShot.tsx
+++ b/src/fidgets/snapshot/SnapShot.tsx
@@ -11,11 +11,11 @@ import { FaAngleLeft, FaAngleRight } from "react-icons/fa6";
 import ProposalItem from "./components/ProposalItem";
 import ThemeColorSelector from "@/common/components/molecules/ThemeColorSelector";
 
-export type snapShotSettings = {
+export type SnapShotSettings = {
   subgraphUrl: string;
   daoContractAddress: string;
-  "snapshot ens": string;
-  "snapshot space": string;
+  snapshotEns: string;
+  snapshotSpace: string;
   scale: number;
   headingsFontFamily?: string;
   fontFamily?: string;
@@ -30,7 +30,7 @@ export const snapshotConfig: FidgetProperties = {
   icon: 0x26a1,
   fields: [
     {
-      fieldName: "snapshot ens",
+      fieldName: "snapshotEns",
       displayName: "Snapshot ENS",
       displayNameHint: "Enter the ENS name of the Snapshot space (e.g. 'gnars.eth')",
       default: "gnars.eth",
@@ -115,7 +115,7 @@ export const snapshotConfig: FidgetProperties = {
   },
 };
 
-export const SnapShot: React.FC<FidgetArgs<snapShotSettings>> = ({
+export const SnapShot: React.FC<FidgetArgs<SnapShotSettings>> = ({
   settings,
 }) => {
   // const [expandedProposalId, setExpandedProposalId] = useState<string | null>(
@@ -125,12 +125,12 @@ export const SnapShot: React.FC<FidgetArgs<snapShotSettings>> = ({
   const first = 5;
 
   const { proposals, error } = useSnapshotProposals({
-    ens: settings["snapshot ens"],
+    ens: settings.snapshotEns,
     skip,
     first,
   });
   // const { snapShotInfo } = useSnapShotInfo({
-  //   ens: settings["snapshot ens"],
+  //   ens: settings.snapshotEns,
   // });
 
   // const handleToggleExpand = (proposalId: string) => {
@@ -189,7 +189,7 @@ export const SnapShot: React.FC<FidgetArgs<snapShotSettings>> = ({
             color: getHeadingsFontColor()
           }}
         >
-          {settings["snapshot ens"]} proposals
+          {settings.snapshotEns} proposals
         </h1>
         {error && <p className="text-red-500" style={{ fontFamily: getBodyFontFamily(), color: getBodyFontColor() }}>{error}</p>}
         <div
@@ -200,7 +200,7 @@ export const SnapShot: React.FC<FidgetArgs<snapShotSettings>> = ({
             <ProposalItem
               key={proposal.id}
               proposal={proposal}
-              space={settings["snapshot ens"]}
+              space={settings.snapshotEns}
               headingsFont={getHeadingsFontFamily()}
               headingsColor={getHeadingsFontColor()}
               bodyFont={getBodyFontFamily()}
@@ -232,4 +232,4 @@ export const SnapShot: React.FC<FidgetArgs<snapShotSettings>> = ({
 export default {
   fidget: SnapShot,
   properties: snapshotConfig,
-} as FidgetModule<FidgetArgs<snapShotSettings>>;
+} as FidgetModule<FidgetArgs<SnapShotSettings>>;

--- a/src/fidgets/swap/Swap.tsx
+++ b/src/fidgets/swap/Swap.tsx
@@ -33,6 +33,7 @@ const matchaProperties: FidgetProperties = {
     ...mobileStyleSettings,
     {
       fieldName: "defaultSellToken",
+      displayName: "Default Sell Token",
       default: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       required: true,
       inputSelector: (props) => (
@@ -46,6 +47,7 @@ const matchaProperties: FidgetProperties = {
     },
     {
       fieldName: "defaultBuyToken",
+      displayName: "Default Buy Token",
       default: "0x48c6740bcf807d6c47c864faeea15ed4da3910ab",
       required: true,
       inputSelector: (props) => (
@@ -60,6 +62,7 @@ const matchaProperties: FidgetProperties = {
     },
     {
       fieldName: "fromChain",
+      displayName: "Sell Chain",
       default: { id: "8453", name: "Base" },
       required: false,
       inputSelector: (props) => (
@@ -90,6 +93,7 @@ const matchaProperties: FidgetProperties = {
     },
     {
       fieldName: "toChain",
+      displayName: "Buy Chain",
       default: { id: "8453", name: "Base" },
       required: false,
       inputSelector: (props) => (

--- a/src/fidgets/swap/Swap.tsx
+++ b/src/fidgets/swap/Swap.tsx
@@ -32,7 +32,7 @@ const matchaProperties: FidgetProperties = {
   fields: [
     ...mobileStyleSettings,
     {
-      fieldName: "Default Sell Token",
+      fieldName: "defaultSellToken",
       default: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
       required: true,
       inputSelector: (props) => (
@@ -45,7 +45,7 @@ const matchaProperties: FidgetProperties = {
       group: "settings",
     },
     {
-      fieldName: "Default Buy Token",
+      fieldName: "defaultBuyToken",
       default: "0x48c6740bcf807d6c47c864faeea15ed4da3910ab",
       required: true,
       inputSelector: (props) => (
@@ -59,7 +59,7 @@ const matchaProperties: FidgetProperties = {
       group: "settings",
     },
     {
-      fieldName: "From Chain",
+      fieldName: "fromChain",
       default: { id: "8453", name: "Base" },
       required: false,
       inputSelector: (props) => (
@@ -89,7 +89,7 @@ const matchaProperties: FidgetProperties = {
       group: "style",
     },
     {
-      fieldName: "To Chain",
+      fieldName: "toChain",
       default: { id: "8453", name: "Base" },
       required: false,
       inputSelector: (props) => (

--- a/src/fidgets/ui/Text.tsx
+++ b/src/fidgets/ui/Text.tsx
@@ -60,7 +60,7 @@ export const textConfig: FidgetProperties = {
       group: "settings",
     },
     {
-      fieldName: "font Family",
+      fieldName: "fontFamily",
       displayName: "Font Family",
       displayNameHint: "Font used for the text input (body text). Set to Theme Font to inherit the Body Font from the Theme.",
       default: "var(--user-theme-font)",

--- a/src/fidgets/ui/rss.tsx
+++ b/src/fidgets/ui/rss.tsx
@@ -43,7 +43,7 @@ export const rssConfig: FidgetProperties = {
       group: "settings",
     },
     {
-      fieldName: "font Family",
+      fieldName: "fontFamily",
       displayName: "Font Family",
       displayNameHint: "Font used for the content text. Set to Theme Font to inherit the Body Font from the Theme.",
       default: "var(--user-theme-font)",


### PR DESCRIPTION
This fixes an issue where the swap fidget on token spaces wasn't being autopopulated with the token + chain. the issue was due to incorrect fidget field names (ie. Default Sell Token instead of DefaultSellToken).

It also fixes other misnamed fidget settings.

## Summary
- align Channel fidget field name with settings
- standardize SnapShot fidget setting keys
- correct fontFamily field names for Text and RSS fidgets

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*
- `npm test` *(fails: vitest not found)*