### PR TITLE
Fix proposal space registration defaults

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -243,7 +243,8 @@ export default function PublicSpace({
         providedSpaceId &&
         proposalRegistrationRef.current !== providedSpaceId &&
         spaceOwnerAddress &&
-        spaceOwnerFid
+        spaceOwnerFid &&
+        currentUserFid === spaceOwnerFid
       ) {
         const registerProposalSpaceHandler = async () => {
           try {
@@ -264,11 +265,13 @@ export default function PublicSpace({
               proposalId: providedSpaceId,
               spaceId: proposalSpaceId,
               fid: spaceOwnerFid,
+              proposerAddress: spaceOwnerAddress,
             });
 
             console.debug("Proposal space registered successfully", {
               proposalSpaceId,
             });
+            proposalRegistrationRef.current = proposalSpaceId;
 
             // Load the space tab order and the default tab
             await loadSpaceTabOrder(proposalSpaceId);
@@ -442,7 +445,8 @@ export default function PublicSpace({
       isNil(currentSpaceId) &&
       !isNil(currentUserFid) &&
       !loading &&
-      !editabilityCheck.isLoading
+      !editabilityCheck.isLoading &&
+      pageType !== "proposal"
     ) {
       console.log("Space registration conditions met:", {
         isEditable: editabilityCheck.isEditable,

--- a/src/app/(spaces)/p/[proposalId]/ProposalDefinedSpace.tsx
+++ b/src/app/(spaces)/p/[proposalId]/ProposalDefinedSpace.tsx
@@ -38,8 +38,8 @@ const ProposalDefinedSpace = ({
   return (
     <div className="w-full">
       <PublicSpace
-        spaceId={spaceId || ""}
-        tabName={tabName || "Profile"}
+        spaceId={spaceId || proposalId || ""}
+        tabName={tabName || `Nouns Prop ${proposalId}`}
         initialConfig={INITIAL_SPACE_CONFIG}
         getSpacePageUrl={getSpacePageUrl}
         isTokenPage={false}

--- a/src/app/(spaces)/p/[proposalId]/[tabname]/page.tsx
+++ b/src/app/(spaces)/p/[proposalId]/[tabname]/page.tsx
@@ -9,6 +9,10 @@ import { loadProposalData } from "../utils";
 
 export default async function WrapperProposalPrimarySpace({ params }) {
   const proposalId = params?.proposalId as string;
+  const tabName = params?.tabname
+    ? decodeURIComponent(params.tabname as string)
+    : `Nouns Prop ${proposalId}`;
+  const spaceId = proposalId;
   const proposalData = await loadProposalData(proposalId || "0");
 
   // Fetch proposer FID using our API route
@@ -43,6 +47,8 @@ export default async function WrapperProposalPrimarySpace({ params }) {
   const props = {
     proposalId,
     fid,
+    spaceId,
+    tabName,
   };
 
   return (

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -12,6 +12,7 @@ import { EtherScanChainName } from "@/constants/etherscanChainIds";
 import createIntialPersonSpaceConfigForFid, {
   INITIAL_SPACE_CONFIG_EMPTY,
 } from "@/constants/initialPersonSpace";
+import createInitalProposalSpaceConfigForProposalId from "@/constants/initialProposalSpace";
 import {
   ModifiableSpacesResponse,
   RegisterNewSpaceResponse,
@@ -29,6 +30,7 @@ import {
 import { UnsignedDeleteSpaceTabRequest } from "@/pages/api/space/registry/[spaceId]/tabs/[tabId]";
 import axios from "axios";
 import stringify from "fast-json-stable-stringify";
+import type { Address } from "viem";
 import {
   cloneDeep,
   debounce,
@@ -986,7 +988,7 @@ export const createSpaceStoreFunc = (
   registerProposalSpace: async (payload: RegisterProposalSpacePayload) => {
     console.debug('[registerProposalSpace] payload', payload);
     // Use 'fid' for DB compatibility
-    const { proposalId, spaceId, fid, connectedFid } = payload;
+    const { proposalId, spaceId, fid, proposerAddress } = payload;
     try {
       // Check if a space already exists for this proposal
       const { data: existingSpaces } = await axiosBackend.get<ModifiableSpacesResponse>(
@@ -1046,10 +1048,15 @@ export const createSpaceStoreFunc = (
       });
 
       // Create and commit the initial "Nouns Prop {proposalId}" tab
+      const initialConfig = createInitalProposalSpaceConfigForProposalId(
+        proposalId as Address,
+        (proposerAddress ?? "0x0000000000000000000000000000000000000000") as Address,
+        proposerAddress as Address | undefined,
+      );
       await get().space.createSpaceTab(
         newSpaceId,
         `Nouns Prop ${proposalId}`,
-        INITIAL_SPACE_CONFIG_EMPTY
+        initialConfig
       );
 
       // Optionally track analytics here
@@ -1117,4 +1124,5 @@ export type RegisterProposalSpacePayload = {
   spaceId: string;
   fid: number;
   connectedFid?: number | null;
+  proposerAddress?: Address;
 };


### PR DESCRIPTION
## Summary
- use proposal initial config when registering
- restrict proposal space registration to proposer
- ignore user-space registration on proposal pages
- pass space ID and tab name to proposal pages

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*