### PR TITLE
Enable proposal space customization

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -364,8 +364,7 @@ export default function PublicSpace({
     // Only proceed with registration if we're sure the space doesn't exist and FID is linked
     if (
       editabilityCheck.isEditable &&
-      currentSpaceId &&
-      !editableSpaces[currentSpaceId] &&
+      (isNil(currentSpaceId) || !editableSpaces[currentSpaceId]) &&
       !isNil(currentUserFid) &&
       !loading &&
       !editabilityCheck.isLoading

--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -36,6 +36,7 @@ interface PublicSpaceProps {
   tokenData?: MasterToken;
   // New prop to identify page type
   pageType?: SpacePageType;
+  proposalId?: string;
 }
 
 export default function PublicSpace({
@@ -51,6 +52,7 @@ export default function PublicSpace({
   contractAddress,
   tokenData,
   pageType, // New prop
+  proposalId,
 }: PublicSpaceProps) {
   console.log("PublicSpace mounted:", {
     spaceId: providedSpaceId,
@@ -85,6 +87,7 @@ export default function PublicSpace({
     deleteSpaceTab,
     registerSpaceFid,
     registerSpaceContract,
+    registerProposalSpace,
   } = useAppStore((state) => ({
     getCurrentSpaceId: state.currentSpace.getCurrentSpaceId,
     setCurrentSpaceId: state.currentSpace.setCurrentSpaceId,
@@ -104,6 +107,7 @@ export default function PublicSpace({
     commitSpaceTabOrder: state.space.commitSpaceOrderToDatabase,
     registerSpaceFid: state.space.registerSpaceFid,
     registerSpaceContract: state.space.registerSpaceContract,
+    registerProposalSpace: state.space.registerProposalSpace,
   }));
 
   const {
@@ -120,7 +124,7 @@ export default function PublicSpace({
       spaceOwnerAddress,
       tokenData,
       wallets: wallets.map((w) => ({ address: w.address as Address })),
-      isTokenPage,
+      isTokenPage: isTokenPage || pageType === "proposal",
     });
 
     console.log("Editability check:", {
@@ -139,6 +143,7 @@ export default function PublicSpace({
     tokenData,
     wallets,
     isTokenPage,
+    pageType,
   ]);
 
   // Internal isEditable function
@@ -181,7 +186,9 @@ export default function PublicSpace({
           network: tokenData.network,
         });
         setCurrentSpaceId(existingSpace.id);
-        setCurrentTabName(decodeURIComponent(providedTabName));
+        setCurrentTabName(
+          providedTabName ? decodeURIComponent(providedTabName) : "Profile",
+        );
         return;
       }
     } else if (resolvedPageType === "person" && spaceOwnerFid) {
@@ -195,17 +202,25 @@ export default function PublicSpace({
           spaceOwnerFid,
         });
         setCurrentSpaceId(existingSpace.id);
-        setCurrentTabName(decodeURIComponent(providedTabName));
+        setCurrentTabName(
+          providedTabName ? decodeURIComponent(providedTabName) : "Profile",
+        );
         return;
       }
-    } else if (resolvedPageType === "proposal") {
-      console.log("Handling proposal page logic...");
-      // Add specific logic for proposal pages here
+    } else if (resolvedPageType === "proposal" && proposalId) {
+      const generatedId = `proposal:${proposalId}`;
+      setCurrentSpaceId(generatedId);
+      setCurrentTabName(
+        providedTabName ? decodeURIComponent(providedTabName) : "Overview",
+      );
+      return;
     }
 
     // If no existing space found locally, use the provided spaceId
     setCurrentSpaceId(providedSpaceId);
-    setCurrentTabName(decodeURIComponent(providedTabName));
+    setCurrentTabName(
+      providedTabName ? decodeURIComponent(providedTabName) : "Profile",
+    );
   }, [
     resolvedPageType,
     providedSpaceId,
@@ -404,6 +419,10 @@ export default function PublicSpace({
               newSpaceId,
               contractAddress,
             });
+          } else if (resolvedPageType === "proposal" && proposalId) {
+            console.log("Attempting to register proposal space:", { proposalId });
+            newSpaceId = await registerProposalSpace(proposalId);
+            console.log("Proposal space registration result:", newSpaceId);
           } else if (!isTokenPage) {
             console.log("Attempting to register user space:", {
               currentUserFid,
@@ -427,17 +446,18 @@ export default function PublicSpace({
           if (newSpaceId) {
             // Set both spaceId and currentSpaceId atomically
             setCurrentSpaceId(newSpaceId);
-            setCurrentTabName("Profile");
+            const defaultTab = resolvedPageType === "proposal" ? "Overview" : "Profile";
+            setCurrentTabName(defaultTab);
 
             // Load the space data after registration
             await loadSpaceTabOrder(newSpaceId);
             await loadEditableSpaces(); // First load
-            await loadSpaceTab(newSpaceId, "Profile");
+            await loadSpaceTab(newSpaceId, defaultTab);
 
             // Load remaining tabs
             const tabOrder = localSpaces[newSpaceId]?.order || [];
             for (const tabName of tabOrder) {
-              if (tabName !== "Profile") {
+              if (tabName !== defaultTab) {
                 await loadSpaceTab(newSpaceId, tabName);
               }
             }
@@ -446,8 +466,8 @@ export default function PublicSpace({
             await loadEditableSpaces(); // Second load to invalidate cache
 
             // Update the URL to include the new space ID
-            revalidatePath(getSpacePageUrl("Profile"));
-            const newUrl = getSpacePageUrl("Profile");
+            revalidatePath(getSpacePageUrl(defaultTab));
+            const newUrl = getSpacePageUrl(defaultTab);
             router.replace(newUrl, { scroll: false });
           }
         } catch (error) {
@@ -465,6 +485,7 @@ export default function PublicSpace({
     isTokenPage,
     contractAddress,
     tokenData?.network,
+    proposalId,
     getCurrentSpaceId,
     getCurrentTabName,
     localSpaces,

--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -210,6 +210,18 @@ export default function PublicSpace({
         return;
       }
     } else if (resolvedPageType === "proposal" && proposalId) {
+      const existingSpace = Object.values(localSpaces).find(
+        (space) => space.proposalId === proposalId,
+      );
+
+      if (existingSpace) {
+        setCurrentSpaceId(existingSpace.id);
+        setCurrentTabName(
+          providedTabName ? decodeURIComponent(providedTabName) : "Overview",
+        );
+        return;
+      }
+
       const generatedId = `proposal:${proposalId}`;
       setCurrentSpaceId(generatedId);
       setCurrentTabName(
@@ -230,6 +242,7 @@ export default function PublicSpace({
     contractAddress,
     tokenData?.network,
     spaceOwnerFid,
+    proposalId,
     localSpaces,
   ]);
 
@@ -424,7 +437,7 @@ export default function PublicSpace({
             });
           } else if (resolvedPageType === "proposal" && proposalId) {
             console.log("Attempting to register proposal space:", { proposalId });
-            newSpaceId = await registerProposalSpace(proposalId);
+            newSpaceId = await registerProposalSpace(proposalId, initialConfig);
             console.log("Proposal space registration result:", newSpaceId);
           } else if (!isTokenPage) {
             console.log("Attempting to register user space:", {

--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -75,6 +75,7 @@ export default function PublicSpace({
     setCurrentTabName,
     loadEditableSpaces,
     localSpaces,
+    editableSpaces,
     remoteSpaces,
     loadSpaceTab,
     saveLocalSpaceTab,
@@ -95,6 +96,7 @@ export default function PublicSpace({
     setCurrentTabName: state.currentSpace.setCurrentTabName,
     localSpaces: state.space.localSpaces,
     remoteSpaces: state.space.remoteSpaces,
+    editableSpaces: state.space.editableSpaces,
     loadEditableSpaces: state.space.loadEditableSpaces,
     getCurrentSpaceConfig: state.currentSpace.getCurrentSpaceConfig,
     loadSpaceTab: state.space.loadSpaceTab,
@@ -349,7 +351,8 @@ export default function PublicSpace({
     // Only proceed with registration if we're sure the space doesn't exist and FID is linked
     if (
       editabilityCheck.isEditable &&
-      isNil(currentSpaceId) &&
+      currentSpaceId &&
+      !editableSpaces[currentSpaceId] &&
       !isNil(currentUserFid) &&
       !loading &&
       !editabilityCheck.isLoading

--- a/src/app/(spaces)/p/[proposalId]/ProposalDefinedSpace.tsx
+++ b/src/app/(spaces)/p/[proposalId]/ProposalDefinedSpace.tsx
@@ -38,14 +38,13 @@ const ProposalDefinedSpace = ({
   return (
     <div className="w-full">
       <PublicSpace
-        spaceId={spaceId || ""} // Ensure spaceId is a string
-        tabName={tabName || "Profile"} // Ensure tabName is a string
+        spaceId={spaceId || `proposal:${proposalId}`}
+        tabName={tabName || "Overview"}
         initialConfig={INITIAL_SPACE_CONFIG}
         getSpacePageUrl={getSpacePageUrl}
-        isTokenPage={false}
-        spaceOwnerFid={1}
         spaceOwnerAddress={ownerId}
         pageType="proposal"
+        proposalId={proposalId || undefined}
       />
     </div>
   );

--- a/src/app/(spaces)/p/[proposalId]/[tabname]/page.tsx
+++ b/src/app/(spaces)/p/[proposalId]/[tabname]/page.tsx
@@ -9,11 +9,13 @@ import { loadProposalData } from "../utils";
 
 export default async function WrapperProposalPrimarySpace({ params }) {
   const proposalId = params?.proposalId as string;
+  const tabName = params?.tabname as string | undefined;
   const proposalData = await loadProposalData(proposalId || "0");
 
   const props = {
     ...proposalData,
     proposalId,
+    tabName,
   };
 
   return (

--- a/src/common/components/molecules/ClaimButtonWithModal.tsx
+++ b/src/common/components/molecules/ClaimButtonWithModal.tsx
@@ -12,15 +12,20 @@ import { Address } from "viem";
 
 interface ClaimButtonWithModalProps {
   contractAddress?: Address;
+  tokenSymbol?: string;
 }
 
 const ClaimButtonWithModal: React.FC<ClaimButtonWithModalProps> = ({
   contractAddress,
+  tokenSymbol,
 }) => {
   const [isModalOpen, setModalOpenState] = React.useState(false);
   const { tokenData } = useToken();
   const symbol =
-    tokenData?.clankerData?.symbol || tokenData?.geckoData?.symbol || "";
+    tokenSymbol ||
+    tokenData?.clankerData?.symbol ||
+    tokenData?.geckoData?.symbol ||
+    "";
 
   const handleClaimClick = () => {
     setModalOpenState(true);
@@ -45,8 +50,9 @@ const ClaimButtonWithModal: React.FC<ClaimButtonWithModalProps> = ({
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            Log in with the Farcaster account that deployed ${symbol} to
-            customize this space.
+            {symbol
+              ? `Log in with the Farcaster account that deployed ${symbol} to customize this space.`
+              : 'Log in with Farcaster to customize this space.'}
           </TooltipContent>
         </Tooltip>
       </div>

--- a/src/common/components/molecules/ClaimButtonWithModal.tsx
+++ b/src/common/components/molecules/ClaimButtonWithModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { Button } from "../atoms/button";
 import ClaimModal from "./ClaimModal";
@@ -7,20 +9,18 @@ import {
   TooltipContent,
   TooltipProvider,
 } from "../atoms/tooltip";
-import { useToken } from "@/common/providers/TokenProvider";
-import { Address } from "viem";
+import { TokenContext } from "@/common/providers/TokenProvider";
 
 interface ClaimButtonWithModalProps {
-  contractAddress?: Address;
   tokenSymbol?: string;
 }
 
 const ClaimButtonWithModal: React.FC<ClaimButtonWithModalProps> = ({
-  contractAddress,
   tokenSymbol,
 }) => {
   const [isModalOpen, setModalOpenState] = React.useState(false);
-  const { tokenData } = useToken();
+  const tokenContext = React.useContext(TokenContext);
+  const tokenData = tokenContext?.tokenData;
   const symbol =
     tokenSymbol ||
     tokenData?.clankerData?.symbol ||

--- a/src/common/components/molecules/ClaimModal.tsx
+++ b/src/common/components/molecules/ClaimModal.tsx
@@ -29,8 +29,14 @@ const ClaimModal: React.FC<ClaimModalProps> = ({
     <Modal
       open={isModalOpen}
       setOpen={handleModalClose}
-      title={`Claim ${tokenSymbol}'s Token Space`}
-      description={`Login in with the Farcaster Account that deployed ${tokenSymbol} to customize this space.`}
+      title={
+        tokenSymbol ? `Claim ${tokenSymbol}'s Token Space` : 'Claim this Space'
+      }
+      description={
+        tokenSymbol
+          ? `Login in with the Farcaster Account that deployed ${tokenSymbol} to customize this space.`
+          : 'Log in with Farcaster to customize this space.'
+      }
     >
       <video
         autoPlay

--- a/src/common/components/molecules/ClaimModal.tsx
+++ b/src/common/components/molecules/ClaimModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import Modal from "../molecules/Modal";
 import { Button } from "../atoms/button";

--- a/src/common/components/organisms/ProposalDataHeader.tsx
+++ b/src/common/components/organisms/ProposalDataHeader.tsx
@@ -60,7 +60,7 @@ const ProposalDataHeader: React.FC = () => {
   return (
     <div className="mt-2 flex flex-col md:flex-row items-start md:items-center justify-between px-3 md:px-4 py-2 w-full border-r-2 border-r-gray-200">
       <div className="flex flex-col">
-        <h1 className="text-xl font-bold text-black">⌐◨-◨ - Proposal {id}</h1>
+        <h1 className="text-xl font-bold text-black">Prop {id}: {title}</h1>
         <div className="text-sm text-gray-500">
           Proposed by <AddressDisplay address={proposer} /> at {formattedDate}
           {signers && signers.length > 0 && (

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -243,9 +243,7 @@ function TabBar({
           !getIsInitializing() &&
           !isLoggedIn &&
           !isMobile && (
-            <ClaimButtonWithModal
-              contractAddress={isTokenPage ? contractAddress : undefined}
-            />
+            <ClaimButtonWithModal />
           )}
         {inEditMode ? (
           <div className="mr-36 flex flex-row z-infinity">

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -203,6 +203,11 @@ function TabBar({
             <TokenDataHeader />
           </div>
         )}
+        {pageType === "proposal" && (
+          <div className="flex flex-row justify-start h-16 overflow-y-scroll w-full z-30 bg-white">
+            <ProposalDataHeader />
+          </div>
+        )}
         <div className="flex w-64 flex-auto justify-start h-16 z-70 bg-white pr-8 md:pr-0 flex-nowrap overflow-y-scroll">
           {tabs && (
             <Reorder.Group

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -192,6 +192,9 @@ function TabBar({
 
   const isLoggedIn = getIsLoggedIn();
 
+  const defaultTab = pageType === "proposal" ? "Overview" : "Profile";
+  const tabs = tabList && tabList.length > 0 ? tabList : [defaultTab];
+
   return (
     <TooltipProvider>
       <div className="flex flex-col md:flex-row justify-start md:h-16 z-50 bg-white">
@@ -201,19 +204,19 @@ function TabBar({
           </div>
         )}
         <div className="flex w-64 flex-auto justify-start h-16 z-70 bg-white pr-8 md:pr-0 flex-nowrap overflow-y-scroll">
-          {tabList && (
+          {tabs && (
             <Reorder.Group
               as="ol"
               axis="x"
               onReorder={updateTabOrder}
               className="flex flex-row gap-5 md:gap-4 items-start m-4 tabs"
-              values={tabList}
+              values={tabs}
             >
               <AnimatePresence initial={false}>
                 {map(
                     inHomebase
-                    ? ["Feed", ...tabList]
-                    : tabList,
+                    ? ["Feed", ...tabs]
+                    : tabs,
                   (tabName: string) => {
                     return (
                       <Tab
@@ -236,9 +239,14 @@ function TabBar({
             </Reorder.Group>
           )}
         </div>
-        {isTokenPage && !getIsInitializing() && !isLoggedIn && !isMobile && (
-          <ClaimButtonWithModal contractAddress={contractAddress} />
-        )}
+        {(isTokenPage || pageType === "proposal") &&
+          !getIsInitializing() &&
+          !isLoggedIn &&
+          !isMobile && (
+            <ClaimButtonWithModal
+              contractAddress={isTokenPage ? contractAddress : undefined}
+            />
+          )}
         {inEditMode ? (
           <div className="mr-36 flex flex-row z-infinity">
             <NogsGateButton

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -94,6 +94,7 @@ interface CachedSpace {
   orderUpdatedAt?: string;
   contractAddress?: string | null;
   network?: string | null;
+  proposalId?: string | null;
 }
 
 interface LocalSpace extends CachedSpace {
@@ -176,6 +177,7 @@ interface SpaceActions {
   ) => Promise<string | undefined>;
   registerProposalSpace: (
     proposalId: string,
+    initialConfig: Omit<SpaceConfig, "isEditable">,
   ) => Promise<string | undefined>;
   clear: () => void;
 }
@@ -972,7 +974,7 @@ export const createSpaceStoreFunc = (
       throw e;
     }
   },
-  registerProposalSpace: async (proposalId) => {
+  registerProposalSpace: async (proposalId, initialConfig) => {
     try {
       // Check if a space already exists for this proposal
       const { data: existingSpaces } = await axiosBackend.get<ModifiableSpacesResponse>(
@@ -1021,12 +1023,14 @@ export const createSpaceStoreFunc = (
           tabs: {},
           order: [],
           changedNames: {},
+          proposalId,
         };
         draft.space.remoteSpaces[newSpaceId] = {
           id: newSpaceId,
           updatedAt: moment().toISOString(),
           tabs: {},
           order: [],
+          proposalId,
         };
       });
 
@@ -1034,7 +1038,7 @@ export const createSpaceStoreFunc = (
       await get().space.createSpaceTab(
         newSpaceId,
         "Overview",
-        INITIAL_SPACE_CONFIG_EMPTY
+        initialConfig ?? INITIAL_SPACE_CONFIG_EMPTY
       );
 
 

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -997,7 +997,7 @@ export const createSpaceStoreFunc = (
       // Register a new space for the proposal
       const unsignedRegistration: Omit<SpaceRegistrationProposer, "signature"> = {
         identityPublicKey: get().account.currentSpaceIdentityPublicKey!,
-        spaceName: `Proposal-${proposalId}`,
+        spaceName: `Nouns Prop ${proposalId}`,
         timestamp: moment().toISOString(),
         proposalId,
       };
@@ -1014,13 +1014,19 @@ export const createSpaceStoreFunc = (
 
       // Initialize the space with proper structure
       set((draft) => {
-        draft.space.editableSpaces[newSpaceId] = `Proposal-${proposalId}`;
+        draft.space.editableSpaces[newSpaceId] = `Nouns Prop ${proposalId}`;
         draft.space.localSpaces[newSpaceId] = {
           id: newSpaceId,
           updatedAt: moment().toISOString(),
           tabs: {},
           order: [],
           changedNames: {},
+        };
+        draft.space.remoteSpaces[newSpaceId] = {
+          id: newSpaceId,
+          updatedAt: moment().toISOString(),
+          tabs: {},
+          order: [],
         };
       });
 

--- a/src/common/providers/TokenProvider.tsx
+++ b/src/common/providers/TokenProvider.tsx
@@ -27,7 +27,8 @@ interface TokenContextProps {
   isLoading: boolean;
 }
 
-const TokenContext = createContext<TokenContextProps | undefined>(undefined);
+export const TokenContext =
+  createContext<TokenContextProps | undefined>(undefined);
 
 interface TokenProviderProps {
   children: ReactNode;

--- a/src/common/utils/spaceEditability.ts
+++ b/src/common/utils/spaceEditability.ts
@@ -63,10 +63,17 @@ export const createEditabilityChecker = (context: EditabilityContext) => {
     }
 
     // Check if user owns the wallet address (doesn't require clankerData)
-    if (spaceOwnerAddress && wallets.some(w => w.address === spaceOwnerAddress)) {
+    if (
+      spaceOwnerAddress &&
+      wallets.some(
+        (w) => w.address.toLowerCase() === spaceOwnerAddress.toLowerCase(),
+      )
+    ) {
       // console.log('Editable: User owns by address', {
       //   spaceOwnerAddress,
-      //   matchingWallet: wallets.find(w => w.address === spaceOwnerAddress),
+      //   matchingWallet: wallets.find(
+      //     (w) => w.address.toLowerCase() === spaceOwnerAddress.toLowerCase(),
+      //   ),
       // });
       return { isEditable: true, isLoading: false };
     }

--- a/src/pages/api/space/registry/[spaceId]/index.ts
+++ b/src/pages/api/space/registry/[spaceId]/index.ts
@@ -137,18 +137,22 @@ export async function identitiesCanModifySpace(
   const supabase = createSupabaseServerClient();
   const { data: spaceRegistrationData } = await supabase
     .from("spaceRegistrations")
-    .select("contractAddress")
+    .select("contractAddress, fid, identityPublicKey")
     .eq("spaceId", spaceId);
   if (spaceRegistrationData === null || spaceRegistrationData.length === 0)
     return [];
-  const contractAddress = first(spaceRegistrationData)!.contractAddress;
+  const registration = first(spaceRegistrationData)!;
+  const contractAddress = registration.contractAddress;
+  const fid = registration.fid;
   if (!isNull(contractAddress)) {
     return await loadIdentitiesOwningContractSpace(
       contractAddress,
       String(network),
     );
-  } else {
+  } else if (!isNull(fid)) {
     return await loadOwnedItentitiesForSpaceByFid(spaceId);
+  } else {
+    return [registration.identityPublicKey];
   }
 }
 


### PR DESCRIPTION
## Summary
- make Claim modal generic if no token symbol
- extend claim button for proposal spaces
- update TabBar to show claim option on proposals
- register and edit proposal spaces using proposer address
- support proposal pages in PublicSpace
- generate default proposal space id and tab names
- prevent crash in proposal space initialization

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definition files)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for "proposal" spaces as a new page type, including dedicated handling, registration, and tab management.
  - Enhanced proposal space pages with a descriptive header displaying both proposal ID and title.

- **Improvements**
  - Updated tab navigation to default to "Overview" for proposal spaces and ensure a default tab is always present.
  - The claim button and modal now display context-aware messages based on the presence of a token symbol or proposal context.
  - Proposal spaces now use more descriptive names and allow for initial configuration during registration.
  - Improved wallet address comparison for editability checks to be case-insensitive, ensuring more reliable ownership detection.

- **Bug Fixes**
  - Prevented duplicate registration of editable spaces.

- **Other**
  - Minor updates to exported entities to support new context and prop requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->