### PR TITLE
Add label and background to customize button

### DIFF
--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -248,11 +248,10 @@ function TabBar({
             onClick={() => setEditMode(true)}
             size="icon"
             variant="secondary"
-            className="absolute right-2 top-2 z-infinity"
+            className="absolute right-2 top-2 z-infinity bg-white flex items-center px-2"
           >
-            <div className="flex items-center p-1">
-              <FaPaintbrush />
-            </div>
+            <FaPaintbrush />
+            <span className="ml-2">Customize</span>
           </Button>
         )}
         {inEditMode ? (


### PR DESCRIPTION
## Summary
- add `Customize` text beside the paintbrush icon
- give the edit button a white background so tab text doesn't show through

## Testing
- `npm run lint`
- `npm run check-types`
