### PR TITLE
Add dynamic token space thumbnails

### DIFF
--- a/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
@@ -62,9 +62,20 @@ export async function generateMetadata({
     : `${WEBSITE_URL}/t/${network}/${contractAddress}`;
     
   // Create token frame with the symbol if available
+  const params = new URLSearchParams({
+    name,
+    symbol,
+    imageUrl,
+    address: contractAddress,
+    marketCap,
+    priceChange,
+  });
+
+  const ogImageUrl = `${WEBSITE_URL}/api/metadata/token?${params.toString()}`;
+
   const tokenFrame = {
     version: "next",
-    imageUrl: `${WEBSITE_URL}/images/nounspace_og_low.png`,
+    imageUrl: ogImageUrl,
     button: {
       title: symbol ? `Visit ${symbol}` : "Visit Token Space",
       action: {

--- a/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
@@ -2,6 +2,7 @@ import { WEBSITE_URL } from "@/constants/app";
 import { Metadata } from "next/types";
 import React from "react";
 import { fetchTokenData } from "@/common/lib/utils/fetchTokenData";
+import { getTokenMetadataStructure } from "@/common/lib/utils/tokenMetadata";
 import { defaultFrame } from "@/common/lib/frames/metadata";
 
 // Default metadata (used as fallback)
@@ -23,6 +24,10 @@ export async function generateMetadata({
   // Try to fetch token data using fetchMasterToken
   let symbol = "";
   let price = "";
+  let name = "";
+  let imageUrl = "";
+  let marketCap = "";
+  let priceChange = "";
   
   try {
     const tokenData = await fetchTokenData(
@@ -35,6 +40,10 @@ export async function generateMetadata({
     
     // Get symbol and price from tokenData
     symbol = tokenData?.symbol || "";
+    name = tokenData?.name || "";
+    imageUrl = tokenData?.image_url || "";
+    marketCap = tokenData?.market_cap_usd || "";
+    priceChange = tokenData?.priceChange || "";
     
     // Get price from tokenData
     price = tokenData?.price_usd 
@@ -69,14 +78,25 @@ export async function generateMetadata({
   };
   
   // Create metadata object with token data if available
+  const tokenMetadata = getTokenMetadataStructure({
+    name,
+    symbol,
+    imageUrl,
+    contractAddress,
+    marketCap,
+    priceChange,
+    network,
+  });
+
   const metadataWithFrame = {
+    ...tokenMetadata,
     title: symbol ? `${symbol} ${price ? `- ${price}` : ""} | Nounspace` : "Token Space | Nounspace",
-    description: symbol 
+    description: symbol
       ? `${symbol} ${price ? `(${price})` : ""} token information and trading on Nounspace, the customizable web3 social app built on Farcaster.`
       : "Token information and trading on Nounspace, the customizable web3 social app built on Farcaster.",
     other: {
       "fc:frame": JSON.stringify(tokenFrame),
-    }
+    },
   };
   
   return metadataWithFrame;

--- a/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
@@ -45,10 +45,17 @@ export async function generateMetadata({
     marketCap = tokenData?.market_cap_usd || "";
     priceChange = tokenData?.priceChange || "";
     
-    // Get price from tokenData
-    price = tokenData?.price_usd 
-      ? `$${Number(tokenData.price_usd).toFixed(2)}` 
-      : "";
+    // Format price with extra precision for small values
+    if (tokenData?.price_usd) {
+      const priceNumber = Number(tokenData.price_usd);
+      const formatted = priceNumber.toLocaleString(undefined, {
+        minimumFractionDigits: priceNumber < 0.01 ? 4 : 2,
+        maximumFractionDigits: priceNumber < 0.01 ? 6 : 2,
+      });
+      price = `$${formatted}`;
+    } else {
+      price = "";
+    }
   } catch (error) {
     console.error("Error fetching token data for frame metadata:", error);
   }
@@ -68,6 +75,7 @@ export async function generateMetadata({
     imageUrl,
     address: contractAddress,
     marketCap,
+    price,
     priceChange,
   });
 
@@ -95,6 +103,7 @@ export async function generateMetadata({
     imageUrl,
     contractAddress,
     marketCap,
+    price,
     priceChange,
     network,
   });

--- a/src/common/lib/utils/fetchTokenData.ts
+++ b/src/common/lib/utils/fetchTokenData.ts
@@ -87,6 +87,14 @@ export async function fetchTokenData(
       }
     }
 
+    let priceChange: string | null = null;
+    for (const pool of result.included) {
+      if (pool.attributes?.price_change_percentage?.h24) {
+        priceChange = pool.attributes.price_change_percentage.h24;
+        break;
+      }
+    }
+
     // Calculate market cap if not available
     if (!marketCap && token.price_usd) {
       const totalSupply = token.total_supply;
@@ -115,6 +123,7 @@ export async function fetchTokenData(
     return {
       ...token,
       market_cap_usd: marketCap,
+      priceChange,
     };
   } catch (error) {
     // console.error("Error fetching token data:", error);

--- a/src/common/lib/utils/tokenMetadata.tsx
+++ b/src/common/lib/utils/tokenMetadata.tsx
@@ -8,6 +8,7 @@ export type TokenMetadata = {
   imageUrl?: string;
   contractAddress?: string;
   marketCap?: string;
+  price?: string;
   priceChange?: string;
   network?: string;
 };
@@ -25,6 +26,7 @@ export const getTokenMetadataStructure = (
     imageUrl,
     contractAddress,
     marketCap,
+    price,
     priceChange,
     network,
   } = token;
@@ -41,6 +43,7 @@ export const getTokenMetadataStructure = (
     imageUrl: imageUrl || "",
     address: contractAddress || "",
     marketCap: marketCap || "",
+    price: price || "",
     priceChange: priceChange || "",
   });
 
@@ -61,9 +64,10 @@ export const getTokenMetadataStructure = (
     },
   };
 
-  if (marketCap || priceChange) {
+  if (marketCap || priceChange || price) {
     const descParts: string[] = [];
     if (marketCap) descParts.push(`Market Cap: $${marketCap}`);
+    if (price) descParts.push(`Price: ${price}`);
     if (priceChange) descParts.push(`24h: ${priceChange}%`);
     const description = descParts.join(" | ");
     merge(metadata, {

--- a/src/common/lib/utils/tokenMetadata.tsx
+++ b/src/common/lib/utils/tokenMetadata.tsx
@@ -1,0 +1,77 @@
+import { WEBSITE_URL } from "@/constants/app";
+import { merge } from "lodash";
+import { Metadata } from "next";
+
+export type TokenMetadata = {
+  name?: string;
+  symbol?: string;
+  imageUrl?: string;
+  contractAddress?: string;
+  marketCap?: string;
+  priceChange?: string;
+  network?: string;
+};
+
+export const getTokenMetadataStructure = (
+  token: TokenMetadata,
+): Metadata => {
+  if (!token) {
+    return {};
+  }
+
+  const {
+    name,
+    symbol,
+    imageUrl,
+    contractAddress,
+    marketCap,
+    priceChange,
+    network,
+  } = token;
+
+  const spaceUrl =
+    network && contractAddress
+      ? `https://nounspace.com/t/${network}/${contractAddress}`
+      : undefined;
+  const title = symbol ? `${symbol} on Nounspace` : "Token Space on Nounspace";
+
+  const params = new URLSearchParams({
+    name: name || "",
+    symbol: symbol || "",
+    imageUrl: imageUrl || "",
+    address: contractAddress || "",
+    marketCap: marketCap || "",
+    priceChange: priceChange || "",
+  });
+
+  const ogImageUrl = `${WEBSITE_URL}/api/metadata/token?${params.toString()}`;
+
+  const metadata: Metadata = {
+    title,
+    openGraph: {
+      title,
+      url: spaceUrl,
+      images: [ogImageUrl],
+    },
+    twitter: {
+      title,
+      site: "https://nounspace.com/",
+      images: [ogImageUrl],
+      card: "summary_large_image",
+    },
+  };
+
+  if (marketCap || priceChange) {
+    const descParts: string[] = [];
+    if (marketCap) descParts.push(`Market Cap: $${marketCap}`);
+    if (priceChange) descParts.push(`24h: ${priceChange}%`);
+    const description = descParts.join(" | ");
+    merge(metadata, {
+      description,
+      openGraph: { description },
+      twitter: { description },
+    });
+  }
+
+  return metadata;
+};

--- a/src/pages/api/metadata/token.tsx
+++ b/src/pages/api/metadata/token.tsx
@@ -104,7 +104,7 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
         <span style={{ fontSize: "28px" }}>
           Price: {formattedPrice}{" "}
           <span style={{ color: priceChangeColor }}>
-            ({formattedPriceChange}% 24h)
+            {formattedPriceChange}%
           </span>
         </span>
         <span style={{ fontSize: "28px" }}>Address: {data.address}</span>

--- a/src/pages/api/metadata/token.tsx
+++ b/src/pages/api/metadata/token.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { NextApiRequest, NextApiResponse } from "next";
+import { ImageResponse } from "next/og";
+
+export const config = {
+  runtime: "edge",
+};
+
+interface TokenCardData {
+  name: string;
+  symbol: string;
+  imageUrl: string;
+  address: string;
+  marketCap: string;
+  priceChange: string;
+}
+
+export default async function GET(
+  req: NextApiRequest,
+  res: NextApiResponse<ImageResponse | string>,
+) {
+  if (!req.url) {
+    return res.status(404).send("Url not found");
+  }
+
+  const params = new URLSearchParams(req.url.split("?")[1]);
+  const data: TokenCardData = {
+    name: params.get("name") || "",
+    symbol: params.get("symbol") || "",
+    imageUrl: params.get("imageUrl") || "",
+    address: params.get("address") || "",
+    marketCap: params.get("marketCap") || "",
+    priceChange: params.get("priceChange") || "",
+  };
+
+  return new ImageResponse(<TokenCard data={data} />, {
+    width: 1200,
+    height: 630,
+  });
+}
+
+const TokenCard = ({ data }: { data: TokenCardData }) => (
+  <div
+    style={{
+      width: "100%",
+      height: "100%",
+      padding: "40px",
+      display: "flex",
+      alignItems: "center",
+      background: "white",
+      gap: "32px",
+      fontFamily: "Arial, sans-serif",
+    }}
+  >
+    {data.imageUrl && (
+      <img
+        src={data.imageUrl}
+        width="160"
+        height="160"
+        style={{ borderRadius: "80px" }}
+      />
+    )}
+    <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+      <span style={{ fontSize: "56px", fontWeight: "bold" }}>{data.name}</span>
+      <span style={{ fontSize: "42px", color: "#555" }}>{data.symbol}</span>
+      <span style={{ fontSize: "28px" }}>Address: {data.address}</span>
+      <span style={{ fontSize: "28px" }}>Market Cap: {data.marketCap}</span>
+      <span style={{ fontSize: "28px" }}>24h Change: {data.priceChange}%</span>
+    </div>
+  </div>
+);

--- a/src/pages/api/metadata/token.tsx
+++ b/src/pages/api/metadata/token.tsx
@@ -39,33 +39,55 @@ export default async function GET(
   });
 }
 
-const TokenCard = ({ data }: { data: TokenCardData }) => (
-  <div
-    style={{
-      width: "100%",
-      height: "100%",
-      padding: "40px",
-      display: "flex",
-      alignItems: "center",
-      background: "white",
-      gap: "32px",
-      fontFamily: "Arial, sans-serif",
-    }}
-  >
-    {data.imageUrl && (
-      <img
-        src={data.imageUrl}
-        width="160"
-        height="160"
-        style={{ borderRadius: "80px" }}
-      />
-    )}
-    <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
-      <span style={{ fontSize: "56px", fontWeight: "bold" }}>{data.name}</span>
-      <span style={{ fontSize: "42px", color: "#555" }}>{data.symbol}</span>
-      <span style={{ fontSize: "28px" }}>Address: {data.address}</span>
-      <span style={{ fontSize: "28px" }}>Market Cap: {data.marketCap}</span>
-      <span style={{ fontSize: "28px" }}>24h Change: {data.priceChange}%</span>
+const TokenCard = ({ data }: { data: TokenCardData }) => {
+  const marketCapNumber = Number(data.marketCap);
+  const formattedMarketCap = Number.isFinite(marketCapNumber)
+    ? `$${marketCapNumber.toLocaleString(undefined, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })}`
+    : data.marketCap;
+
+  const priceChangeNumber = Number(data.priceChange);
+  const priceChangeColor = Number.isFinite(priceChangeNumber)
+    ? priceChangeNumber >= 0
+      ? "green"
+      : "red"
+    : "#000";
+  const formattedPriceChange = Number.isFinite(priceChangeNumber)
+    ? priceChangeNumber.toFixed(2)
+    : data.priceChange;
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        padding: "40px",
+        display: "flex",
+        alignItems: "center",
+        background: "white",
+        gap: "32px",
+        fontFamily: "Arial, sans-serif",
+      }}
+    >
+      {data.imageUrl && (
+        <img
+          src={data.imageUrl}
+          width="160"
+          height="160"
+          style={{ borderRadius: "80px" }}
+        />
+      )}
+      <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+        <span style={{ fontSize: "56px", fontWeight: "bold" }}>{data.name}</span>
+        <span style={{ fontSize: "42px", color: "#555" }}>{`$${data.symbol}`}</span>
+        <span style={{ fontSize: "28px" }}>Address: {data.address}</span>
+        <span style={{ fontSize: "28px" }}>Market Cap: {formattedMarketCap}</span>
+        <span style={{ fontSize: "28px", color: priceChangeColor }}>
+          24h Change: {formattedPriceChange}%
+        </span>
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/src/pages/api/metadata/token.tsx
+++ b/src/pages/api/metadata/token.tsx
@@ -65,7 +65,8 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
         height: "100%",
         padding: "40px",
         display: "flex",
-        alignItems: "center",
+        flexDirection: "column",
+        alignItems: "flex-start",
         background: "white",
         gap: "32px",
         fontFamily: "Arial, sans-serif",
@@ -76,7 +77,7 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
           src={data.imageUrl}
           width="160"
           height="160"
-          style={{ borderRadius: "80px" }}
+          style={{ borderRadius: "80px", alignSelf: "center" }}
         />
       )}
       <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>

--- a/src/pages/api/metadata/token.tsx
+++ b/src/pages/api/metadata/token.tsx
@@ -86,7 +86,7 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
           display: "flex",
           flexDirection: "column",
           gap: "12px",
-          paddingLeft: "20px",
+          paddingLeft: "111px",
         }}
       >
         <span style={{ fontSize: "56px", fontWeight: "bold" }}>{data.name}</span>

--- a/src/pages/api/metadata/token.tsx
+++ b/src/pages/api/metadata/token.tsx
@@ -12,6 +12,7 @@ interface TokenCardData {
   imageUrl: string;
   address: string;
   marketCap: string;
+  price: string;
   priceChange: string;
 }
 
@@ -30,6 +31,7 @@ export default async function GET(
     imageUrl: params.get("imageUrl") || "",
     address: params.get("address") || "",
     marketCap: params.get("marketCap") || "",
+    price: params.get("price") || "",
     priceChange: params.get("priceChange") || "",
   };
 
@@ -47,6 +49,14 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
         maximumFractionDigits: 2,
       })}`
     : data.marketCap;
+
+  const priceNumber = parseFloat(data.price.replace(/[$,]/g, ""));
+  const formattedPrice = Number.isFinite(priceNumber)
+    ? `$${priceNumber.toLocaleString(undefined, {
+        minimumFractionDigits: priceNumber < 0.01 ? 4 : 2,
+        maximumFractionDigits: priceNumber < 0.01 ? 6 : 2,
+      })}`
+    : data.price;
 
   const priceChangeNumber = Number(data.priceChange);
   const priceChangeColor = Number.isFinite(priceChangeNumber)
@@ -91,11 +101,14 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
       >
         <span style={{ fontSize: "56px", fontWeight: "bold" }}>{data.name}</span>
         <span style={{ fontSize: "42px", color: "white" }}>{`$${data.symbol}`}</span>
+        <span style={{ fontSize: "28px" }}>
+          Price: {formattedPrice}{" "}
+          <span style={{ color: priceChangeColor }}>
+            ({formattedPriceChange}% 24h)
+          </span>
+        </span>
         <span style={{ fontSize: "28px" }}>Address: {data.address}</span>
         <span style={{ fontSize: "28px" }}>Market Cap: {formattedMarketCap}</span>
-        <span style={{ fontSize: "28px", color: priceChangeColor }}>
-          24h Change: {formattedPriceChange}%
-        </span>
       </div>
     </div>
   );

--- a/src/pages/api/metadata/token.tsx
+++ b/src/pages/api/metadata/token.tsx
@@ -80,7 +80,14 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
           style={{ borderRadius: "80px", alignSelf: "center" }}
         />
       )}
-      <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "12px",
+          paddingLeft: "20px",
+        }}
+      >
         <span style={{ fontSize: "56px", fontWeight: "bold" }}>{data.name}</span>
         <span style={{ fontSize: "42px", color: "#555" }}>{`$${data.symbol}`}</span>
         <span style={{ fontSize: "28px" }}>Address: {data.address}</span>

--- a/src/pages/api/metadata/token.tsx
+++ b/src/pages/api/metadata/token.tsx
@@ -53,7 +53,7 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
     ? priceChangeNumber >= 0
       ? "green"
       : "red"
-    : "#000";
+    : "white";
   const formattedPriceChange = Number.isFinite(priceChangeNumber)
     ? priceChangeNumber.toFixed(2)
     : data.priceChange;
@@ -67,7 +67,8 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
         display: "flex",
         flexDirection: "column",
         alignItems: "flex-start",
-        background: "white",
+        background: "black",
+        color: "white",
         gap: "32px",
         fontFamily: "Arial, sans-serif",
       }}
@@ -89,7 +90,7 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
         }}
       >
         <span style={{ fontSize: "56px", fontWeight: "bold" }}>{data.name}</span>
-        <span style={{ fontSize: "42px", color: "#555" }}>{`$${data.symbol}`}</span>
+        <span style={{ fontSize: "42px", color: "white" }}>{`$${data.symbol}`}</span>
         <span style={{ fontSize: "28px" }}>Address: {data.address}</span>
         <span style={{ fontSize: "28px" }}>Market Cap: {formattedMarketCap}</span>
         <span style={{ fontSize: "28px", color: priceChangeColor }}>


### PR DESCRIPTION
## Summary
- allow dynamic token metadata images
- expose new token metadata endpoint
- include token metadata in token space layout
- provide token price change via fetchTokenData
- correct Twitter metadata properties for dynamic token images

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.