### PR TITLE
Update EditorPanel with mobile drag reorder

### DIFF
--- a/src/common/components/molecules/IconSelector.tsx
+++ b/src/common/components/molecules/IconSelector.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState, useRef } from 'react'
+import { SearchIcon, UploadIcon } from 'lucide-react'
+import { createPortal } from 'react-dom'
+
+interface IconSelectorProps {
+  onSelectIcon: (icon: string) => void
+  triggerRef: React.RefObject<HTMLElement>
+  onClose: () => void
+}
+
+export function IconSelector({ onSelectIcon, triggerRef, onClose }: IconSelectorProps) {
+  const [searchTerm, setSearchTerm] = useState('')
+  const [activeTab, setActiveTab] = useState<'library' | 'custom'>('library')
+  const [position, setPosition] = useState({ top: 0, left: 0, width: 0 })
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  const iconLibrary = [
+    'RssIcon',
+    'VoteIcon',
+    'ImageIcon',
+    'HomeIcon',
+    'GiftIcon',
+    'UserIcon',
+    'SettingsIcon',
+    'BellIcon',
+    'CalendarIcon',
+    'MessageIcon',
+    'FileIcon',
+    'FolderIcon',
+    'StarIcon',
+    'HeartIcon',
+    'ShareIcon',
+  ]
+  const filteredIcons = iconLibrary.filter((icon) =>
+    icon.toLowerCase().includes(searchTerm.toLowerCase()),
+  )
+
+  useEffect(() => {
+    if (triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect()
+      const windowHeight = window.innerHeight
+      const windowWidth = window.innerWidth
+      const dropdownWidth = Math.max(320, rect.width)
+      const dropdownHeight = 400
+      let top = rect.bottom + window.scrollY + 4
+      let left = rect.left + window.scrollX
+      if (rect.bottom + dropdownHeight > windowHeight) {
+        top = rect.top + window.scrollY - dropdownHeight - 4
+      }
+      if (left + dropdownWidth > windowWidth) {
+        left = windowWidth - dropdownWidth - 16
+      }
+      setPosition({ top, left, width: dropdownWidth })
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node) &&
+        !triggerRef.current?.contains(event.target as Node)
+      ) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [triggerRef, onClose])
+
+  const handleIconSelect = (icon: string) => {
+    onSelectIcon(icon)
+    onClose()
+  }
+
+  return createPortal(
+    <div
+      ref={dropdownRef}
+      className="fixed bg-white border border-gray-200 rounded-md shadow-lg z-50 max-h-80 overflow-auto"
+      style={{ top: `${position.top}px`, left: `${position.left}px`, width: `${position.width}px` }}
+    >
+      <div className="p-3 border-b border-gray-200">
+        <div className="relative">
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <SearchIcon className="h-4 w-4 text-gray-400" />
+          </div>
+          <input
+            type="text"
+            placeholder="Search icons..."
+            className="pl-10 w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="flex border-b border-gray-200">
+        <button
+          className={`flex-1 px-4 py-2 text-sm font-medium ${activeTab === 'library' ? 'text-blue-600 border-b-2 border-blue-600' : 'text-gray-500'}`}
+          onClick={() => setActiveTab('library')}
+        >
+          Icon Library
+        </button>
+        <button
+          className={`flex-1 px-4 py-2 text-sm font-medium ${activeTab === 'custom' ? 'text-blue-600 border-b-2 border-blue-600' : 'text-gray-500'}`}
+          onClick={() => setActiveTab('custom')}
+        >
+          Custom Upload
+        </button>
+      </div>
+      {activeTab === 'library' ? (
+        <div className="p-3 grid grid-cols-5 gap-2">
+          {filteredIcons.length > 0 ? (
+            filteredIcons.map((icon) => (
+              <button
+                key={icon}
+                onClick={() => handleIconSelect(icon)}
+                className="flex flex-col items-center justify-center p-2 hover:bg-gray-100 rounded-md"
+              >
+                <div className="w-8 h-8 bg-gray-100 rounded-md flex items-center justify-center mb-1">
+                  {icon.charAt(0)}
+                </div>
+                <span className="text-xs text-gray-600 truncate w-full text-center">
+                  {icon}
+                </span>
+              </button>
+            ))
+          ) : (
+            <div className="col-span-5 py-4 text-center text-gray-500">No icons found</div>
+          )}
+        </div>
+      ) : (
+        <div className="p-6 flex flex-col items-center justify-center">
+          <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mb-4">
+            <UploadIcon className="h-8 w-8 text-gray-400" />
+          </div>
+          <p className="text-sm text-gray-600 mb-4 text-center">
+            Upload a custom icon (SVG, PNG, or JPG)
+          </p>
+          <label className="cursor-pointer bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded-md">
+            <span>Upload Icon</span>
+            <input type="file" className="hidden" accept="image/*" />
+          </label>
+        </div>
+      )}
+    </div>,
+    document.body,
+  )
+}
+
+export default IconSelector

--- a/src/common/components/molecules/IconSelector.tsx
+++ b/src/common/components/molecules/IconSelector.tsx
@@ -2,8 +2,17 @@ import React, { useEffect, useState, useRef } from 'react'
 import { SearchIcon, UploadIcon } from 'lucide-react'
 import { createPortal } from 'react-dom'
 import * as FaIcons from 'react-icons/fa6'
