### PR TITLE
Fix query config call

### DIFF
--- a/src/common/data/queries/spaceConfig.ts
+++ b/src/common/data/queries/spaceConfig.ts
@@ -3,24 +3,22 @@ import { useAppStore } from "../stores/app";
 
 export const useHomebaseTabConfig = (tabName: string) => {
   const loadTab = useAppStore((state) => state.homebase.loadHomebaseTab);
-  return useQuery<void>({
+  return useQuery({
     queryKey: ["homebase-tab-config", tabName],
     suspense: true,
-    queryFn: async () => {
-      await loadTab(tabName);
-    },
+    queryFn: async () => loadTab(tabName),
   });
 };
 
 export const useSpaceTabConfig = (spaceId: string | null, tabName: string) => {
   const loadTab = useAppStore((state) => state.space.loadSpaceTab);
-  return useQuery<void>({
+  return useQuery({
     queryKey: ["space-tab-config", spaceId, tabName],
     enabled: !!spaceId,
     suspense: true,
     queryFn: async () => {
-      if (!spaceId) return;
-      await loadTab(spaceId, tabName);
+      if (!spaceId) return undefined;
+      return loadTab(spaceId, tabName);
     },
   });
 };


### PR DESCRIPTION
## Summary
- return the loader results in `useSpaceTabConfig` and `useHomebaseTabConfig`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*
