### PR TITLE
Enable proposal space customization

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -36,6 +36,7 @@ interface PublicSpaceProps {
   tokenData?: MasterToken;
   // New prop to identify page type
   pageType?: SpacePageType;
+  proposalId?: string;
 }
 
 export default function PublicSpace({
@@ -51,6 +52,7 @@ export default function PublicSpace({
   contractAddress,
   tokenData,
   pageType, // New prop
+  proposalId,
 }: PublicSpaceProps) {
   console.log("PublicSpace mounted:", {
     spaceId: providedSpaceId,
@@ -85,6 +87,7 @@ export default function PublicSpace({
     deleteSpaceTab,
     registerSpaceFid,
     registerSpaceContract,
+    registerProposalSpace,
   } = useAppStore((state) => ({
     getCurrentSpaceId: state.currentSpace.getCurrentSpaceId,
     setCurrentSpaceId: state.currentSpace.setCurrentSpaceId,
@@ -104,6 +107,7 @@ export default function PublicSpace({
     commitSpaceTabOrder: state.space.commitSpaceOrderToDatabase,
     registerSpaceFid: state.space.registerSpaceFid,
     registerSpaceContract: state.space.registerSpaceContract,
+    registerProposalSpace: state.space.registerProposalSpace,
   }));
 
   const {
@@ -120,7 +124,7 @@ export default function PublicSpace({
       spaceOwnerAddress,
       tokenData,
       wallets: wallets.map((w) => ({ address: w.address as Address })),
-      isTokenPage,
+      isTokenPage: isTokenPage || pageType === "proposal",
     });
 
     console.log("Editability check:", {
@@ -139,6 +143,7 @@ export default function PublicSpace({
     tokenData,
     wallets,
     isTokenPage,
+    pageType,
   ]);
 
   // Internal isEditable function
@@ -198,9 +203,11 @@ export default function PublicSpace({
         setCurrentTabName(decodeURIComponent(providedTabName));
         return;
       }
-    } else if (resolvedPageType === "proposal") {
-      console.log("Handling proposal page logic...");
-      // Add specific logic for proposal pages here
+    } else if (resolvedPageType === "proposal" && proposalId) {
+      const generatedId = `proposal:${proposalId}`;
+      setCurrentSpaceId(generatedId);
+      setCurrentTabName(decodeURIComponent(providedTabName) || "Overview");
+      return;
     }
 
     // If no existing space found locally, use the provided spaceId
@@ -387,15 +394,16 @@ export default function PublicSpace({
           }
 
           if (isTokenPage && contractAddress && tokenData?.network) {
+            const userFid = currentUserFid as number;
             console.log("Attempting to register contract space:", {
               contractAddress,
-              currentUserFid,
+              currentUserFid: userFid,
               network: tokenData.network,
             });
             newSpaceId = await registerSpaceContract(
               contractAddress,
               "Profile",
-              currentUserFid,
+              userFid,
               initialConfig,
               tokenData.network
             );
@@ -404,12 +412,17 @@ export default function PublicSpace({
               newSpaceId,
               contractAddress,
             });
+          } else if (resolvedPageType === "proposal" && proposalId) {
+            console.log("Attempting to register proposal space:", { proposalId });
+            newSpaceId = await registerProposalSpace(proposalId);
+            console.log("Proposal space registration result:", newSpaceId);
           } else if (!isTokenPage) {
+            const userFid = currentUserFid as number;
             console.log("Attempting to register user space:", {
-              currentUserFid,
+              currentUserFid: userFid,
             });
             newSpaceId = await registerSpaceFid(
-              currentUserFid,
+              userFid,
               "Profile",
               getSpacePageUrl("Profile")
             );
@@ -427,17 +440,18 @@ export default function PublicSpace({
           if (newSpaceId) {
             // Set both spaceId and currentSpaceId atomically
             setCurrentSpaceId(newSpaceId);
-            setCurrentTabName("Profile");
+            const defaultTab = resolvedPageType === "proposal" ? "Overview" : "Profile";
+            setCurrentTabName(defaultTab);
 
             // Load the space data after registration
             await loadSpaceTabOrder(newSpaceId);
             await loadEditableSpaces(); // First load
-            await loadSpaceTab(newSpaceId, "Profile");
+            await loadSpaceTab(newSpaceId, defaultTab);
 
             // Load remaining tabs
             const tabOrder = localSpaces[newSpaceId]?.order || [];
             for (const tabName of tabOrder) {
-              if (tabName !== "Profile") {
+              if (tabName !== defaultTab) {
                 await loadSpaceTab(newSpaceId, tabName);
               }
             }
@@ -446,8 +460,8 @@ export default function PublicSpace({
             await loadEditableSpaces(); // Second load to invalidate cache
 
             // Update the URL to include the new space ID
-            revalidatePath(getSpacePageUrl("Profile"));
-            const newUrl = getSpacePageUrl("Profile");
+            revalidatePath(getSpacePageUrl(defaultTab));
+            const newUrl = getSpacePageUrl(defaultTab);
             router.replace(newUrl, { scroll: false });
           }
         } catch (error) {
@@ -465,6 +479,7 @@ export default function PublicSpace({
     isTokenPage,
     contractAddress,
     tokenData?.network,
+    proposalId,
     getCurrentSpaceId,
     getCurrentTabName,
     localSpaces,

--- a/src/app/(spaces)/p/[proposalId]/ProposalDefinedSpace.tsx
+++ b/src/app/(spaces)/p/[proposalId]/ProposalDefinedSpace.tsx
@@ -38,14 +38,13 @@ const ProposalDefinedSpace = ({
   return (
     <div className="w-full">
       <PublicSpace
-        spaceId={spaceId || ""} // Ensure spaceId is a string
-        tabName={tabName || "Profile"} // Ensure tabName is a string
+        spaceId={spaceId || `proposal:${proposalId}`}
+        tabName={tabName || "Overview"}
         initialConfig={INITIAL_SPACE_CONFIG}
         getSpacePageUrl={getSpacePageUrl}
-        isTokenPage={false}
-        spaceOwnerFid={1}
         spaceOwnerAddress={ownerId}
         pageType="proposal"
+        proposalId={proposalId || undefined}
       />
     </div>
   );

--- a/src/common/components/molecules/ClaimButtonWithModal.tsx
+++ b/src/common/components/molecules/ClaimButtonWithModal.tsx
@@ -12,15 +12,20 @@ import { Address } from "viem";
 
 interface ClaimButtonWithModalProps {
   contractAddress?: Address;
+  tokenSymbol?: string;
 }
 
 const ClaimButtonWithModal: React.FC<ClaimButtonWithModalProps> = ({
   contractAddress,
+  tokenSymbol,
 }) => {
   const [isModalOpen, setModalOpenState] = React.useState(false);
   const { tokenData } = useToken();
   const symbol =
-    tokenData?.clankerData?.symbol || tokenData?.geckoData?.symbol || "";
+    tokenSymbol ||
+    tokenData?.clankerData?.symbol ||
+    tokenData?.geckoData?.symbol ||
+    "";
 
   const handleClaimClick = () => {
     setModalOpenState(true);
@@ -45,8 +50,9 @@ const ClaimButtonWithModal: React.FC<ClaimButtonWithModalProps> = ({
             </Button>
           </TooltipTrigger>
           <TooltipContent>
-            Log in with the Farcaster account that deployed ${symbol} to
-            customize this space.
+            {symbol
+              ? `Log in with the Farcaster account that deployed ${symbol} to customize this space.`
+              : 'Log in with Farcaster to customize this space.'}
           </TooltipContent>
         </Tooltip>
       </div>

--- a/src/common/components/molecules/ClaimModal.tsx
+++ b/src/common/components/molecules/ClaimModal.tsx
@@ -29,8 +29,14 @@ const ClaimModal: React.FC<ClaimModalProps> = ({
     <Modal
       open={isModalOpen}
       setOpen={handleModalClose}
-      title={`Claim ${tokenSymbol}'s Token Space`}
-      description={`Login in with the Farcaster Account that deployed ${tokenSymbol} to customize this space.`}
+      title={
+        tokenSymbol ? `Claim ${tokenSymbol}'s Token Space` : 'Claim this Space'
+      }
+      description={
+        tokenSymbol
+          ? `Login in with the Farcaster Account that deployed ${tokenSymbol} to customize this space.`
+          : 'Log in with Farcaster to customize this space.'
+      }
     >
       <video
         autoPlay

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -236,9 +236,14 @@ function TabBar({
             </Reorder.Group>
           )}
         </div>
-        {isTokenPage && !getIsInitializing() && !isLoggedIn && !isMobile && (
-          <ClaimButtonWithModal contractAddress={contractAddress} />
-        )}
+        {(isTokenPage || pageType === "proposal") &&
+          !getIsInitializing() &&
+          !isLoggedIn &&
+          !isMobile && (
+            <ClaimButtonWithModal
+              contractAddress={isTokenPage ? contractAddress : undefined}
+            />
+          )}
         {inEditMode ? (
           <div className="mr-36 flex flex-row z-infinity">
             <NogsGateButton

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -997,7 +997,7 @@ export const createSpaceStoreFunc = (
       // Register a new space for the proposal
       const unsignedRegistration: Omit<SpaceRegistrationProposer, "signature"> = {
         identityPublicKey: get().account.currentSpaceIdentityPublicKey!,
-        spaceName: `Proposal-${proposalId}`,
+        spaceName: `Nouns Prop ${proposalId}`,
         timestamp: moment().toISOString(),
         proposalId,
       };
@@ -1014,13 +1014,19 @@ export const createSpaceStoreFunc = (
 
       // Initialize the space with proper structure
       set((draft) => {
-        draft.space.editableSpaces[newSpaceId] = `Proposal-${proposalId}`;
+        draft.space.editableSpaces[newSpaceId] = `Nouns Prop ${proposalId}`;
         draft.space.localSpaces[newSpaceId] = {
           id: newSpaceId,
           updatedAt: moment().toISOString(),
           tabs: {},
           order: [],
           changedNames: {},
+        };
+        draft.space.remoteSpaces[newSpaceId] = {
+          id: newSpaceId,
+          updatedAt: moment().toISOString(),
+          tabs: {},
+          order: [],
         };
       });
 


### PR DESCRIPTION
## Summary
- make Claim modal generic if no token symbol
- extend claim button for proposal spaces
- update TabBar to show claim option on proposals
- register and edit proposal spaces using proposer address
- support proposal pages in PublicSpace
- generate default proposal space id and tab names
- fix type error when registering spaces

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definition files)*