### PR TITLE
Fix proposal space registration handling

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -210,6 +210,18 @@ export default function PublicSpace({
         return;
       }
     } else if (resolvedPageType === "proposal" && proposalId) {
+      const existingSpace = Object.values(localSpaces).find(
+        (space) => space.proposalId === proposalId,
+      );
+
+      if (existingSpace) {
+        setCurrentSpaceId(existingSpace.id);
+        setCurrentTabName(
+          providedTabName ? decodeURIComponent(providedTabName) : "Overview",
+        );
+        return;
+      }
+
       const generatedId = `proposal:${proposalId}`;
       setCurrentSpaceId(generatedId);
       setCurrentTabName(
@@ -230,6 +242,7 @@ export default function PublicSpace({
     contractAddress,
     tokenData?.network,
     spaceOwnerFid,
+    proposalId,
     localSpaces,
   ]);
 

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -94,6 +94,7 @@ interface CachedSpace {
   orderUpdatedAt?: string;
   contractAddress?: string | null;
   network?: string | null;
+  proposalId?: string | null;
 }
 
 interface LocalSpace extends CachedSpace {
@@ -1021,12 +1022,14 @@ export const createSpaceStoreFunc = (
           tabs: {},
           order: [],
           changedNames: {},
+          proposalId,
         };
         draft.space.remoteSpaces[newSpaceId] = {
           id: newSpaceId,
           updatedAt: moment().toISOString(),
           tabs: {},
           order: [],
+          proposalId,
         };
       });
 


### PR DESCRIPTION
## Summary
- add proposalId to space store definitions
- preserve proposalId on proposal space registration
- reuse registered proposal spaces when visiting proposal pages

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition files)*