### PR TITLE
Fix mobile fidget reorder

### DIFF
--- a/src/common/components/organisms/MobileSettings.tsx
+++ b/src/common/components/organisms/MobileSettings.tsx
@@ -5,9 +5,10 @@ import MiniAppSettings, { MiniApp } from '../molecules/MiniAppSettings'
 interface MobileSettingsProps {
   miniApps: MiniApp[]
   onUpdateMiniApp: (app: MiniApp) => void
+  onReorder?: (apps: MiniApp[]) => void
 }
 
-export function MobileSettings({ miniApps, onUpdateMiniApp }: MobileSettingsProps) {
+export function MobileSettings({ miniApps, onUpdateMiniApp, onReorder }: MobileSettingsProps) {
   const [items, setItems] = useState<MiniApp[]>([])
 
   useEffect(() => {
@@ -20,6 +21,9 @@ export function MobileSettings({ miniApps, onUpdateMiniApp }: MobileSettingsProp
     newOrder.forEach((item, index) => {
       onUpdateMiniApp({ ...item, order: index + 1 })
     })
+    if (onReorder) {
+      onReorder(newOrder)
+    }
   }
 
   return (

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -112,6 +112,17 @@ export function ThemeSettingsEditor({
     saveFidgetInstanceDatums(newDatums);
   };
 
+  const handleReorderMiniApps = (apps: MiniApp[]) => {
+    const newDatums: { [key: string]: FidgetInstanceData } = {};
+    apps.forEach(app => {
+      const datum = fidgetInstanceDatums[app.id];
+      if (datum) {
+        newDatums[app.id] = datum;
+      }
+    });
+    saveFidgetInstanceDatums(newDatums);
+  };
+
   function themePropSetter<_T extends string>(property: string): (value: string) => void {
     return (value: string): void => {
       const newTheme = {
@@ -362,6 +373,7 @@ export function ThemeSettingsEditor({
                   <MobileSettings
                     miniApps={miniApps}
                     onUpdateMiniApp={handleUpdateMiniApp}
+                    onReorder={handleReorderMiniApps}
                   />
                 </TabsContent>
               </Tabs>


### PR DESCRIPTION
## Summary
- add `onReorder` callback to `MobileSettings`
- update `ThemeSettingsEditor` to persist fidget order when reordered

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*