### PR TITLE
Fix collapsed nav cast button size

### DIFF
--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -334,6 +334,7 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
                   onClick={openCastModal}
                   variant="primary"
                   width="auto"
+                  size={shrunk ? "icon" : undefined}
                   className="flex items-center justify-center w-12 h-12"
                 >
                   {shrunk ? <span className="sr-only">Cast</span> : "Cast"}


### PR DESCRIPTION
## Summary
- set icon size for Cast button when sidebar is collapsed

## Testing
- `npm run lint`
- `npm run check-types`
