### PR TITLE
Improve mobile fidget editing

### DIFF
--- a/src/common/components/molecules/MiniAppSettings.tsx
+++ b/src/common/components/molecules/MiniAppSettings.tsx
@@ -17,9 +17,10 @@ interface MiniAppSettingsProps {
   miniApp: MiniApp
   onUpdateMiniApp: (app: MiniApp) => void
   dragControls?: DragControls
+  orderNumber?: number
 }
 
-export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls }: MiniAppSettingsProps) {
+export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls, orderNumber }: MiniAppSettingsProps) {
   const [isIconSelectorOpen, setIsIconSelectorOpen] = useState(false)
   const iconButtonRef = useRef<HTMLButtonElement>(null)
 
@@ -71,8 +72,8 @@ export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls }: Mini
     );
   }
   return (
-    <div className="py-2 border-b last:border-b-0">
-      <div className="px-2">
+    <div className="py-2 border-y">
+      <div className="px-1">
         <div className="flex items-center gap-2 mb-2">
           <div
             className="cursor-move p-1 hover:bg-gray-100 rounded shrink-0"
@@ -81,6 +82,9 @@ export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls }: Mini
           >
             <GripVerticalIcon className="h-4 w-4 text-gray-400" />
           </div>
+          <span className="text-xs text-gray-400 w-4 text-center">
+            {orderNumber ?? "-"}
+          </span>
           <div className="text-sm text-gray-500 truncate flex-1">
             {miniApp.context}
           </div>

--- a/src/common/components/organisms/MobileSettings.tsx
+++ b/src/common/components/organisms/MobileSettings.tsx
@@ -11,9 +11,11 @@ interface MobileSettingsProps {
 function DraggableMiniApp({
   miniApp,
   onUpdateMiniApp,
+  orderNumber,
 }: {
   miniApp: MiniApp
   onUpdateMiniApp: (app: MiniApp) => void
+  orderNumber?: number
 }) {
   const controls = useDragControls()
   return (
@@ -27,6 +29,7 @@ function DraggableMiniApp({
         miniApp={miniApp}
         onUpdateMiniApp={onUpdateMiniApp}
         dragControls={controls}
+        orderNumber={orderNumber}
       />
     </Reorder.Item>
   )
@@ -49,8 +52,15 @@ export function MobileSettings({
     onReorderMiniApps(newOrder)
   }
 
+  const visibleOrderMap: Record<string | number, number> = {}
+  items
+    .filter((app) => app.displayOnMobile)
+    .forEach((app, index) => {
+      visibleOrderMap[app.id] = index + 1
+    })
+
   return (
-    <div className="p-2">
+    <div className="px-2 pt-1 pb-2">
       <p className="text-sm text-gray-500 mb-4">
         Drag fidgets to reorder them in the mobile nav, and customize their
         visibility, display name, and icon.
@@ -66,6 +76,7 @@ export function MobileSettings({
             key={miniApp.id}
             miniApp={miniApp}
             onUpdateMiniApp={onUpdateMiniApp}
+            orderNumber={visibleOrderMap[miniApp.id]}
           />
         ))}
       </Reorder.Group>


### PR DESCRIPTION
## Summary
- update MiniAppSettings row styles and show mobile order number
- compute order number for visible fidgets
- tighten padding in MobileSettings panel

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*