### PR TITLE
Fix token space registration

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -364,8 +364,7 @@ export default function PublicSpace({
     // Only proceed with registration if we're sure the space doesn't exist and FID is linked
     if (
       editabilityCheck.isEditable &&
-      currentSpaceId &&
-      !editableSpaces[currentSpaceId] &&
+      (isNil(currentSpaceId) || !editableSpaces[currentSpaceId]) &&
       !isNil(currentUserFid) &&
       !loading &&
       !editabilityCheck.isLoading


### PR DESCRIPTION
## Summary
- fix registration condition in PublicSpace to cover token spaces

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*