### PR TITLE
Fix new proposal tab defaults

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -311,10 +311,15 @@ export default function PublicSpace({
     console.error("Current space config is undefined");
   }
 
+  const fallbackConfig =
+    getCurrentTabName() === "Overview" || getCurrentTabName() === "Profile"
+      ? initialConfig
+      : INITIAL_SPACE_CONFIG_EMPTY;
+
   const config = {
     ...(currentConfig?.tabs[getCurrentTabName() ?? "Profile"]
       ? currentConfig.tabs[getCurrentTabName() ?? "Profile"]
-      : { ...initialConfig }),
+      : { ...fallbackConfig }),
     isEditable,
   };
 


### PR DESCRIPTION
## Summary
- use empty initial config for new space tabs when no tab config exists

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*
