### PR TITLE
Update FidgetPicker layout to fit all fidgets in a normally sized desktop window

### DIFF
--- a/src/common/components/organisms/FidgetPicker.tsx
+++ b/src/common/components/organisms/FidgetPicker.tsx
@@ -53,29 +53,22 @@ export const FidgetPicker: React.FC<FidgetPickerProps> = ({
           >
             <button
               key={fidgetId}
-              className="w-full h-10 flex items-center gap-2 p-1"
+              className="group w-full h-10 flex items-center gap-2 p-1 bg-transparent transform-gpu transition-transform will-change-transform hover:scale-[1.02]"
               onClick={() => addFidget(fidgetId, fidgetModule)}
-              style={{ transform: "scale(1)", transition: "transform 0.3s" }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.transform = "scale(1.02)";
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.transform = "scale(1)";
-              }}
             >
               <Card className="w-full h-full bg-[#F3F4F6] flex items-center p-1 rounded-lg">
                 <CardContent className="overflow-hidden flex items-center gap-2 p-0 pl-2">
                   <div className="flex items-center justify-center w-5 h-5">
                     {/* Icon Container */}
                     <span
-                      className="text-sm leading-none text-black"
+                      className="text-sm leading-none text-black group-hover:text-black"
                       role="img"
                       aria-label={fidgetModule.properties.fidgetName}
                     >
                       {String.fromCodePoint(fidgetModule.properties.icon)}
                     </span>
                   </div>
-                  <span className="text-xs text-black text-left leading-none">
+                  <span className="text-xs text-black text-left leading-none group-hover:text-black">
                     {/* Text Container */}
                     {fidgetModule.properties.fidgetName}
                   </span>

--- a/src/common/components/organisms/FidgetPicker.tsx
+++ b/src/common/components/organisms/FidgetPicker.tsx
@@ -53,7 +53,7 @@ export const FidgetPicker: React.FC<FidgetPickerProps> = ({
           >
             <button
               key={fidgetId}
-              className="group w-full h-10 flex items-center gap-2 p-1 bg-transparent transform-gpu transition-transform will-change-transform hover:scale-[1.02]"
+              className="group w-full h-10 flex items-center gap-2 p-1 bg-transparent transform-gpu transition-transform will-change-transform hover:scale-[1.04]"
               onClick={() => addFidget(fidgetId, fidgetModule)}
             >
               <Card className="w-full h-full bg-[#F3F4F6] flex items-center p-1 rounded-lg">

--- a/src/common/components/organisms/FidgetPicker.tsx
+++ b/src/common/components/organisms/FidgetPicker.tsx
@@ -53,7 +53,7 @@ export const FidgetPicker: React.FC<FidgetPickerProps> = ({
           >
             <button
               key={fidgetId}
-              className="w-32 h-32 flex flex-col items-center justify-center p-2"
+              className="w-full h-8 flex items-center gap-2 p-1"
               onClick={() => addFidget(fidgetId, fidgetModule)}
               style={{ transform: "scale(1)", transition: "transform 0.3s" }}
               onMouseEnter={(e) => {
@@ -63,21 +63,19 @@ export const FidgetPicker: React.FC<FidgetPickerProps> = ({
                 e.currentTarget.style.transform = "scale(1)";
               }}
             >
-              <Card className="w-full h-full bg-[#F3F4F6] flex flex-col items-center justify-center p-1">
-                <CardContent className="overflow-hidden flex flex-col items-center justify-center p-1">
-                  <div className="flex items-center justify-center w-14 h-12 mb-2">
-                    {" "}
+              <Card className="w-full h-full bg-[#F3F4F6] flex items-center p-1">
+                <CardContent className="overflow-hidden flex items-center gap-2 p-0">
+                  <div className="flex items-center justify-center w-5 h-5">
                     {/* Icon Container */}
                     <span
-                      className="text-2xl leading-none" // Consistent icon size
+                      className="text-sm leading-none"
                       role="img"
                       aria-label={fidgetModule.properties.fidgetName}
                     >
                       {String.fromCodePoint(fidgetModule.properties.icon)}
                     </span>
                   </div>
-                  <span className="text-sm text-black text-center leading-none">
-                    {" "}
+                  <span className="text-xs text-black text-left leading-none">
                     {/* Text Container */}
                     {fidgetModule.properties.fidgetName}
                   </span>
@@ -100,7 +98,7 @@ export const FidgetPicker: React.FC<FidgetPickerProps> = ({
       </div>
       <section
         id="Fidgets"
-        className="mx-auto grid grid-cols-1 lg:grid-cols-2 md:grid-cols-1"
+        className="mx-auto grid grid-cols-1 gap-1"
       >
         {generateFidgetCards()}
       </section>

--- a/src/common/components/organisms/FidgetPicker.tsx
+++ b/src/common/components/organisms/FidgetPicker.tsx
@@ -57,18 +57,18 @@ export const FidgetPicker: React.FC<FidgetPickerProps> = ({
               onClick={() => addFidget(fidgetId, fidgetModule)}
               style={{ transform: "scale(1)", transition: "transform 0.3s" }}
               onMouseEnter={(e) => {
-                e.currentTarget.style.transform = "scale(1.05)";
+                e.currentTarget.style.transform = "scale(1.02)";
               }}
               onMouseLeave={(e) => {
                 e.currentTarget.style.transform = "scale(1)";
               }}
             >
-              <Card className="w-full h-full bg-[#F3F4F6] flex items-center p-1">
+              <Card className="w-full h-full bg-[#F3F4F6] flex items-center p-1 rounded-lg">
                 <CardContent className="overflow-hidden flex items-center gap-2 p-0 pl-2">
                   <div className="flex items-center justify-center w-5 h-5">
                     {/* Icon Container */}
                     <span
-                      className="text-sm leading-none"
+                      className="text-sm leading-none text-black"
                       role="img"
                       aria-label={fidgetModule.properties.fidgetName}
                     >

--- a/src/common/components/organisms/FidgetPicker.tsx
+++ b/src/common/components/organisms/FidgetPicker.tsx
@@ -53,7 +53,7 @@ export const FidgetPicker: React.FC<FidgetPickerProps> = ({
           >
             <button
               key={fidgetId}
-              className="w-full h-8 flex items-center gap-2 p-1"
+              className="w-full h-10 flex items-center gap-2 p-1"
               onClick={() => addFidget(fidgetId, fidgetModule)}
               style={{ transform: "scale(1)", transition: "transform 0.3s" }}
               onMouseEnter={(e) => {
@@ -64,7 +64,7 @@ export const FidgetPicker: React.FC<FidgetPickerProps> = ({
               }}
             >
               <Card className="w-full h-full bg-[#F3F4F6] flex items-center p-1">
-                <CardContent className="overflow-hidden flex items-center gap-2 p-0">
+                <CardContent className="overflow-hidden flex items-center gap-2 p-0 pl-2">
                   <div className="flex items-center justify-center w-5 h-5">
                     {/* Icon Container */}
                     <span


### PR DESCRIPTION
With so many fidgets, they can't all fit into a normal sized screen on desktop. This updates the style to make them all fit better.

## Summary
- make fidget picker a single list with small rows
- reduce icon size and align icon with fidget name
![image](https://github.com/user-attachments/assets/8a630548-bc1a-4688-ac85-04408be75515)


## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*