### PR TITLE
Fix token metadata thumbnail padding

### DIFF
--- a/src/pages/api/metadata/token.tsx
+++ b/src/pages/api/metadata/token.tsx
@@ -86,7 +86,7 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
           display: "flex",
           flexDirection: "column",
           gap: "12px",
-          paddingLeft: "80px",
+          paddingLeft: "100px",
         }}
       >
         <span style={{ fontSize: "56px", fontWeight: "bold" }}>{data.name}</span>

--- a/src/pages/api/metadata/token.tsx
+++ b/src/pages/api/metadata/token.tsx
@@ -86,7 +86,7 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
           display: "flex",
           flexDirection: "column",
           gap: "12px",
-          paddingLeft: "60px",
+          paddingLeft: "80px",
         }}
       >
         <span style={{ fontSize: "56px", fontWeight: "bold" }}>{data.name}</span>

--- a/src/pages/api/metadata/token.tsx
+++ b/src/pages/api/metadata/token.tsx
@@ -86,7 +86,7 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
           display: "flex",
           flexDirection: "column",
           gap: "12px",
-          paddingLeft: "20px",
+          paddingLeft: "60px",
         }}
       >
         <span style={{ fontSize: "56px", fontWeight: "bold" }}>{data.name}</span>

--- a/src/pages/api/metadata/token.tsx
+++ b/src/pages/api/metadata/token.tsx
@@ -86,7 +86,7 @@ const TokenCard = ({ data }: { data: TokenCardData }) => {
           display: "flex",
           flexDirection: "column",
           gap: "12px",
-          paddingLeft: "100px",
+          paddingLeft: "111px",
         }}
       >
         <span style={{ fontSize: "56px", fontWeight: "bold" }}>{data.name}</span>


### PR DESCRIPTION
## Summary
- indent token metadata text in token OG thumbnails

## Testing
- `npm run lint`
- `npm run check-types`
