### PR TITLE
Add proposal header in tab bar

### DIFF
--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -203,6 +203,11 @@ function TabBar({
             <TokenDataHeader />
           </div>
         )}
+        {pageType === "proposal" && (
+          <div className="flex flex-row justify-start h-16 overflow-y-scroll w-full z-30 bg-white">
+            <ProposalDataHeader />
+          </div>
+        )}
         <div className="flex w-64 flex-auto justify-start h-16 z-70 bg-white pr-8 md:pr-0 flex-nowrap overflow-y-scroll">
           {tabs && (
             <Reorder.Group


### PR DESCRIPTION
## Summary
- display ProposalDataHeader when viewing proposal spaces

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*