### PR TITLE
Add mobile icon customization

### DIFF
--- a/src/common/components/molecules/IconSelector.tsx
+++ b/src/common/components/molecules/IconSelector.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useState, useRef } from 'react'
 import { SearchIcon, UploadIcon } from 'lucide-react'
 import { createPortal } from 'react-dom'
+import * as FaIcons from 'react-icons/fa6'
+import type { IconType } from 'react-icons'
+import ImgBBUploader from './ImgBBUploader'
 
 interface IconSelectorProps {
   onSelectIcon: (icon: string) => void
@@ -15,21 +18,21 @@ export function IconSelector({ onSelectIcon, triggerRef, onClose }: IconSelector
   const dropdownRef = useRef<HTMLDivElement>(null)
 
   const iconLibrary = [
-    'RssIcon',
-    'VoteIcon',
-    'ImageIcon',
-    'HomeIcon',
-    'GiftIcon',
-    'UserIcon',
-    'SettingsIcon',
-    'BellIcon',
-    'CalendarIcon',
-    'MessageIcon',
-    'FileIcon',
-    'FolderIcon',
-    'StarIcon',
-    'HeartIcon',
-    'ShareIcon',
+    'FaRss',
+    'FaVoteYea',
+    'FaImage',
+    'FaHouse',
+    'FaGift',
+    'FaUser',
+    'FaGear',
+    'FaBell',
+    'FaCalendar',
+    'FaEnvelope',
+    'FaFile',
+    'FaFolder',
+    'FaStar',
+    'FaHeart',
+    'FaShareNodes',
   ]
   const filteredIcons = iconLibrary.filter((icon) =>
     icon.toLowerCase().includes(searchTerm.toLowerCase()),
@@ -108,20 +111,23 @@ export function IconSelector({ onSelectIcon, triggerRef, onClose }: IconSelector
       {activeTab === 'library' ? (
         <div className="p-3 grid grid-cols-5 gap-2">
           {filteredIcons.length > 0 ? (
-            filteredIcons.map((icon) => (
-              <button
-                key={icon}
-                onClick={() => handleIconSelect(icon)}
-                className="flex flex-col items-center justify-center p-2 hover:bg-gray-100 rounded-md"
-              >
-                <div className="w-8 h-8 bg-gray-100 rounded-md flex items-center justify-center mb-1">
-                  {icon.charAt(0)}
-                </div>
-                <span className="text-xs text-gray-600 truncate w-full text-center">
-                  {icon}
-                </span>
-              </button>
-            ))
+            filteredIcons.map((icon) => {
+              const Icon = (FaIcons as Record<string, IconType>)[icon] as IconType
+              return (
+                <button
+                  key={icon}
+                  onClick={() => handleIconSelect(icon)}
+                  className="flex flex-col items-center justify-center p-2 hover:bg-gray-100 rounded-md"
+                >
+                  <div className="w-8 h-8 bg-gray-100 rounded-md flex items-center justify-center mb-1">
+                    {Icon ? <Icon className="w-5 h-5" /> : icon.charAt(0)}
+                  </div>
+                  <span className="text-xs text-gray-600 truncate w-full text-center">
+                    {icon}
+                  </span>
+                </button>
+              )
+            })
           ) : (
             <div className="col-span-5 py-4 text-center text-gray-500">No icons found</div>
           )}
@@ -134,10 +140,7 @@ export function IconSelector({ onSelectIcon, triggerRef, onClose }: IconSelector
           <p className="text-sm text-gray-600 mb-4 text-center">
             Upload a custom icon (SVG, PNG, or JPG)
           </p>
-          <label className="cursor-pointer bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded-md">
-            <span>Upload Icon</span>
-            <input type="file" className="hidden" accept="image/*" />
-          </label>
+          <ImgBBUploader onImageUploaded={handleIconSelect} />
         </div>
       )}
     </div>,

--- a/src/common/components/molecules/MiniAppSettings.tsx
+++ b/src/common/components/molecules/MiniAppSettings.tsx
@@ -2,6 +2,8 @@ import React, { useState, useRef } from 'react'
 import { DragControls } from 'framer-motion'
 import { IconSelector } from './IconSelector'
 import { EyeIcon, EyeOffIcon, GripVerticalIcon } from 'lucide-react'
+import * as FaIcons from 'react-icons/fa6'
+import type { IconType } from 'react-icons'
 
 export interface MiniApp {
   id: string | number
@@ -38,38 +40,26 @@ export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls, orderN
   }
 
   const getIconComponent = (iconName: string) => {
-    const IconMap: Record<string, React.ReactNode> = {
-      RssIcon: (
-        <div className="w-6 h-6 bg-blue-100 text-blue-600 flex items-center justify-center rounded">
-          RSS
-        </div>
-      ),
-      VoteIcon: (
-        <div className="w-6 h-6 bg-purple-100 text-purple-600 flex items-center justify-center rounded">
-          V
-        </div>
-      ),
-      ImageIcon: (
-        <div className="w-6 h-6 bg-green-100 text-green-600 flex items-center justify-center rounded">
-          I
-        </div>
-      ),
-      HomeIcon: (
-        <div className="w-6 h-6 bg-yellow-100 text-yellow-600 flex items-center justify-center rounded">
-          H
-        </div>
-      ),
-      GiftIcon: (
-        <div className="w-6 h-6 bg-red-100 text-red-600 flex items-center justify-center rounded">
-          G
-        </div>
-      ),
-    }
-    return (
-      IconMap[iconName] || (
+    if (!iconName) {
+      return (
         <div className="w-6 h-6 bg-gray-100 flex items-center justify-center rounded">?</div>
       )
-    );
+    }
+
+    if (iconName.startsWith('http')) {
+      return (
+        <img src={iconName} alt="icon" className="w-6 h-6 rounded object-contain" />
+      )
+    }
+
+    const Icon = (FaIcons as Record<string, IconType>)[iconName] as IconType
+    if (Icon) {
+      return <Icon className="w-6 h-6" />
+    }
+
+    return (
+      <div className="w-6 h-6 bg-gray-100 flex items-center justify-center rounded">?</div>
+    )
   }
   return (
     <div className="py-2 border-y">

--- a/src/common/fidgets/index.d.ts
+++ b/src/common/fidgets/index.d.ts
@@ -20,6 +20,8 @@ export type FidgetSettings = {
 export type FidgetSettingsStyle = {
   showOnMobile?: boolean;
   customMobileDisplayName?: string;
+  mobileIconName?: string;
+  mobileOrder?: number;
   background?: Color;
   fontFamily?: FontFamily;
   fontColor?: Color;

--- a/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
+++ b/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
@@ -2,6 +2,8 @@ import React, { useMemo, useRef, useState, useEffect } from "react";
 import { TabsList, TabsTrigger } from "@/common/components/atoms/tabs";
 import { BsImage, BsImageFill, BsFillPinFill, BsPin } from "react-icons/bs";
 import { MdGridView } from "react-icons/md";
+import * as FaIcons from "react-icons/fa6";
+import type { IconType } from "react-icons";
 import { CompleteFidgets } from "@/fidgets";
 import { getFidgetDisplayName } from "../utils";
 import { usePathname } from "next/navigation";
@@ -167,11 +169,22 @@ const TabNavigation: React.FC<TabNavigationProps> = ({
 
     // On mobile, use custom mobile icons if available
     if (isMobile) {
-      const isSelected = selectedTab === fidgetId;
+      const customIcon = fidgetDatum.config.settings.mobileIconName as string | undefined
+      if (customIcon) {
+        if (customIcon.startsWith('http')) {
+          return <img src={customIcon} alt="icon" className="w-5 h-5" />
+        }
+        const Icon = (FaIcons as Record<string, IconType>)[customIcon] as IconType
+        if (Icon) {
+          return <Icon className="text-xl" />
+        }
+      }
+
+      const isSelected = selectedTab === fidgetId
       if (isSelected && fidgetModule.properties.mobileIconSelected) {
-        return fidgetModule.properties.mobileIconSelected;
+        return fidgetModule.properties.mobileIconSelected
       } else if (fidgetModule.properties.mobileIcon) {
-        return fidgetModule.properties.mobileIcon;
+        return fidgetModule.properties.mobileIcon
       }
     }
     


### PR DESCRIPTION
## Summary
- implement Font Awesome icons in IconSelector
- allow uploading custom icons using ImgBB
- display selected icons in settings
- show user-selected icons in mobile nav
- extend fidget settings type with mobile icon info

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*