### PR TITLE
Render profile while grid loads

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -661,6 +661,9 @@ export default function PublicSpace({
       <div className="user-theme-background w-full h-full relative flex-col">
         <div className="w-full transition-all duration-100 ease-out">
           <div className="flex flex-col h-full">
+            {profile ? (
+              <div className="z-50 bg-white md:h-40">{profile}</div>
+            ) : null}
             <TabBarSkeleton />
             <div className="flex h-full">
               <div className="grow">


### PR DESCRIPTION
## Summary
- keep the profile section visible during DB loading

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*