### PR TITLE
Update mobile icon handling

### DIFF
--- a/src/common/components/molecules/IconSelector.tsx
+++ b/src/common/components/molecules/IconSelector.tsx
@@ -2,8 +2,17 @@ import React, { useEffect, useState, useRef } from 'react'
 import { SearchIcon, UploadIcon } from 'lucide-react'
 import { createPortal } from 'react-dom'
 import * as FaIcons from 'react-icons/fa6'
+import * as BsIcons from 'react-icons/bs'
+import * as GiIcons from 'react-icons/gi'
 import type { IconType } from 'react-icons'
+import { DEFAULT_FIDGET_ICON_MAP } from '@/constants/mobileFidgetIcons'
 import ImgBBUploader from './ImgBBUploader'
+
+const ICON_PACK: Record<string, IconType> = {
+  ...FaIcons,
+  ...BsIcons,
+  ...GiIcons,
+}
 
 interface IconSelectorProps {
   onSelectIcon: (icon: string) => void
@@ -33,8 +42,10 @@ export function IconSelector({ onSelectIcon, triggerRef, onClose }: IconSelector
     'FaStar',
     'FaHeart',
     'FaShareNodes',
+    ...Object.values(DEFAULT_FIDGET_ICON_MAP),
   ]
-  const filteredIcons = iconLibrary.filter((icon) =>
+  const uniqueIcons = Array.from(new Set(iconLibrary))
+  const filteredIcons = uniqueIcons.filter((icon) =>
     icon.toLowerCase().includes(searchTerm.toLowerCase()),
   )
 
@@ -112,7 +123,7 @@ export function IconSelector({ onSelectIcon, triggerRef, onClose }: IconSelector
         <div className="p-3 grid grid-cols-5 gap-2">
           {filteredIcons.length > 0 ? (
             filteredIcons.map((icon) => {
-              const Icon = (FaIcons as Record<string, IconType>)[icon] as IconType
+              const Icon = ICON_PACK[icon] as IconType | undefined
               return (
                 <button
                   key={icon}

--- a/src/common/components/molecules/MiniAppSettings.tsx
+++ b/src/common/components/molecules/MiniAppSettings.tsx
@@ -3,7 +3,15 @@ import { DragControls } from 'framer-motion'
 import { IconSelector } from './IconSelector'
 import { EyeIcon, EyeOffIcon, GripVerticalIcon } from 'lucide-react'
 import * as FaIcons from 'react-icons/fa6'
+import * as BsIcons from 'react-icons/bs'
+import * as GiIcons from 'react-icons/gi'
 import type { IconType } from 'react-icons'
+
+const ICON_PACK: Record<string, IconType> = {
+  ...FaIcons,
+  ...BsIcons,
+  ...GiIcons,
+}
 
 export interface MiniApp {
   id: string | number
@@ -52,7 +60,7 @@ export function MiniAppSettings({ miniApp, onUpdateMiniApp, dragControls, orderN
       )
     }
 
-    const Icon = (FaIcons as Record<string, IconType>)[iconName] as IconType
+    const Icon = ICON_PACK[iconName] as IconType | undefined
     if (Icon) {
       return <Icon className="w-6 h-6" />
     }

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -48,6 +48,7 @@ import { Address, formatUnits, zeroAddress } from "viem";
 import { base } from "viem/chains";
 import { useBalance } from "wagmi";
 import { CompleteFidgets } from "@/fidgets";
+import { DEFAULT_FIDGET_ICON_MAP } from "@/constants/mobileFidgetIcons";
 import MobileSettings from "@/common/components/organisms/MobileSettings";
 import { MiniApp } from "@/common/components/molecules/MiniAppSettings";
 
@@ -75,6 +76,7 @@ export function ThemeSettingsEditor({
   const miniApps = useMemo<MiniApp[]>(() => {
     return Object.values(fidgetInstanceDatums).map((d, i) => {
       const props = CompleteFidgets[d.fidgetType]?.properties;
+      const defaultIcon = DEFAULT_FIDGET_ICON_MAP[d.fidgetType] ?? 'HomeIcon';
       return {
         id: d.id,
         name: d.fidgetType,
@@ -84,7 +86,7 @@ export function ThemeSettingsEditor({
           props?.fidgetName,
         context: props?.fidgetName,
         order: (d.config.settings.mobileOrder as number) || i + 1,
-        icon: (d.config.settings.mobileIconName as string) || 'HomeIcon',
+        icon: (d.config.settings.mobileIconName as string) || defaultIcon,
         displayOnMobile: d.config.settings.showOnMobile !== false,
       };
     });

--- a/src/constants/mobileFidgetIcons.ts
+++ b/src/constants/mobileFidgetIcons.ts
@@ -1,0 +1,16 @@
+export const DEFAULT_FIDGET_ICON_MAP: Record<string, string> = {
+  frame: 'BsAspectRatio',
+  cast: 'BsPin',
+  feed: 'BsChatRightHeart',
+  SnapShot: 'BsFillLightningChargeFill',
+  iframe: 'BsCloud',
+  FramesV2: 'BsCloud',
+  links: 'BsLink45Deg',
+  Swap: 'BsArrowRepeat',
+  Rss: 'BsRss',
+  Market: 'BsBarChart',
+  Portfolio: 'GiTwoCoins',
+  Chat: 'BsChatDots',
+  profile: 'BsPerson',
+};
+

--- a/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
+++ b/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
@@ -3,9 +3,17 @@ import { TabsList, TabsTrigger } from "@/common/components/atoms/tabs";
 import { BsImage, BsImageFill, BsFillPinFill, BsPin } from "react-icons/bs";
 import { MdGridView } from "react-icons/md";
 import * as FaIcons from "react-icons/fa6";
+import * as BsIcons from "react-icons/bs";
+import * as GiIcons from "react-icons/gi";
 import type { IconType } from "react-icons";
 import { CompleteFidgets } from "@/fidgets";
 import { getFidgetDisplayName } from "../utils";
+
+const ICON_PACK: Record<string, IconType> = {
+  ...FaIcons,
+  ...BsIcons,
+  ...GiIcons,
+};
 import { usePathname } from "next/navigation";
 
 interface TabNavigationProps {
@@ -174,7 +182,7 @@ const TabNavigation: React.FC<TabNavigationProps> = ({
         if (customIcon.startsWith('http')) {
           return <img src={customIcon} alt="icon" className="w-5 h-5" />
         }
-        const Icon = (FaIcons as Record<string, IconType>)[customIcon] as IconType
+        const Icon = ICON_PACK[customIcon] as IconType | undefined
         if (Icon) {
           return <Icon className="text-xl" />
         }


### PR DESCRIPTION
## Summary
- add map of default fidget icons
- use default icons when building mobile settings list
- support more icon packs in IconSelector and MiniAppSettings
- render custom icons in mobile TabNavigation

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: Cannot find type definition file for 'node')*