### PR TITLE
Fix Links fidget scrolling

### DIFF
--- a/src/fidgets/ui/Links.tsx
+++ b/src/fidgets/ui/Links.tsx
@@ -312,8 +312,7 @@ export const Links: React.FC<FidgetArgs<LinkFidgetSettings>> = ({
   };
 
   return (
-    <div
-    >
+    <div className="flex flex-col h-full">
       {settings?.title && (
         <CardHeader className="p-4">
           <CardTitle
@@ -327,8 +326,12 @@ export const Links: React.FC<FidgetArgs<LinkFidgetSettings>> = ({
           </CardTitle>
         </CardHeader>
       )}
-
-      <div className={isGridView ? "grid grid-cols-3 gap-4" : "flex flex-col"}>
+      <div
+        className={
+          (isGridView ? "grid grid-cols-3 gap-4" : "flex flex-col") +
+          " overflow-y-auto flex-grow"
+        }
+      >
         {links.length > 0 &&
           links.map((link, index) => (
             <a


### PR DESCRIPTION
Currently in prod, links fidgets can't be scrolled. This fixes that 

## Summary
- ensure Links fidget list is scrollable when overflowing

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*