### PR TITLE
Add Suspense loaders for spaces

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState, Suspense } from "react";
 import { useAuthenticatorManager } from "@/authenticators/AuthenticatorManager";
 import { useAppStore } from "@/common/data/stores/app";
 import { useSidebarContext } from "@/common/components/organisms/Sidebar";
@@ -17,6 +17,8 @@ import Profile from "@/fidgets/ui/profile";
 import { createEditabilityChecker } from "@/common/utils/spaceEditability";
 import { revalidatePath } from "next/cache";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialPersonSpace";
+import SpaceLoading from "./SpaceLoading";
+import { useSpaceTabConfig } from "@/common/data/queries/spaceConfig";
 const FARCASTER_NOUNSPACE_AUTHENTICATOR_NAME = "farcaster:nounspace";
 
 export type SpacePageType = "profile" | "token" | "proposal";
@@ -647,16 +649,27 @@ export default function PublicSpace({
   if (!profile) {
     console.warn("Profile component is undefined");
   }
+  const TabContent = () => {
+    useSpaceTabConfig(getCurrentSpaceId(), providedTabName);
+
+    return (
+      <SpacePage
+        key={getCurrentSpaceId() + providedTabName}
+        config={memoizedConfig}
+        saveConfig={saveConfig}
+        commitConfig={commitConfig}
+        resetConfig={resetConfig}
+        tabBar={tabBar}
+        profile={profile ?? undefined}
+      />
+    );
+  };
 
   return (
-    <SpacePage
-      key={getCurrentSpaceId() + providedTabName}
-      config={memoizedConfig}
-      saveConfig={saveConfig}
-      commitConfig={commitConfig}
-      resetConfig={resetConfig}
-      tabBar={tabBar}
-      profile={profile ?? undefined}
-    />
+    <Suspense
+      fallback={<SpaceLoading hasProfile={!!profile} hasFeed={false} />}
+    >
+      <TabContent />
+    </Suspense>
   );
 }

--- a/src/app/(spaces)/homebase/PrivateSpace.tsx
+++ b/src/app/(spaces)/homebase/PrivateSpace.tsx
@@ -183,46 +183,48 @@ function PrivateSpace({ tabName }: { tabName: string }) {
     />
   ), [tabName, tabOrdering.local, editMode]);
 
-  // Define the arguments for the SpacePage component
-  const args: SpacePageArgs = useMemo(() => ({
-    config: (() => {
-      const { timestamp, ...restConfig } = {
-        ...((tabName === "Feed" 
-            ? homebaseConfig 
-            : tabConfigs[tabName]?.config)
-            ?? INITIAL_SPACE_CONFIG_EMPTY),
-        isEditable: true,
-      };
-      return restConfig;
-    })(),
-    saveConfig: saveConfigHandler,
-    commitConfig: commitConfigHandler,
-    resetConfig: resetConfigHandler,
-    tabBar: tabBar,
-    feed: tabName === "Feed" && currentFid ? (
-      <FeedModule.fidget
-        settings={{
-          feedType: FeedType.Following,
-          users: "",
-          filterType: FilterType.Users,
-          selectPlatform: { name: "Farcaster", icon: "/images/farcaster.jpeg" },
-          Xhandle: "",
-          style: "",
-          fontFamily: "var(--user-theme-font)",
-          fontColor: "var(--user-theme-font-color)" as any,
-        }}
-        saveData={async () => noop()}
-        data={{}}
-      />
-    ) : undefined,
-  }), [
-    tabName,
-    tabName === "Feed" 
-      ? homebaseConfig 
-      : tabConfigs[tabName]?.config,
-    tabOrdering.local,
-    editMode
-  ]);
+  const TabContent = () => {
+    useHomebaseTabConfig(tabName);
+
+    const args: SpacePageArgs = useMemo(() => ({
+      config: (() => {
+        const { timestamp, ...restConfig } = {
+          ...((tabName === "Feed"
+              ? homebaseConfig
+              : tabConfigs[tabName]?.config) ?? INITIAL_SPACE_CONFIG_EMPTY),
+          isEditable: true,
+        };
+        return restConfig;
+      })(),
+      saveConfig: saveConfigHandler,
+      commitConfig: commitConfigHandler,
+      resetConfig: resetConfigHandler,
+      tabBar: tabBar,
+      feed: tabName === "Feed" && currentFid ? (
+        <FeedModule.fidget
+          settings={{
+            feedType: FeedType.Following,
+            users: "",
+            filterType: FilterType.Users,
+            selectPlatform: { name: "Farcaster", icon: "/images/farcaster.jpeg" },
+            Xhandle: "",
+            style: "",
+            fontFamily: "var(--user-theme-font)",
+            fontColor: "var(--user-theme-font-color)" as any,
+          }}
+          saveData={async () => noop()}
+          data={{}}
+        />
+      ) : undefined,
+    }), [
+      tabName,
+      tabName === "Feed" ? homebaseConfig : tabConfigs[tabName]?.config,
+      tabOrdering.local,
+      editMode,
+    ]);
+
+    return <SpacePage key={tabName} {...args} />;
+  };
 
   // If not logged in, show a loading state with the login modal
   if (!isLoggedIn) {
@@ -242,9 +244,15 @@ function PrivateSpace({ tabName }: { tabName: string }) {
     );
   }
 
-  // Render the SpacePage component with the defined arguments
+  // Render the SpacePage component within Suspense
   return (
-    <SpacePage key={tabName} {...args} />
+    <Suspense
+      fallback={
+        <SpaceLoading hasProfile={false} hasFeed={tabName === "Feed"} />
+      }
+    >
+      <TabContent />
+    </Suspense>
   );
 }
 

--- a/src/common/data/queries/spaceConfig.ts
+++ b/src/common/data/queries/spaceConfig.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAppStore } from "../stores/app";
+
+export const useHomebaseTabConfig = (tabName: string) => {
+  const loadTab = useAppStore((state) => state.homebase.loadHomebaseTab);
+  return useQuery({
+    queryKey: ["homebase-tab-config", tabName],
+    suspense: true,
+    queryFn: () => loadTab(tabName),
+  });
+};
+
+export const useSpaceTabConfig = (spaceId: string | null, tabName: string) => {
+  const loadTab = useAppStore((state) => state.space.loadSpaceTab);
+  return useQuery({
+    queryKey: ["space-tab-config", spaceId, tabName],
+    enabled: !!spaceId,
+    suspense: true,
+    queryFn: () => {
+      if (!spaceId) return null;
+      return loadTab(spaceId, tabName);
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- show skeletons while loading space tabs
- add query helpers for space config fetching
- fix query hook return values

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*
