### PR TITLE
Fix fidget settings guard

### DIFF
--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -38,17 +38,18 @@ export type FidgetWrapperProps = {
 };
 
 export const getSettingsWithDefaults = (
-  settings: FidgetSettings,
+  settings: FidgetSettings | undefined,
   config: FidgetProperties,
 ): FidgetSettings => {
+  const safeSettings = settings ?? {};
   return reduce(
     config.fields,
     (acc, f) => ({
       ...acc,
       [f.fieldName]:
-        f.fieldName in settings
-          ? settings[f.fieldName]
-          : f.default || undefined,
+        f.fieldName in safeSettings
+          ? safeSettings[f.fieldName]
+          : f.default ?? undefined,
     }),
     {},
   );


### PR DESCRIPTION
## Summary
- avoid crash if fidget settings are undefined

## Testing
- `npm run lint`
- `npm run check-types`
