### PR TITLE
Add Balance portfolio to default profile space

### DIFF
--- a/src/app/(spaces)/s/[handle]/ProfileSpace.tsx
+++ b/src/app/(spaces)/s/[handle]/ProfileSpace.tsx
@@ -25,7 +25,10 @@ export const ProfileSpace = ({
     return <SpaceNotFound />;
   }
 
-  const INITIAL_PERSONAL_SPACE_CONFIG = createIntialPersonSpaceConfigForFid(spaceOwnerFid);
+  const INITIAL_PERSONAL_SPACE_CONFIG = createIntialPersonSpaceConfigForFid(
+    spaceOwnerFid,
+    spaceOwnerUsername ?? undefined,
+  );
 
   const getSpacePageUrl = (tabName: string) => {
     if (!spaceOwnerUsername) return '#';

--- a/src/constants/initialPersonSpace.ts
+++ b/src/constants/initialPersonSpace.ts
@@ -50,7 +50,7 @@ const createIntialPersonSpaceConfigForFid = (
     },
   };
   config.layoutDetails.layoutConfig.layout.push({
-    w: 5,
+    w: 6,
     h: 8,
     x: 0,
     y: 0,
@@ -63,10 +63,10 @@ const createIntialPersonSpaceConfigForFid = (
     static: false,
   });
   config.layoutDetails.layoutConfig.layout.push({
-    w: 5,
-    h: 6,
-    x: 0,
-    y: 8,
+    w: 6,
+    h: 8,
+    x: 7,
+    y: 0,
     i: "Portfolio:cd627e89-d661-4255-8c4c-2242a950e93e",
     minW: 3,
     maxW: 36,

--- a/src/constants/initialPersonSpace.ts
+++ b/src/constants/initialPersonSpace.ts
@@ -18,6 +18,7 @@ export const INITIAL_SPACE_CONFIG_EMPTY: Omit<SpaceConfig, "isEditable"> = {
 
 const createIntialPersonSpaceConfigForFid = (
   fid: number,
+  username?: string,
 ): Omit<SpaceConfig, "isEditable"> => {
   const config = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
   config.fidgetInstanceDatums = {
@@ -34,6 +35,19 @@ const createIntialPersonSpaceConfigForFid = (
       fidgetType: "feed",
       id: "feed:profile",
     },
+    "Portfolio:cd627e89-d661-4255-8c4c-2242a950e93e": {
+      config: {
+        editable: false,
+        settings: {
+          trackType: "farcaster",
+          farcasterUsername: username ?? "",
+          walletAddresses: "",
+        },
+        data: {},
+      },
+      fidgetType: "Portfolio",
+      id: "Portfolio:cd627e89-d661-4255-8c4c-2242a950e93e",
+    },
   };
   config.layoutDetails.layoutConfig.layout.push({
     w: 5,
@@ -44,6 +58,19 @@ const createIntialPersonSpaceConfigForFid = (
     minW: 4,
     maxW: 36,
     minH: 6,
+    maxH: 36,
+    moved: false,
+    static: false,
+  });
+  config.layoutDetails.layoutConfig.layout.push({
+    w: 5,
+    h: 6,
+    x: 0,
+    y: 8,
+    i: "Portfolio:cd627e89-d661-4255-8c4c-2242a950e93e",
+    minW: 3,
+    maxW: 36,
+    minH: 3,
     maxH: 36,
     moved: false,
     static: false,


### PR DESCRIPTION
## Summary
- include Portfolio fidget when creating a default person space
- pre-fill the Portfolio fidget username with the viewed profile's handle

## Testing
- `npm run lint`
- `npm run check-types`
