### PR TITLE
Fix proposal space registration editing

### DIFF
--- a/src/pages/api/space/registry/[spaceId]/index.ts
+++ b/src/pages/api/space/registry/[spaceId]/index.ts
@@ -137,19 +137,21 @@ export async function identitiesCanModifySpace(
   const supabase = createSupabaseServerClient();
   const { data: spaceRegistrationData } = await supabase
     .from("spaceRegistrations")
-    .select("contractAddress")
+    .select("contractAddress, fid, identityPublicKey")
     .eq("spaceId", spaceId);
   if (spaceRegistrationData === null || spaceRegistrationData.length === 0)
     return [];
-  const contractAddress = first(spaceRegistrationData)!.contractAddress;
-  if (!isNull(contractAddress)) {
+  const registration = first(spaceRegistrationData)!;
+  if (!isNull(registration.contractAddress)) {
     return await loadIdentitiesOwningContractSpace(
-      contractAddress,
+      registration.contractAddress,
       String(network),
     );
-  } else {
+  }
+  if (!isNull(registration.fid)) {
     return await loadOwnedItentitiesForSpaceByFid(spaceId);
   }
+  return [registration.identityPublicKey];
 }
 
 async function spacePublicKeys(req: NextApiRequest, res: NextApiResponse) {


### PR DESCRIPTION
## Summary
- allow spaces registered without a fid or contract to be modified by the registering identity

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*