+import * as BsIcons from 'react-icons/bs'
+import * as GiIcons from 'react-icons/gi'
 import type { IconType } from 'react-icons'
+import { DEFAULT_FIDGET_ICON_MAP } from '@/constants/mobileFidgetIcons'
 import ImgBBUploader from './ImgBBUploader'
+
+const ICON_PACK: Record<string, IconType> = {
+  ...FaIcons,
+  ...BsIcons,
+  ...GiIcons,
+}
 
 interface IconSelectorProps {
   onSelectIcon: (icon: string) => void
@@ -33,8 +42,10 @@ export function IconSelector({ onSelectIcon, triggerRef, onClose }: IconSelector
     'FaStar',
     'FaHeart',
     'FaShareNodes',
+    ...Object.values(DEFAULT_FIDGET_ICON_MAP),
   ]
-  const filteredIcons = iconLibrary.filter((icon) =>
+  const uniqueIcons = Array.from(new Set(iconLibrary))
+  const filteredIcons = uniqueIcons.filter((icon) =>
     icon.toLowerCase().includes(searchTerm.toLowerCase()),
   )
 
@@ -112,7 +123,7 @@ export function IconSelector({ onSelectIcon, triggerRef, onClose }: IconSelector
         <div className="p-3 grid grid-cols-5 gap-2">
           {filteredIcons.length > 0 ? (
             filteredIcons.map((icon) => {
-              const Icon = (FaIcons as Record<string, IconType>)[icon] as IconType
+              const Icon = ICON_PACK[icon] as IconType | undefined
               return (
                 <button
                   key={icon}

--- a/src/common/components/molecules/IconSelector.tsx
+++ b/src/common/components/molecules/IconSelector.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useState, useRef } from 'react'
 import { SearchIcon, UploadIcon } from 'lucide-react'
 import { createPortal } from 'react-dom'
+import * as FaIcons from 'react-icons/fa6'
+import type { IconType } from 'react-icons'
+import ImgBBUploader from './ImgBBUploader'
 
 interface IconSelectorProps {
   onSelectIcon: (icon: string) => void
@@ -15,21 +18,21 @@ export function IconSelector({ onSelectIcon, triggerRef, onClose }: IconSelector
   const dropdownRef = useRef<HTMLDivElement>(null)
 
   const iconLibrary = [
-    'RssIcon',
-    'VoteIcon',
-    'ImageIcon',
-    'HomeIcon',
-    'GiftIcon',
-    'UserIcon',
-    'SettingsIcon',
-    'BellIcon',
-    'CalendarIcon',
-    'MessageIcon',
-    'FileIcon',
-    'FolderIcon',
-    'StarIcon',
-    'HeartIcon',
-    'ShareIcon',
+    'FaRss',
+    'FaVoteYea',
+    'FaImage',
+    'FaHouse',
+    'FaGift',
+    'FaUser',
+    'FaGear',
+    'FaBell',
+    'FaCalendar',
+    'FaEnvelope',
+    'FaFile',
+    'FaFolder',
+    'FaStar',
+    'FaHeart',
+    'FaShareNodes',
   ]
   const filteredIcons = iconLibrary.filter((icon) =>
     icon.toLowerCase().includes(searchTerm.toLowerCase()),
@@ -108,20 +111,23 @@ export function IconSelector({ onSelectIcon, triggerRef, onClose }: IconSelector
       {activeTab === 'library' ? (
         <div className="p-3 grid grid-cols-5 gap-2">
           {filteredIcons.length > 0 ? (
-            filteredIcons.map((icon) => (
-              <button
-                key={icon}
-                onClick={() => handleIconSelect(icon)}
-                className="flex flex-col items-center justify-center p-2 hover:bg-gray-100 rounded-md"
-              >
-                <div className="w-8 h-8 bg-gray-100 rounded-md flex items-center justify-center mb-1">
-                  {icon.charAt(0)}
-                </div>
-                <span className="text-xs text-gray-600 truncate w-full text-center">
-                  {icon}
-                </span>
-              </button>
-            ))
+            filteredIcons.map((icon) => {
+              const Icon = (FaIcons as Record<string, IconType>)[icon] as IconType
+              return (
+                <button
+                  key={icon}
+                  onClick={() => handleIconSelect(icon)}
+                  className="flex flex-col items-center justify-center p-2 hover:bg-gray-100 rounded-md"
+                >
+                  <div className="w-8 h-8 bg-gray-100 rounded-md flex items-center justify-center mb-1">
+                    {Icon ? <Icon className="w-5 h-5" /> : icon.charAt(0)}
+                  </div>
+                  <span className="text-xs text-gray-600 truncate w-full text-center">
+                    {icon}
+                  </span>
+                </button>
+              )
+            })
           ) : (
             <div className="col-span-5 py-4 text-center text-gray-500">No icons found</div>
           )}
@@ -134,10 +140,7 @@ export function IconSelector({ onSelectIcon, triggerRef, onClose }: IconSelector
           <p className="text-sm text-gray-600 mb-4 text-center">
             Upload a custom icon (SVG, PNG, or JPG)
           </p>
-          <label className="cursor-pointer bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded-md">
-            <span>Upload Icon</span>
-            <input type="file" className="hidden" accept="image/*" />
-          </label>
+          <ImgBBUploader onImageUploaded={handleIconSelect} />
         </div>
       )}
     </div>,

--- a/src/common/components/molecules/MiniAppSettings.tsx
+++ b/src/common/components/molecules/MiniAppSettings.tsx
@@ -1,0 +1,133 @@
+import React, { useState, useRef } from 'react'
+import { DragControls } from 'framer-motion'
+import { IconSelector } from './IconSelector'
+import { EyeIcon, EyeOffIcon, GripVerticalIcon } from 'lucide-react'
+
+export interface MiniApp {
+  id: string | number
+  name: string
+  mobileDisplayName: string
+  context?: string
+  order: number
+  icon: string
+  displayOnMobile: boolean
+}
+
+interface MiniAppSettingsProps {
+  miniApp: MiniApp
+  onUpdateMiniApp: (app: MiniApp) => void
+  dragControls?: DragControls
+}
+
+export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls }: MiniAppSettingsProps) {
+  const [isIconSelectorOpen, setIsIconSelectorOpen] = useState(false)
+  const iconButtonRef = useRef<HTMLButtonElement>(null)
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onUpdateMiniApp({ ...miniApp, mobileDisplayName: e.target.value })
+  }
+
+  const handleIconSelect = (iconName: string) => {
+    onUpdateMiniApp({ ...miniApp, icon: iconName })
+    setIsIconSelectorOpen(false)
+  }
+
+  const toggleVisibility = () => {
+    onUpdateMiniApp({ ...miniApp, displayOnMobile: !miniApp.displayOnMobile })
+  }
+
+  const getIconComponent = (iconName: string) => {
+    const IconMap: Record<string, React.ReactNode> = {
+      RssIcon: (
+        <div className="w-6 h-6 bg-blue-100 text-blue-600 flex items-center justify-center rounded">
+          RSS
+        </div>
+      ),
+      VoteIcon: (
+        <div className="w-6 h-6 bg-purple-100 text-purple-600 flex items-center justify-center rounded">
+          V
+        </div>
+      ),
+      ImageIcon: (
+        <div className="w-6 h-6 bg-green-100 text-green-600 flex items-center justify-center rounded">
+          I
+        </div>
+      ),
+      HomeIcon: (
+        <div className="w-6 h-6 bg-yellow-100 text-yellow-600 flex items-center justify-center rounded">
+          H
+        </div>
+      ),
+      GiftIcon: (
+        <div className="w-6 h-6 bg-red-100 text-red-600 flex items-center justify-center rounded">
+          G
+        </div>
+      ),
+    }
+    return (
+      IconMap[iconName] || (
+        <div className="w-6 h-6 bg-gray-100 flex items-center justify-center rounded">?</div>
+      )
+    );
+  }
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg">
+      <div className="p-3">
+        <div className="flex items-center gap-2 mb-3">
+          <div
+            className="cursor-move p-1 hover:bg-gray-100 rounded shrink-0"
+            title="Drag to reorder"
+            onPointerDown={(e) => dragControls?.start(e)}
+          >
+            <GripVerticalIcon className="h-4 w-4 text-gray-400" />
+          </div>
+          <div className="text-sm text-gray-500 truncate flex-1">
+            {miniApp.context}
+          </div>
+          <button
+            onClick={toggleVisibility}
+            className={`p-1.5 rounded-md transition-colors shrink-0 ${miniApp.displayOnMobile ? 'bg-blue-100 text-blue-600 hover:bg-blue-200' : 'bg-gray-100 text-gray-400 hover:bg-gray-200'}`}
+          >
+            {miniApp.displayOnMobile ? (
+              <EyeIcon className="h-4 w-4" />
+            ) : (
+              <EyeOffIcon className="h-4 w-4" />
+            )}
+          </button>
+        </div>
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <label className="block text-xs text-gray-500 mb-1">Name</label>
+            <input
+              type="text"
+              value={miniApp.mobileDisplayName}
+              onChange={handleNameChange}
+              className="w-full h-10 px-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Display name"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">Icon</label>
+            <button
+              type="button"
+              ref={iconButtonRef}
+              onClick={() => setIsIconSelectorOpen(!isIconSelectorOpen)}
+              className="h-10 w-10 flex items-center justify-center border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {getIconComponent(miniApp.icon)}
+            </button>
+            {isIconSelectorOpen && (
+              <IconSelector
+                onSelectIcon={handleIconSelect}
+                triggerRef={iconButtonRef}
+                onClose={() => setIsIconSelectorOpen(false)}
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default MiniAppSettings

--- a/src/common/components/molecules/MiniAppSettings.tsx
+++ b/src/common/components/molecules/MiniAppSettings.tsx
@@ -72,7 +72,7 @@ export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls }: Mini
   }
   return (
     <div className="bg-white border border-gray-200 rounded-lg">
-      <div className="p-3">
+      <div className="py-2 px-2">
         <div className="flex items-center gap-2 mb-3">
           <div
             className="cursor-move p-1 hover:bg-gray-100 rounded shrink-0"
@@ -97,7 +97,7 @@ export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls }: Mini
         </div>
         <div className="flex gap-2">
           <div className="flex-1">
-            <label className="block text-xs text-gray-500 mb-1">Name</label>
+            <label className="block text-xs text-gray-500 mb-1">Display Name</label>
             <input
               type="text"
               value={miniApp.mobileDisplayName}

--- a/src/common/components/molecules/MiniAppSettings.tsx
+++ b/src/common/components/molecules/MiniAppSettings.tsx
@@ -2,6 +2,8 @@ import React, { useState, useRef } from 'react'
 import { DragControls } from 'framer-motion'
 import { IconSelector } from './IconSelector'
 import { EyeIcon, EyeOffIcon, GripVerticalIcon } from 'lucide-react'
+import * as FaIcons from 'react-icons/fa6'
+import type { IconType } from 'react-icons'
 
 export interface MiniApp {
   id: string | number
@@ -38,38 +40,26 @@ export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls, orderN
   }
 
   const getIconComponent = (iconName: string) => {
-    const IconMap: Record<string, React.ReactNode> = {
-      RssIcon: (
-        <div className="w-6 h-6 bg-blue-100 text-blue-600 flex items-center justify-center rounded">
-          RSS
-        </div>
-      ),
-      VoteIcon: (
-        <div className="w-6 h-6 bg-purple-100 text-purple-600 flex items-center justify-center rounded">
-          V
-        </div>
-      ),
-      ImageIcon: (
-        <div className="w-6 h-6 bg-green-100 text-green-600 flex items-center justify-center rounded">
-          I
-        </div>
-      ),
-      HomeIcon: (
-        <div className="w-6 h-6 bg-yellow-100 text-yellow-600 flex items-center justify-center rounded">
-          H
-        </div>
-      ),
-      GiftIcon: (
-        <div className="w-6 h-6 bg-red-100 text-red-600 flex items-center justify-center rounded">
-          G
-        </div>
-      ),
-    }
-    return (
-      IconMap[iconName] || (
+    if (!iconName) {
+      return (
         <div className="w-6 h-6 bg-gray-100 flex items-center justify-center rounded">?</div>
       )
-    );
+    }
+
+    if (iconName.startsWith('http')) {
+      return (
+        <img src={iconName} alt="icon" className="w-6 h-6 rounded object-contain" />
+      )
+    }
+
+    const Icon = (FaIcons as Record<string, IconType>)[iconName] as IconType
+    if (Icon) {
+      return <Icon className="w-6 h-6" />
+    }
+
+    return (
+      <div className="w-6 h-6 bg-gray-100 flex items-center justify-center rounded">?</div>
+    )
   }
   return (
     <div className="py-2 border-y">

--- a/src/common/components/molecules/MiniAppSettings.tsx
+++ b/src/common/components/molecules/MiniAppSettings.tsx
@@ -71,9 +71,9 @@ export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls }: Mini
     );
   }
   return (
-    <div className="bg-white border border-gray-200 rounded-lg">
-      <div className="py-2 px-2">
-        <div className="flex items-center gap-2 mb-3">
+    <div className="py-2 border-b last:border-b-0">
+      <div className="px-2">
+        <div className="flex items-center gap-2 mb-2">
           <div
             className="cursor-move p-1 hover:bg-gray-100 rounded shrink-0"
             title="Drag to reorder"

--- a/src/common/components/molecules/MiniAppSettings.tsx
+++ b/src/common/components/molecules/MiniAppSettings.tsx
@@ -17,9 +17,10 @@ interface MiniAppSettingsProps {
   miniApp: MiniApp
   onUpdateMiniApp: (app: MiniApp) => void
   dragControls?: DragControls
+  orderNumber?: number
 }
 
-export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls }: MiniAppSettingsProps) {
+export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls, orderNumber }: MiniAppSettingsProps) {
   const [isIconSelectorOpen, setIsIconSelectorOpen] = useState(false)
   const iconButtonRef = useRef<HTMLButtonElement>(null)
 
@@ -71,8 +72,8 @@ export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls }: Mini
     );
   }
   return (
-    <div className="py-2 border-b last:border-b-0">
-      <div className="px-2">
+    <div className="py-2 border-y">
+      <div className="px-1">
         <div className="flex items-center gap-2 mb-2">
           <div
             className="cursor-move p-1 hover:bg-gray-100 rounded shrink-0"
@@ -81,6 +82,9 @@ export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls }: Mini
           >
             <GripVerticalIcon className="h-4 w-4 text-gray-400" />
           </div>
+          <span className="text-xs text-gray-400 w-4 text-center">
+            {orderNumber ?? "-"}
+          </span>
           <div className="text-sm text-gray-500 truncate flex-1">
             {miniApp.context}
           </div>

--- a/src/common/components/molecules/MiniAppSettings.tsx
+++ b/src/common/components/molecules/MiniAppSettings.tsx
@@ -3,7 +3,15 @@ import { DragControls } from 'framer-motion'
 import { IconSelector } from './IconSelector'
 import { EyeIcon, EyeOffIcon, GripVerticalIcon } from 'lucide-react'
 import * as FaIcons from 'react-icons/fa6'
+import * as BsIcons from 'react-icons/bs'
+import * as GiIcons from 'react-icons/gi'
 import type { IconType } from 'react-icons'
+
+const ICON_PACK: Record<string, IconType> = {
+  ...FaIcons,
+  ...BsIcons,
+  ...GiIcons,
+}
 
 export interface MiniApp {
   id: string | number
@@ -52,7 +60,7 @@ export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls, orderN
       )
     }
 
-    const Icon = (FaIcons as Record<string, IconType>)[iconName] as IconType
+    const Icon = ICON_PACK[iconName] as IconType | undefined
     if (Icon) {
       return <Icon className="w-6 h-6" />
     }

--- a/src/common/components/molecules/VideoSelector.tsx
+++ b/src/common/components/molecules/VideoSelector.tsx
@@ -69,7 +69,7 @@ export function VideoSelector({
 
       {selectedVideo && (
         <div className="mt-4">
-          <h5>Selected Song:</h5>
+          <h5 className="text-sm">Selected Song:</h5>
           <Player url={selectedVideo} />
         </div>
       )}

--- a/src/common/components/organisms/EditorPanel.tsx
+++ b/src/common/components/organisms/EditorPanel.tsx
@@ -136,12 +136,14 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({
                   setIsPickingFidget={setIsPickingFidget}
                 />
               ) : (
-                <ThemeSettingsEditor
-                  theme={theme}
-                  saveTheme={saveTheme}
-                  saveExitEditMode={saveExitEditMode}
-                  cancelExitEditMode={cancelExitEditMode}
-                />
+              <ThemeSettingsEditor
+                theme={theme}
+                saveTheme={saveTheme}
+                saveExitEditMode={saveExitEditMode}
+                cancelExitEditMode={cancelExitEditMode}
+                fidgetInstanceDatums={fidgetInstanceDatums}
+                saveFidgetInstanceDatums={saveFidgetInstanceDatums}
+              />
               )}
             </>
           )}

--- a/src/common/components/organisms/MobileSettings.tsx
+++ b/src/common/components/organisms/MobileSettings.tsx
@@ -11,9 +11,11 @@ interface MobileSettingsProps {
 function DraggableMiniApp({
   miniApp,
   onUpdateMiniApp,
+  orderNumber,
 }: {
   miniApp: MiniApp
   onUpdateMiniApp: (app: MiniApp) => void
+  orderNumber?: number
 }) {
   const controls = useDragControls()
   return (
@@ -27,6 +29,7 @@ function DraggableMiniApp({
         miniApp={miniApp}
         onUpdateMiniApp={onUpdateMiniApp}
         dragControls={controls}
+        orderNumber={orderNumber}
       />
     </Reorder.Item>
   )
@@ -49,8 +52,15 @@ export function MobileSettings({
     onReorderMiniApps(newOrder)
   }
 
+  const visibleOrderMap: Record<string | number, number> = {}
+  items
+    .filter((app) => app.displayOnMobile)
+    .forEach((app, index) => {
+      visibleOrderMap[app.id] = index + 1
+    })
+
   return (
-    <div className="p-2">
+    <div className="px-2 pt-1 pb-2">
       <p className="text-sm text-gray-500 mb-4">
         Drag fidgets to reorder them in the mobile nav, and customize their
         visibility, display name, and icon.
@@ -66,6 +76,7 @@ export function MobileSettings({
             key={miniApp.id}
             miniApp={miniApp}
             onUpdateMiniApp={onUpdateMiniApp}
+            orderNumber={visibleOrderMap[miniApp.id]}
           />
         ))}
       </Reorder.Group>

--- a/src/common/components/organisms/MobileSettings.tsx
+++ b/src/common/components/organisms/MobileSettings.tsx
@@ -55,7 +55,12 @@ export function MobileSettings({
         Drag fidgets to reorder them in the mobile nav, and customize their
         visibility, display name, and icon.
       </p>
-      <Reorder.Group axis="y" values={items} onReorder={handleReorder} className="space-y-3">
+      <Reorder.Group
+        axis="y"
+        values={items}
+        onReorder={handleReorder}
+        className="flex flex-col"
+      >
         {items.map((miniApp) => (
           <DraggableMiniApp
             key={miniApp.id}

--- a/src/common/components/organisms/MobileSettings.tsx
+++ b/src/common/components/organisms/MobileSettings.tsx
@@ -50,12 +50,11 @@ export function MobileSettings({
   }
 
   return (
-    <div className="p-4">
-      <h2 className="text-lg font-semibold mb-2">Edit</h2>
-      <div className="mb-6">
-        <h3 className="text-md font-medium mb-1">Mobile Settings</h3>
-        <p className="text-sm text-gray-500 mb-4">Configure how fidgets appear on mobile</p>
-      </div>
+    <div className="p-2">
+      <p className="text-sm text-gray-500 mb-4">
+        Drag fidgets to reorder them in the mobile nav, and customize their
+        visibility, display name, and icon.
+      </p>
       <Reorder.Group axis="y" values={items} onReorder={handleReorder} className="space-y-3">
         {items.map((miniApp) => (
           <DraggableMiniApp

--- a/src/common/components/organisms/MobileSettings.tsx
+++ b/src/common/components/organisms/MobileSettings.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react'
+import { Reorder, useDragControls } from 'framer-motion'
+import MiniAppSettings, { MiniApp } from '../molecules/MiniAppSettings'
+
+interface MobileSettingsProps {
+  miniApps: MiniApp[]
+  onUpdateMiniApp: (app: MiniApp) => void
+  onReorderMiniApps: (apps: MiniApp[]) => void
+}
+
+function DraggableMiniApp({
+  miniApp,
+  onUpdateMiniApp,
+}: {
+  miniApp: MiniApp
+  onUpdateMiniApp: (app: MiniApp) => void
+}) {
+  const controls = useDragControls()
+  return (
+    <Reorder.Item
+      value={miniApp}
+      dragListener={false}
+      dragControls={controls}
+      className="cursor-default"
+    >
+      <MiniAppSettings
+        miniApp={miniApp}
+        onUpdateMiniApp={onUpdateMiniApp}
+        dragControls={controls}
+      />
+    </Reorder.Item>
+  )
+}
+
+export function MobileSettings({
+  miniApps,
+  onUpdateMiniApp,
+  onReorderMiniApps,
+}: MobileSettingsProps) {
+  const [items, setItems] = useState<MiniApp[]>([])
+
+  useEffect(() => {
+    const sorted = [...miniApps].sort((a, b) => a.order - b.order)
+    setItems(sorted)
+  }, [miniApps])
+
+  const handleReorder = (newOrder: MiniApp[]) => {
+    setItems(newOrder)
+    onReorderMiniApps(newOrder)
+  }
+
+  return (
+    <div className="p-4">
+      <h2 className="text-lg font-semibold mb-2">Edit</h2>
+      <div className="mb-6">
+        <h3 className="text-md font-medium mb-1">Mobile Settings</h3>
+        <p className="text-sm text-gray-500 mb-4">Configure how fidgets appear on mobile</p>
+      </div>
+      <Reorder.Group axis="y" values={items} onReorder={handleReorder} className="space-y-3">
+        {items.map((miniApp) => (
+          <DraggableMiniApp
+            key={miniApp.id}
+            miniApp={miniApp}
+            onUpdateMiniApp={onUpdateMiniApp}
+          />
+        ))}
+      </Reorder.Group>
+    </div>
+  )
+}
+
+export default MobileSettings

--- a/src/common/fidgets/index.d.ts
+++ b/src/common/fidgets/index.d.ts
@@ -20,6 +20,8 @@ export type FidgetSettings = {
 export type FidgetSettingsStyle = {
   showOnMobile?: boolean;
   customMobileDisplayName?: string;
+  mobileIconName?: string;
+  mobileOrder?: number;
   background?: Color;
   fontFamily?: FontFamily;
   fontColor?: Color;

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -262,7 +262,7 @@ export function ThemeSettingsEditor({
                 <TabsContent value="space" className={tabContentClasses}>
                   <div className="flex flex-col gap-1">
                     <div className="flex flex-row gap-1">
-                      <h4 className="text-sm">Headings</h4>
+                      <h4 className="text-sm">Heading Font</h4>
                       <ThemeSettingsTooltip text="The primary, or header font that Fidgets can inherit." />
                     </div>
                     <div className="flex items-center gap-1">
@@ -283,7 +283,7 @@ export function ThemeSettingsEditor({
                   </div>
                   <div className="flex flex-col gap-1">
                     <div className="flex flex-row gap-1">
-                      <h4 className="text-sm">Body</h4>
+                      <h4 className="text-sm">Body Font</h4>
                       <ThemeSettingsTooltip text="The secondary, or body font that Fidgets can inherit." />
                     </div>
                     <div className="flex items-center gap-1">
@@ -303,7 +303,6 @@ export function ThemeSettingsEditor({
                     </div>
                   </div>
                   <div className="flex flex-col gap-1 mt-4">
-                    <h4 className="text-sm font-bold my-2">Space Settings</h4>
                     <div className="flex flex-row gap-1">
                       <h4 className="text-sm">Background color</h4>
                       <ThemeSettingsTooltip text="Set a solid background or gradient color. You can also add custom backgrounds with HTML/CSS on the Generate section." />
@@ -319,61 +318,62 @@ export function ThemeSettingsEditor({
                     backgroundHTML={backgroundHTML}
                     onChange={themePropSetter<string>("backgroundHTML")}
                   />
+                  <div className="grid gap-2 mt-4">
+                    <div className="flex flex-row gap-1">
+                      <h4 className="text-sm">Music</h4>
+                      <ThemeSettingsTooltip text="Search or paste Youtube link for any song, video, or playlist." />
+                    </div>
+                    <VideoSelector
+                      initialVideoURL={theme.properties.musicURL}
+                      onVideoSelect={themePropSetter("musicURL")}
+                    />
+                  </div>
                 </TabsContent>
                 {/* Fidgets */}
                 <TabsContent value="fidgets" className={tabContentClasses}>
-                  <div className="flex flex-col gap-1">
-                    <h4 className="text-sm font-bold my-2">Fidget Settings</h4>
-                    <div className="flex flex-col gap-1">
-                      <div className="">
-                        <div className="flex flex-row gap-1">
-                          <h5 className="text-sm">Background color</h5>
-                          <ThemeSettingsTooltip text="Set the default background color for all Fidgets on your Space." />
-                        </div>
-                        <ColorSelector
-                          className="rounded-full overflow-hidden w-6 h-6 shrink-0 my-2"
-                          innerClassName="rounded-full"
-                          value={fidgetBackground as Color}
-                          onChange={themePropSetter<Color>("fidgetBackground")}
-                        />
-                      </div>
-                      <div className="">
-                        <div className="flex flex-row gap-1">
-                          <h5 className="text-sm">Border</h5>
-                          <ThemeSettingsTooltip text="Set the default border width and color for all Fidgets on your Space." />
-                        </div>
-                        <div className="flex items-center gap-1">
-                          <ColorSelector
-                            className="rounded-full overflow-hidden w-6 h-6 shrink-0"
-                            innerClassName="rounded-full"
-                            value={fidgetBorderColor as Color}
-                            onChange={themePropSetter<Color>(
-                              "fidgetBorderColor",
-                            )}
-                          />
-                          <BorderSelector
-                            className="ring-0 focus:ring-0 border-0 shadow-none"
-                            value={fidgetBorderWidth as string}
-                            onChange={themePropSetter<string>(
-                              "fidgetBorderWidth",
-                            )}
-                            hideGlobalSettings
-                          />
-                        </div>
-                      </div>
-                      <div className="">
-                        <div className="flex flex-row gap-1">
-                          <h5 className="text-sm">Shadow</h5>
-                          <ThemeSettingsTooltip text="Set the default shadow for all Fidgets on your Space." />
-                        </div>
-                        <ShadowSelector
-                          className="ring-0 focus:ring-0 border-0 shadow-none"
-                          value={fidgetShadow as string}
-                          onChange={themePropSetter<string>("fidgetShadow")}
-                          hideGlobalSettings
-                        />
-                      </div>
+                  <div className="">
+                    <div className="flex flex-row gap-1">
+                      <h5 className="text-sm">Background color</h5>
+                      <ThemeSettingsTooltip text="Set the default background color for all Fidgets on your Space." />
                     </div>
+                    <ColorSelector
+                      className="rounded-full overflow-hidden w-6 h-6 shrink-0 my-2"
+                      innerClassName="rounded-full"
+                      value={fidgetBackground as Color}
+                      onChange={themePropSetter<Color>("fidgetBackground")}
+                    />
+                  </div>
+                  <div className="">
+                    <div className="flex flex-row gap-1">
+                      <h5 className="text-sm">Border</h5>
+                      <ThemeSettingsTooltip text="Set the default border width and color for all Fidgets on your Space." />
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <ColorSelector
+                        className="rounded-full overflow-hidden w-6 h-6 shrink-0"
+                        innerClassName="rounded-full"
+                        value={fidgetBorderColor as Color}
+                        onChange={themePropSetter<Color>("fidgetBorderColor")}
+                      />
+                      <BorderSelector
+                        className="ring-0 focus:ring-0 border-0 shadow-none"
+                        value={fidgetBorderWidth as string}
+                        onChange={themePropSetter<string>("fidgetBorderWidth")}
+                        hideGlobalSettings
+                      />
+                    </div>
+                  </div>
+                  <div className="">
+                    <div className="flex flex-row gap-1">
+                      <h5 className="text-sm">Shadow</h5>
+                      <ThemeSettingsTooltip text="Set the default shadow for all Fidgets on your Space." />
+                    </div>
+                    <ShadowSelector
+                      className="ring-0 focus:ring-0 border-0 shadow-none"
+                      value={fidgetShadow as string}
+                      onChange={themePropSetter<string>("fidgetShadow")}
+                      hideGlobalSettings
+                    />
                   </div>
                 </TabsContent>
                 {/* Mobile */}
@@ -385,17 +385,6 @@ export function ThemeSettingsEditor({
                   />
                 </TabsContent>
               </Tabs>
-            </div>
-
-            <div className="grid gap-2 mt-4">
-              <div className="flex flex-row gap-1">
-                <h4 className="text-sm">Music</h4>
-                <ThemeSettingsTooltip text="Search or paste Youtube link for any song, video, or playlist." />
-              </div>
-              <VideoSelector
-                initialVideoURL={theme.properties.musicURL}
-                onVideoSelect={themePropSetter("musicURL")}
-              />
             </div>
           </div>
         </div>

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -48,6 +48,7 @@ import { Address, formatUnits, zeroAddress } from "viem";
 import { base } from "viem/chains";
 import { useBalance } from "wagmi";
 import { CompleteFidgets } from "@/fidgets";
+import { DEFAULT_FIDGET_ICON_MAP } from "@/constants/mobileFidgetIcons";
 import MobileSettings from "@/common/components/organisms/MobileSettings";
 import { MiniApp } from "@/common/components/molecules/MiniAppSettings";
 
@@ -75,6 +76,7 @@ export function ThemeSettingsEditor({
   const miniApps = useMemo<MiniApp[]>(() => {
     return Object.values(fidgetInstanceDatums).map((d, i) => {
       const props = CompleteFidgets[d.fidgetType]?.properties;
+      const defaultIcon = DEFAULT_FIDGET_ICON_MAP[d.fidgetType] ?? 'HomeIcon';
       return {
         id: d.id,
         name: d.fidgetType,
@@ -84,7 +86,7 @@ export function ThemeSettingsEditor({
           props?.fidgetName,
         context: props?.fidgetName,
         order: (d.config.settings.mobileOrder as number) || i + 1,
-        icon: (d.config.settings.mobileIconName as string) || 'HomeIcon',
+        icon: (d.config.settings.mobileIconName as string) || defaultIcon,
         displayOnMobile: d.config.settings.showOnMobile !== false,
       };
     });

--- a/src/constants/mobileFidgetIcons.ts
+++ b/src/constants/mobileFidgetIcons.ts
@@ -1,0 +1,16 @@
+export const DEFAULT_FIDGET_ICON_MAP: Record<string, string> = {
+  frame: 'BsAspectRatio',
+  cast: 'BsPin',
+  feed: 'BsChatRightHeart',
+  SnapShot: 'BsFillLightningChargeFill',
+  iframe: 'BsCloud',
+  FramesV2: 'BsCloud',
+  links: 'BsLink45Deg',
+  Swap: 'BsArrowRepeat',
+  Rss: 'BsRss',
+  Market: 'BsBarChart',
+  Portfolio: 'GiTwoCoins',
+  Chat: 'BsChatDots',
+  profile: 'BsPerson',
+};
+

--- a/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
+++ b/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
@@ -3,9 +3,17 @@ import { TabsList, TabsTrigger } from "@/common/components/atoms/tabs";
 import { BsImage, BsImageFill, BsFillPinFill, BsPin } from "react-icons/bs";
 import { MdGridView } from "react-icons/md";
 import * as FaIcons from "react-icons/fa6";
+import * as BsIcons from "react-icons/bs";
+import * as GiIcons from "react-icons/gi";
 import type { IconType } from "react-icons";
 import { CompleteFidgets } from "@/fidgets";
 import { getFidgetDisplayName } from "../utils";
+
+const ICON_PACK: Record<string, IconType> = {
+  ...FaIcons,
+  ...BsIcons,
+  ...GiIcons,
+};
 import { usePathname } from "next/navigation";
 
 interface TabNavigationProps {
@@ -174,7 +182,7 @@ const TabNavigation: React.FC<TabNavigationProps> = ({
         if (customIcon.startsWith('http')) {
           return <img src={customIcon} alt="icon" className="w-5 h-5" />
         }
-        const Icon = (FaIcons as Record<string, IconType>)[customIcon] as IconType
+        const Icon = ICON_PACK[customIcon] as IconType | undefined
         if (Icon) {
           return <Icon className="text-xl" />
         }

--- a/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
+++ b/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
@@ -2,6 +2,8 @@ import React, { useMemo, useRef, useState, useEffect } from "react";
 import { TabsList, TabsTrigger } from "@/common/components/atoms/tabs";
 import { BsImage, BsImageFill, BsFillPinFill, BsPin } from "react-icons/bs";
 import { MdGridView } from "react-icons/md";
+import * as FaIcons from "react-icons/fa6";
+import type { IconType } from "react-icons";
 import { CompleteFidgets } from "@/fidgets";
 import { getFidgetDisplayName } from "../utils";
 import { usePathname } from "next/navigation";
@@ -167,11 +169,22 @@ const TabNavigation: React.FC<TabNavigationProps> = ({
 
     // On mobile, use custom mobile icons if available
     if (isMobile) {
-      const isSelected = selectedTab === fidgetId;
+      const customIcon = fidgetDatum.config.settings.mobileIconName as string | undefined
+      if (customIcon) {
+        if (customIcon.startsWith('http')) {
+          return <img src={customIcon} alt="icon" className="w-5 h-5" />
+        }
+        const Icon = (FaIcons as Record<string, IconType>)[customIcon] as IconType
+        if (Icon) {
+          return <Icon className="text-xl" />
+        }
+      }
+
+      const isSelected = selectedTab === fidgetId
       if (isSelected && fidgetModule.properties.mobileIconSelected) {
-        return fidgetModule.properties.mobileIconSelected;
+        return fidgetModule.properties.mobileIconSelected
       } else if (fidgetModule.properties.mobileIcon) {
-        return fidgetModule.properties.mobileIcon;
+        return fidgetModule.properties.mobileIcon
       }
     }
     


### PR DESCRIPTION
## Summary
- fix drag handle for mini app settings
- enable drag-and-drop ordering using framer-motion
- reorder `fidgetInstanceDatums` when mobile order changes

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a mobile settings panel for managing and reordering mini-apps with drag-and-drop support.
  - Added an icon selector allowing users to choose from a library or upload custom icons for mini-apps.
  - Enabled editing of mini-app display names, icons, and visibility for mobile navigation.
  - Added support for custom mobile icons (including URLs) for fidgets.
- **Enhancements**
  - Reorganized theme editor tabs and improved UI for managing fidget and mobile settings.
  - Expanded fidget styling options with mobile-specific icon and order fields.
- **Style**
  - Updated styling for selected song label to use a smaller text size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->