### PR TITLE
[CLIENT] add dynamic token share images

### DIFF
--- a/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
@@ -2,6 +2,7 @@ import { WEBSITE_URL } from "@/constants/app";
 import { Metadata } from "next/types";
 import React from "react";
 import { fetchTokenData } from "@/common/lib/utils/fetchTokenData";
+import { getTokenMetadataStructure } from "@/common/lib/utils/tokenMetadata";
 import { defaultFrame } from "@/common/lib/frames/metadata";
 
 // Default metadata (used as fallback)
@@ -23,6 +24,10 @@ export async function generateMetadata({
   // Try to fetch token data using fetchMasterToken
   let symbol = "";
   let price = "";
+  let name = "";
+  let imageUrl = "";
+  let marketCap = "";
+  let priceChange = "";
   
   try {
     const tokenData = await fetchTokenData(
@@ -35,6 +40,10 @@ export async function generateMetadata({
     
     // Get symbol and price from tokenData
     symbol = tokenData?.symbol || "";
+    name = tokenData?.name || "";
+    imageUrl = tokenData?.image_url || "";
+    marketCap = tokenData?.market_cap_usd || "";
+    priceChange = tokenData?.priceChange || "";
     
     // Get price from tokenData
     price = tokenData?.price_usd 
@@ -69,14 +78,25 @@ export async function generateMetadata({
   };
   
   // Create metadata object with token data if available
+  const tokenMetadata = getTokenMetadataStructure({
+    name,
+    symbol,
+    imageUrl,
+    contractAddress,
+    marketCap,
+    priceChange,
+    network,
+  });
+
   const metadataWithFrame = {
+    ...tokenMetadata,
     title: symbol ? `${symbol} ${price ? `- ${price}` : ""} | Nounspace` : "Token Space | Nounspace",
-    description: symbol 
+    description: symbol
       ? `${symbol} ${price ? `(${price})` : ""} token information and trading on Nounspace, the customizable web3 social app built on Farcaster.`
       : "Token information and trading on Nounspace, the customizable web3 social app built on Farcaster.",
     other: {
       "fc:frame": JSON.stringify(tokenFrame),
-    }
+    },
   };
   
   return metadataWithFrame;

--- a/src/common/lib/utils/fetchTokenData.ts
+++ b/src/common/lib/utils/fetchTokenData.ts
@@ -87,6 +87,14 @@ export async function fetchTokenData(
       }
     }
 
+    let priceChange: string | null = null;
+    for (const pool of result.included) {
+      if (pool.attributes?.price_change_percentage?.h24) {
+        priceChange = pool.attributes.price_change_percentage.h24;
+        break;
+      }
+    }
+
     // Calculate market cap if not available
     if (!marketCap && token.price_usd) {
       const totalSupply = token.total_supply;
@@ -115,6 +123,7 @@ export async function fetchTokenData(
     return {
       ...token,
       market_cap_usd: marketCap,
+      priceChange,
     };
   } catch (error) {
     // console.error("Error fetching token data:", error);

--- a/src/common/lib/utils/tokenMetadata.tsx
+++ b/src/common/lib/utils/tokenMetadata.tsx
@@ -1,0 +1,78 @@
+import { WEBSITE_URL } from "@/constants/app";
+import { merge } from "lodash";
+import { Metadata } from "next";
+
+export type TokenMetadata = {
+  name?: string;
+  symbol?: string;
+  imageUrl?: string;
+  contractAddress?: string;
+  marketCap?: string;
+  priceChange?: string;
+  network?: string;
+};
+
+export const getTokenMetadataStructure = (
+  token: TokenMetadata,
+): Metadata => {
+  if (!token) {
+    return {};
+  }
+
+  const {
+    name,
+    symbol,
+    imageUrl,
+    contractAddress,
+    marketCap,
+    priceChange,
+    network,
+  } = token;
+
+  const spaceUrl =
+    network && contractAddress
+      ? `https://nounspace.com/t/${network}/${contractAddress}`
+      : undefined;
+  const title = symbol ? `${symbol} on Nounspace` : "Token Space on Nounspace";
+
+  const params = new URLSearchParams({
+    name: name || "",
+    symbol: symbol || "",
+    imageUrl: imageUrl || "",
+    address: contractAddress || "",
+    marketCap: marketCap || "",
+    priceChange: priceChange || "",
+  });
+
+  const ogImageUrl = `${WEBSITE_URL}/api/metadata/token?${params.toString()}`;
+
+  const metadata: Metadata = {
+    title,
+    openGraph: {
+      title,
+      url: spaceUrl,
+      image: ogImageUrl,
+    },
+    twitter: {
+      title,
+      domain: "https://nounspace.com/",
+      url: spaceUrl,
+      image: ogImageUrl,
+      card: "summary_large_image",
+    },
+  };
+
+  if (marketCap || priceChange) {
+    const descParts: string[] = [];
+    if (marketCap) descParts.push(`Market Cap: $${marketCap}`);
+    if (priceChange) descParts.push(`24h: ${priceChange}%`);
+    const description = descParts.join(" | ");
+    merge(metadata, {
+      description,
+      openGraph: { description },
+      twitter: { description },
+    });
+  }
+
+  return metadata;
+};

--- a/src/pages/api/metadata/token.tsx
+++ b/src/pages/api/metadata/token.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { NextApiRequest, NextApiResponse } from "next";
+import { ImageResponse } from "next/og";
+
+export const config = {
+  runtime: "edge",
+};
+
+interface TokenCardData {
+  name: string;
+  symbol: string;
+  imageUrl: string;
+  address: string;
+  marketCap: string;
+  priceChange: string;
+}
+
+export default async function GET(
+  req: NextApiRequest,
+  res: NextApiResponse<ImageResponse | string>,
+) {
+  if (!req.url) {
+    return res.status(404).send("Url not found");
+  }
+
+  const params = new URLSearchParams(req.url.split("?")[1]);
+  const data: TokenCardData = {
+    name: params.get("name") || "",
+    symbol: params.get("symbol") || "",
+    imageUrl: params.get("imageUrl") || "",
+    address: params.get("address") || "",
+    marketCap: params.get("marketCap") || "",
+    priceChange: params.get("priceChange") || "",
+  };
+
+  return new ImageResponse(<TokenCard data={data} />, {
+    width: 1200,
+    height: 630,
+  });
+}
+
+const TokenCard = ({ data }: { data: TokenCardData }) => (
+  <div
+    style={{
+      width: "100%",
+      height: "100%",
+      padding: "40px",
+      display: "flex",
+      alignItems: "center",
+      background: "white",
+      gap: "32px",
+      fontFamily: "Arial, sans-serif",
+    }}
+  >
+    {data.imageUrl && (
+      <img
+        src={data.imageUrl}
+        width="160"
+        height="160"
+        style={{ borderRadius: "80px" }}
+      />
+    )}
+    <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+      <span style={{ fontSize: "56px", fontWeight: "bold" }}>{data.name}</span>
+      <span style={{ fontSize: "42px", color: "#555" }}>{data.symbol}</span>
+      <span style={{ fontSize: "28px" }}>Address: {data.address}</span>
+      <span style={{ fontSize: "28px" }}>Market Cap: {data.marketCap}</span>
+      <span style={{ fontSize: "28px" }}>24h Change: {data.priceChange}%</span>
+    </div>
+  </div>
+);


### PR DESCRIPTION
## Summary
- allow dynamic token metadata images
- expose new token metadata endpoint
- include token metadata in token space layout
- provide token price change via fetchTokenData

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*