### PR TITLE
Add Pinata uploads to cast modal

### DIFF
--- a/src/common/components/molecules/PinataUploader.tsx
+++ b/src/common/components/molecules/PinataUploader.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/common/components/atoms/button";
+import { mergeClasses } from "@/common/lib/utils/mergeClasses";
 import { Loader2 } from "lucide-react";
 import React, { useRef, useState } from "react";
 
@@ -25,11 +26,22 @@ const ImageIcon = () => (
   </svg>
 );
 
-interface PinataUploaderProps {
-  onImageUploaded: (url: string) => void;
+export interface UploadedImageInfo {
+  url: string;
+  file: File;
 }
 
-const PinataUploader: React.FC<PinataUploaderProps> = ({ onImageUploaded }) => {
+interface PinataUploaderProps {
+  onImageUploaded: (info: UploadedImageInfo) => void;
+  showPreview?: boolean;
+  buttonClassName?: string;
+}
+
+const PinataUploader: React.FC<PinataUploaderProps> = ({
+  onImageUploaded,
+  showPreview = true,
+  buttonClassName,
+}) => {
   const [isUploading, setIsUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [uploadedUrl, setUploadedUrl] = useState<string | null>(null);
@@ -80,7 +92,7 @@ const PinataUploader: React.FC<PinataUploaderProps> = ({ onImageUploaded }) => {
       if (data.IpfsHash) {
         const imageUrl = `https://gateway.pinata.cloud/ipfs/${data.IpfsHash}`;
         setUploadedUrl(imageUrl);
-        onImageUploaded(imageUrl);
+        onImageUploaded({ url: imageUrl, file });
 
         if (window.handleGalleryImageUpload) {
           window.handleGalleryImageUpload(imageUrl);
@@ -117,7 +129,7 @@ const PinataUploader: React.FC<PinataUploaderProps> = ({ onImageUploaded }) => {
         <Button
           variant="outline"
           onClick={handleButtonClick}
-          className="w-full"
+          className={mergeClasses("w-full", buttonClassName)}
           disabled={isUploading}
         >
           {isUploading ? (
@@ -136,7 +148,7 @@ const PinataUploader: React.FC<PinataUploaderProps> = ({ onImageUploaded }) => {
         <p className="text-xs text-muted-foreground mt-1">Maximum file size: 5MB</p>
       </div>
 
-      {uploadedUrl && (
+      {showPreview && uploadedUrl && (
         <div className="flex flex-col gap-2">
           <p className="text-sm text-green-500">Image uploaded successfully!</p>
           <div className="relative h-40 w-full overflow-hidden rounded-md border">

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -54,6 +54,9 @@ import { GoSmiley } from "react-icons/go";
 import { HiOutlineSparkles } from "react-icons/hi2";
 import Spinner from "@/common/components/atoms/spinner";
 import { XCircle } from "lucide-react";
+import PinataUploader, {
+  UploadedImageInfo,
+} from "@/common/components/molecules/PinataUploader";
 import { useBannerStore } from "@/stores/bannerStore";
 import { usePrivy } from "@privy-io/react-auth";
 import { useBalance } from "wagmi";
@@ -506,6 +509,14 @@ const CreateCast: React.FC<CreateCastProps> = ({
     }
   };
 
+  const handlePinataImageUpload = (upload: UploadedImageInfo) => {
+    addEmbed({
+      url: upload.url,
+      status: "loading",
+      metadata: { mimeType: upload.file.type },
+    });
+  };
+
   return (
     <div
       className="flex flex-col items-start min-w-full w-full h-full"
@@ -564,6 +575,11 @@ const CreateCast: React.FC<CreateCastProps> = ({
             <PhotoIcon className="mr-1 w-5 h-5" />
             Add
           </Button>
+          <PinataUploader
+            onImageUploaded={handlePinataImageUpload}
+            showPreview={false}
+            buttonClassName="h-10"
+          />
           <Button
             className="h-10"
             type="button"

--- a/src/fidgets/ui/gallery.tsx
+++ b/src/fidgets/ui/gallery.tsx
@@ -11,7 +11,9 @@ import AlchemyNftSelector, {
 } from "@/common/components/molecules/AlchemyNFTSelector";
 import ColorSelector from "@/common/components/molecules/ColorSelector";
 import ImageScaleSlider from "@/common/components/molecules/ImageScaleSlider";
-import PinataUploader from "@/common/components/molecules/PinataUploader";
+import PinataUploader, {
+  UploadedImageInfo,
+} from "@/common/components/molecules/PinataUploader";
 import MediaSourceSelector, {
   MediaSource,
   MediaSourceTypes,
@@ -62,12 +64,12 @@ const galleryConfig: FidgetProperties = {
       inputSelector: ({ updateSettings }) => {
         const [localImageUrl, setLocalImageUrl] = React.useState<string | null>(null);
 
-        const handleImageUploaded = (Upload: string) => {
-          console.log("Image uploaded, URL:", Upload);
-          setLocalImageUrl(Upload);
+        const handleImageUploaded = (upload: UploadedImageInfo) => {
+          console.log("Image uploaded, URL:", upload.url);
+          setLocalImageUrl(upload.url);
           updateSettings?.({
-            uploadedImage: Upload,
-            imageUrl: Upload
+            uploadedImage: upload.url,
+            imageUrl: upload.url
           });
         };
 


### PR DESCRIPTION
## Summary
- extend `PinataUploader` to return file metadata and allow style overrides
- update Gallery fidget to use new `UploadedImageInfo` signature
- embed uploaded images from `PinataUploader` in the cast creation modal

## Testing
- `npm run lint`
- `npm run check-types`
