### PR TITLE
Fix query config call

### DIFF
--- a/src/common/data/queries/spaceConfig.ts
+++ b/src/common/data/queries/spaceConfig.ts
@@ -1,26 +1,22 @@
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { useAppStore } from "../stores/app";
 
 export const useHomebaseTabConfig = (tabName: string) => {
   const loadTab = useAppStore((state) => state.homebase.loadHomebaseTab);
-  return useQuery<void>({
+  return useSuspenseQuery({
     queryKey: ["homebase-tab-config", tabName],
-    suspense: true,
-    queryFn: async () => {
-      await loadTab(tabName);
-    },
+    queryFn: () => loadTab(tabName),
   });
 };
 
 export const useSpaceTabConfig = (spaceId: string | null, tabName: string) => {
   const loadTab = useAppStore((state) => state.space.loadSpaceTab);
-  return useQuery<void>({
+  return useSuspenseQuery({
     queryKey: ["space-tab-config", spaceId, tabName],
     enabled: !!spaceId,
-    suspense: true,
-    queryFn: async () => {
-      if (!spaceId) return;
-      await loadTab(spaceId, tabName);
+    queryFn: () => {
+      if (!spaceId) return undefined;
+      return loadTab(spaceId, tabName);
     },
   });
 };


### PR DESCRIPTION
## Summary
- return the loader results in `useSpaceTabConfig` and `useHomebaseTabConfig`
- use `useSuspenseQuery` instead of `useQuery` for suspense-based hooks

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*
