### PR TITLE
Fix proposal page tab handling

### DIFF
--- a/src/app/(spaces)/p/[proposalId]/ProposalDefinedSpace.tsx
+++ b/src/app/(spaces)/p/[proposalId]/ProposalDefinedSpace.tsx
@@ -39,7 +39,7 @@ const ProposalDefinedSpace = ({
     <div className="w-full">
       <PublicSpace
         spaceId={proposalId || ""}
-        tabName={tabName || "Profile"}
+        tabName={tabName || `Nouns Prop ${proposalId}`}
         initialConfig={INITIAL_SPACE_CONFIG}
         getSpacePageUrl={getSpacePageUrl}
         isTokenPage={false}

--- a/src/app/(spaces)/p/[proposalId]/[tabname]/page.tsx
+++ b/src/app/(spaces)/p/[proposalId]/[tabname]/page.tsx
@@ -9,6 +9,12 @@ import { loadProposalData } from "../utils";
 
 export default async function WrapperProposalPrimarySpace({ params }) {
   const proposalId = params?.proposalId as string;
+  const rawTabName = params?.tabname;
+  const tabName =
+    typeof rawTabName === "string"
+      ? decodeURIComponent(rawTabName)
+      : `Nouns Prop ${proposalId}`;
+
   const proposalData = await loadProposalData(proposalId || "0");
 
   // Fetch proposer FID using our API route
@@ -43,6 +49,7 @@ export default async function WrapperProposalPrimarySpace({ params }) {
   const props = {
     proposalId,
     fid,
+    tabName,
   };
 
   return (


### PR DESCRIPTION
## Summary
- default to `Nouns Prop {proposalId}` tab when viewing a proposal space
- pass tab names from the URL into proposal pages

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*