### PR TITLE
Enable noImplicitAny and add generic typings

### DIFF
--- a/src/common/data/api/requestHandler.ts
+++ b/src/common/data/api/requestHandler.ts
@@ -1,19 +1,19 @@
 import { isUndefined, keys, map } from "lodash";
 import { NextApiRequest, NextApiResponse } from "next/types";
 
-type ResponseError = {
+interface ResponseError {
   message?: string;
-  [key: string]: any;
-};
+  [key: string]: unknown;
+}
 
-export type NounspaceResponse<
-  D = any,
+export interface NounspaceResponse<
+  D = unknown,
   E extends ResponseError = ResponseError,
-> = {
+> {
   result: "success" | "error";
   error?: E;
   value?: D;
-};
+}
 
 type HandlerFunction<R extends NounspaceResponse = NounspaceResponse> = (
   req: NextApiRequest,

--- a/src/common/data/stores/createStore.ts
+++ b/src/common/data/stores/createStore.ts
@@ -52,8 +52,8 @@ export type StoreSet<T> = MutativeConfigSetFunction<T>;
 export type StoreGet<T> = () => T;
 
 export function createStore<T>(
-  store: any,
-  persistArgs: PersistOptions<any, any>,
+  store: MatativeConfig<T>,
+  persistArgs: PersistOptions<T>,
 ) {
   return create<T>()(devtools(persist(mutative(store), persistArgs)));
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     ],
     "allowJs": true,
     "skipLibCheck": true,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary
- enable `noImplicitAny` in TS config
- tighten generics on API request handler
- provide generics for store creation helpers

## Testing
- `npm run lint`
- `npm run check-types` *(fails: many implicit `any` errors across repo)*