### PR TITLE
Update FidgetPicker layout

### DIFF
--- a/src/common/components/organisms/FidgetPicker.tsx
+++ b/src/common/components/organisms/FidgetPicker.tsx
@@ -53,7 +53,7 @@ export const FidgetPicker: React.FC<FidgetPickerProps> = ({
           >
             <button
               key={fidgetId}
-              className="w-32 h-32 flex flex-col items-center justify-center p-2"
+              className="w-20 h-20 flex flex-col items-center justify-center p-1"
               onClick={() => addFidget(fidgetId, fidgetModule)}
               style={{ transform: "scale(1)", transition: "transform 0.3s" }}
               onMouseEnter={(e) => {
@@ -63,20 +63,20 @@ export const FidgetPicker: React.FC<FidgetPickerProps> = ({
                 e.currentTarget.style.transform = "scale(1)";
               }}
             >
-              <Card className="w-full h-full bg-[#F3F4F6] flex flex-col items-center justify-center p-1">
-                <CardContent className="overflow-hidden flex flex-col items-center justify-center p-1">
-                  <div className="flex items-center justify-center w-14 h-12 mb-2">
+              <Card className="w-full h-full bg-[#F3F4F6] flex flex-col items-center justify-center p-0">
+                <CardContent className="overflow-hidden flex flex-col items-center justify-center p-0">
+                  <div className="flex items-center justify-center w-10 h-10 mb-1">
                     {" "}
                     {/* Icon Container */}
                     <span
-                      className="text-2xl leading-none" // Consistent icon size
+                      className="text-xl leading-none" // Consistent icon size
                       role="img"
                       aria-label={fidgetModule.properties.fidgetName}
                     >
                       {String.fromCodePoint(fidgetModule.properties.icon)}
                     </span>
                   </div>
-                  <span className="text-sm text-black text-center leading-none">
+                  <span className="text-xs text-black text-center leading-none">
                     {" "}
                     {/* Text Container */}
                     {fidgetModule.properties.fidgetName}
@@ -100,7 +100,7 @@ export const FidgetPicker: React.FC<FidgetPickerProps> = ({
       </div>
       <section
         id="Fidgets"
-        className="mx-auto grid grid-cols-1 lg:grid-cols-2 md:grid-cols-1"
+        className="mx-auto grid grid-cols-3 gap-2"
       >
         {generateFidgetCards()}
       </section>


### PR DESCRIPTION
## Summary
- make fidget cards smaller so they fit on one screen
- switch the fidget grid to three columns for better space usage

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*