### PR TITLE
Add dynamic thumbnail to token space frame

### DIFF
--- a/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
@@ -62,9 +62,20 @@ export async function generateMetadata({
     : `${WEBSITE_URL}/t/${network}/${contractAddress}`;
     
   // Create token frame with the symbol if available
+  const params = new URLSearchParams({
+    name,
+    symbol,
+    imageUrl,
+    address: contractAddress,
+    marketCap,
+    priceChange,
+  });
+
+  const ogImageUrl = `${WEBSITE_URL}/api/metadata/token?${params.toString()}`;
+
   const tokenFrame = {
     version: "next",
-    imageUrl: `${WEBSITE_URL}/images/nounspace_og_low.png`,
+    imageUrl: ogImageUrl,
     button: {
       title: symbol ? `Visit ${symbol}` : "Visit Token Space",
       action: {


### PR DESCRIPTION
## Summary
- compute ogImageUrl for token spaces
- use the dynamic URL in the token space frame manifest

## Testing
- `npm run lint`
- `npm run check-types`
