### PR TITLE
Fix proposal space registration and claim modal

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -75,6 +75,7 @@ export default function PublicSpace({
     setCurrentTabName,
     loadEditableSpaces,
     localSpaces,
+    editableSpaces,
     remoteSpaces,
     loadSpaceTab,
     saveLocalSpaceTab,
@@ -95,6 +96,7 @@ export default function PublicSpace({
     setCurrentTabName: state.currentSpace.setCurrentTabName,
     localSpaces: state.space.localSpaces,
     remoteSpaces: state.space.remoteSpaces,
+    editableSpaces: state.space.editableSpaces,
     loadEditableSpaces: state.space.loadEditableSpaces,
     getCurrentSpaceConfig: state.currentSpace.getCurrentSpaceConfig,
     loadSpaceTab: state.space.loadSpaceTab,
@@ -349,7 +351,8 @@ export default function PublicSpace({
     // Only proceed with registration if we're sure the space doesn't exist and FID is linked
     if (
       editabilityCheck.isEditable &&
-      isNil(currentSpaceId) &&
+      currentSpaceId &&
+      !editableSpaces[currentSpaceId] &&
       !isNil(currentUserFid) &&
       !loading &&
       !editabilityCheck.isLoading

--- a/src/common/components/molecules/ClaimButtonWithModal.tsx
+++ b/src/common/components/molecules/ClaimButtonWithModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { Button } from "../atoms/button";
 import ClaimModal from "./ClaimModal";
@@ -7,20 +9,18 @@ import {
   TooltipContent,
   TooltipProvider,
 } from "../atoms/tooltip";
-import { useToken } from "@/common/providers/TokenProvider";
-import { Address } from "viem";
+import { TokenContext } from "@/common/providers/TokenProvider";
 
 interface ClaimButtonWithModalProps {
-  contractAddress?: Address;
   tokenSymbol?: string;
 }
 
 const ClaimButtonWithModal: React.FC<ClaimButtonWithModalProps> = ({
-  contractAddress,
   tokenSymbol,
 }) => {
   const [isModalOpen, setModalOpenState] = React.useState(false);
-  const { tokenData } = useToken();
+  const tokenContext = React.useContext(TokenContext);
+  const tokenData = tokenContext?.tokenData;
   const symbol =
     tokenSymbol ||
     tokenData?.clankerData?.symbol ||

--- a/src/common/components/molecules/ClaimModal.tsx
+++ b/src/common/components/molecules/ClaimModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import Modal from "../molecules/Modal";
 import { Button } from "../atoms/button";

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -243,9 +243,7 @@ function TabBar({
           !getIsInitializing() &&
           !isLoggedIn &&
           !isMobile && (
-            <ClaimButtonWithModal
-              contractAddress={isTokenPage ? contractAddress : undefined}
-            />
+            <ClaimButtonWithModal />
           )}
         {inEditMode ? (
           <div className="mr-36 flex flex-row z-infinity">

--- a/src/common/providers/TokenProvider.tsx
+++ b/src/common/providers/TokenProvider.tsx
@@ -27,7 +27,8 @@ interface TokenContextProps {
   isLoading: boolean;
 }
 
-const TokenContext = createContext<TokenContextProps | undefined>(undefined);
+export const TokenContext =
+  createContext<TokenContextProps | undefined>(undefined);
 
 interface TokenProviderProps {
   children: ReactNode;


### PR DESCRIPTION
## Summary
- export `TokenContext`
- gracefully handle missing token context in claim button
- check `editableSpaces` before registering new proposal space

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*