### PR TITLE
Fix proposal editability check

### DIFF
--- a/src/common/utils/spaceEditability.ts
+++ b/src/common/utils/spaceEditability.ts
@@ -63,10 +63,17 @@ export const createEditabilityChecker = (context: EditabilityContext) => {
     }
 
     // Check if user owns the wallet address (doesn't require clankerData)
-    if (spaceOwnerAddress && wallets.some(w => w.address === spaceOwnerAddress)) {
+    if (
+      spaceOwnerAddress &&
+      wallets.some(
+        (w) => w.address.toLowerCase() === spaceOwnerAddress.toLowerCase(),
+      )
+    ) {
       // console.log('Editable: User owns by address', {
       //   spaceOwnerAddress,
-      //   matchingWallet: wallets.find(w => w.address === spaceOwnerAddress),
+      //   matchingWallet: wallets.find(
+      //     (w) => w.address.toLowerCase() === spaceOwnerAddress.toLowerCase(),
+      //   ),
       // });
       return { isEditable: true, isLoading: false };
     }


### PR DESCRIPTION
## Summary
- fix case-sensitive wallet comparison when determining editability

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: Cannot find type definition file for 'node' etc.)*