### PR TITLE
Fix token icon layout in OG card

### DIFF
--- a/src/pages/api/metadata/token.tsx
+++ b/src/pages/api/metadata/token.tsx
@@ -65,7 +65,8 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
         height: "100%",
         padding: "40px",
         display: "flex",
-        alignItems: "center",
+        flexDirection: "column",
+        alignItems: "flex-start",
         background: "white",
         gap: "32px",
         fontFamily: "Arial, sans-serif",
@@ -76,7 +77,7 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
           src={data.imageUrl}
           width="160"
           height="160"
-          style={{ borderRadius: "80px" }}
+          style={{ borderRadius: "80px", alignSelf: "center" }}
         />
       )}
       <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>


### PR DESCRIPTION
## Summary
- center token icon in token OG card

## Testing
- `npm run lint`
- `npm run check-types`
