### PR TITLE
Update mobile fidget settings layout

### DIFF
--- a/src/common/components/molecules/MiniAppSettings.tsx
+++ b/src/common/components/molecules/MiniAppSettings.tsx
@@ -71,9 +71,9 @@ export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls }: Mini
     );
   }
   return (
-    <div className="bg-white border border-gray-200 rounded-lg">
-      <div className="py-2 px-2">
-        <div className="flex items-center gap-2 mb-3">
+    <div className="py-2 border-b last:border-b-0">
+      <div className="px-2">
+        <div className="flex items-center gap-2 mb-2">
           <div
             className="cursor-move p-1 hover:bg-gray-100 rounded shrink-0"
             title="Drag to reorder"

--- a/src/common/components/organisms/MobileSettings.tsx
+++ b/src/common/components/organisms/MobileSettings.tsx
@@ -55,7 +55,12 @@ export function MobileSettings({
         Drag fidgets to reorder them in the mobile nav, and customize their
         visibility, display name, and icon.
       </p>
-      <Reorder.Group axis="y" values={items} onReorder={handleReorder} className="space-y-3">
+      <Reorder.Group
+        axis="y"
+        values={items}
+        onReorder={handleReorder}
+        className="flex flex-col"
+      >
         {items.map((miniApp) => (
           <DraggableMiniApp
             key={miniApp.id}


### PR DESCRIPTION
## Summary
- refactor Mobile tab fidget list items to use full-width rows
- remove spacing between fidget rows

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*