### PR TITLE
Move customize button into tab bar

### DIFF
--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -13,7 +13,6 @@ import { useLoadFarcasterUser } from "@/common/data/queries/farcaster";
 import { first } from "lodash";
 import { Button } from "../atoms/button";
 import {
-  FaPaintbrush,
   FaDiscord,
   FaChevronLeft,
   FaChevronRight,
@@ -50,7 +49,6 @@ type NavButtonProps = Omit<NavItemProps, "href" | "openInNewTab">;
 
 type NavProps = {
   isEditable: boolean;
-  enterEditMode: () => void;
 };
 
 const NavIconBadge = ({ children }) => {
@@ -64,7 +62,7 @@ const NavIconBadge = ({ children }) => {
   );
 };
 
-const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
+const Navigation: React.FC<NavProps> = ({ isEditable }) => {
   const searchRef = useRef<HTMLInputElement>(null);
   const { setModalOpen, getIsLoggedIn, getIsInitializing } = useAppStore(
     (state) => ({
@@ -90,10 +88,6 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
   function handleLogout() {
     router.push("/home");
     logout();
-  }
-
-  function turnOnEditMode() {
-    enterEditMode();
   }
 
   const openModal = () => setModalOpen(true);
@@ -315,18 +309,6 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
                   shrunk ? "flex-col gap-1" : ""
                 )}
               >
-                {!isNotificationsPage && !isExplorerPage && isEditable && (
-                  <Button
-                    onClick={turnOnEditMode}
-                    size="icon"
-                    variant="secondary"
-                    className="flex items-center justify-center w-12 h-12"
-                  >
-                    <div className="flex items-center p-1">
-                      <FaPaintbrush />
-                    </div>
-                  </Button>
-                )}
                 <Button
                   onClick={openCastModal}
                   variant="primary"

--- a/src/common/components/organisms/Sidebar.tsx
+++ b/src/common/components/organisms/Sidebar.tsx
@@ -52,21 +52,13 @@ export const useSidebarContext = (): SidebarContextValue => {
 };
 
 export const Sidebar: React.FC<SidebarProps> = () => {
-  const { editMode, setEditMode, sidebarEditable, portalRef } =
-    useSidebarContext();
-
-  function enterEditMode() {
-    setEditMode(true);
-  }
+  const { editMode, sidebarEditable, portalRef } = useSidebarContext();
 
   return (
     <>
       <div ref={portalRef} className={editMode ? "w-full" : ""}></div>
       <div className={editMode ? "hidden" : "md:flex mx-auto h-full hidden"}>
-        <Navigation
-          isEditable={sidebarEditable}
-          enterEditMode={enterEditMode}
-        />
+        <Navigation isEditable={sidebarEditable} />
       </div>
     </>
   );

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -1,13 +1,15 @@
 "use client";
 import React from "react";
-import { FaPlus } from "react-icons/fa6";
+import { FaPlus, FaPaintbrush } from "react-icons/fa6";
 import { map } from "lodash";
 import { Reorder, AnimatePresence } from "framer-motion";
 import { Tab } from "../atoms/reorderable-tab";
 import NogsGateButton from "./NogsGateButton";
 import { Address } from "viem";
 import { useAppStore } from "@/common/data/stores/app";
+import { useSidebarContext } from "./Sidebar";
 import { TooltipProvider } from "../atoms/tooltip";
+import { Button } from "../atoms/button";
 import TokenDataHeader from "./TokenDataHeader";
 import ProposalDataHeader from "./ProposalDataHeader";
 import ClaimButtonWithModal from "../molecules/ClaimButtonWithModal";
@@ -69,6 +71,8 @@ function TabBar({
     getIsLoggedIn: state.getIsAccountReady,
     getIsInitializing: state.getIsInitializing,
   }));
+
+  const { setEditMode, sidebarEditable } = useSidebarContext();
 
   function generateNewTabName() {
     const endIndex = tabList.length + 1;
@@ -194,7 +198,7 @@ function TabBar({
 
   return (
     <TooltipProvider>
-      <div className="flex flex-col md:flex-row justify-start md:h-16 z-50 bg-white">
+      <div className="flex flex-col md:flex-row justify-start md:h-16 z-50 bg-white relative">
         {isTokenPage && contractAddress && (
           <div className="flex flex-row justify-start h-16 overflow-y-scroll w-full z-30 bg-white">
             <TokenDataHeader />
@@ -238,6 +242,18 @@ function TabBar({
         </div>
         {isTokenPage && !getIsInitializing() && !isLoggedIn && !isMobile && (
           <ClaimButtonWithModal contractAddress={contractAddress} />
+        )}
+        {!inEditMode && !isMobile && isLoggedIn && sidebarEditable && (
+          <Button
+            onClick={() => setEditMode(true)}
+            size="icon"
+            variant="secondary"
+            className="absolute right-2 top-2 z-infinity"
+          >
+            <div className="flex items-center p-1">
+              <FaPaintbrush />
+            </div>
+          </Button>
         )}
         {inEditMode ? (
           <div className="mr-36 flex flex-row z-infinity">

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -244,16 +244,17 @@ function TabBar({
           <ClaimButtonWithModal contractAddress={contractAddress} />
         )}
         {!inEditMode && !isMobile && isLoggedIn && sidebarEditable && (
-          <Button
-            onClick={() => setEditMode(true)}
-            size="icon"
-            variant="secondary"
-            className="absolute right-2 top-2 z-infinity"
-          >
-            <div className="flex items-center p-1">
+          <div className="absolute right-2 top-2 z-infinity bg-white rounded-md p-1">
+            <Button
+              onClick={() => setEditMode(true)}
+              size="md"
+              variant="secondary"
+              withIcon
+            >
               <FaPaintbrush />
-            </div>
-          </Button>
+              <span className="whitespace-nowrap">Customize</span>
+            </Button>
+          </div>
         )}
         {inEditMode ? (
           <div className="mr-36 flex flex-row z-infinity">

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -244,15 +244,16 @@ function TabBar({
           <ClaimButtonWithModal contractAddress={contractAddress} />
         )}
         {!inEditMode && !isMobile && isLoggedIn && sidebarEditable && (
-          <div className="absolute right-2 top-2 z-infinity bg-white rounded-md p-1">
+          <div className="absolute right-4 top-2.5 z-infinity bg-white rounded-md p-1 pr-0">
             <Button
               onClick={() => setEditMode(true)}
               size="md"
               variant="secondary"
               withIcon
+              className="scale-110"
             >
               <FaPaintbrush />
-              <span className="whitespace-nowrap">Customize</span>
+              <span className="whitespace-nowrap text-[1.05em] font-semibold">Customize</span>
             </Button>
           </div>
         )}

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -38,17 +38,18 @@ export type FidgetWrapperProps = {
 };
 
 export const getSettingsWithDefaults = (
-  settings: FidgetSettings,
+  settings: FidgetSettings | undefined,
   config: FidgetProperties,
 ): FidgetSettings => {
+  const safeSettings = settings ?? {};
   return reduce(
     config.fields,
     (acc, f) => ({
       ...acc,
       [f.fieldName]:
-        f.fieldName in settings
-          ? settings[f.fieldName]
-          : f.default || undefined,
+        f.fieldName in safeSettings
+          ? safeSettings[f.fieldName]
+          : f.default ?? undefined,
     }),
     {},
   );


### PR DESCRIPTION
## Summary
- relocate the edit mode paintbrush button to the tab bar
- remove paintbrush button from navigation
- update Sidebar and Navigation props accordingly

Also, I came across a bug that caused the app to crash. The bug came from fidgets with undefined settings, which may have been unique to my account, but this adds a "Fidget Guard" that I confirmed prevents the crash

## Testing
- `npm run lint`
- `npm run check-types`
