### PR TITLE
Cache visited tabs

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -223,7 +223,7 @@ export default function PublicSpace({
   // Loads and sets up the user's space tab when providedSpaceId or providedTabName changes
   useEffect(() => {
     const currentSpaceId = getCurrentSpaceId();
-    const currentTabName = getCurrentTabName();
+    const currentTabName = getCurrentTabName() ?? "Profile";
 
     console.log("Loading space tab:", {
       currentSpaceId,
@@ -232,8 +232,17 @@ export default function PublicSpace({
     });
 
     if (!isNil(currentSpaceId)) {
-      setLoading(true);
-      // First, load the space tab order
+      const hasCachedTab = !!localSpaces[currentSpaceId]?.tabs[currentTabName];
+      const hasCachedOrder =
+        !!localSpaces[currentSpaceId]?.order &&
+        localSpaces[currentSpaceId].order.length > 0;
+
+      if (!hasCachedTab || !hasCachedOrder) {
+        setLoading(true);
+      } else {
+        setLoading(false);
+      }
+
       loadSpaceTabOrder(currentSpaceId)
         .then(() => {
           console.log("Loaded space tab order");
@@ -241,8 +250,7 @@ export default function PublicSpace({
         })
         .then(() => {
           console.log("Loaded editable spaces");
-          // Load the specific tab
-          return loadSpaceTab(currentSpaceId, currentTabName ?? "Profile");
+          return loadSpaceTab(currentSpaceId, currentTabName);
         })
         .then(() => {
           console.log("Loaded space tab");
@@ -253,7 +261,7 @@ export default function PublicSpace({
           setLoading(false);
         });
     }
-  }, [getCurrentSpaceId, getCurrentTabName]);
+  }, [getCurrentSpaceId, getCurrentTabName, localSpaces]);
 
   // Function to load remaining tabs
   const loadRemainingTabs = useCallback(

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -311,9 +311,14 @@ export const createSpaceStoreFunc = (
 
     console.log("NewConfig", config);
     let localCopy;
+    const newTimestamp = moment().toISOString();
+
     // If the tab doesn't exist yet, use the new config directly
     if (!get().space.localSpaces[spaceId]?.tabs[tabName]) {
-      localCopy = cloneDeep(config);
+      localCopy = {
+        ...cloneDeep(config),
+        timestamp: newTimestamp,
+      };
     } else {
       // Otherwise merge with existing config
       localCopy = cloneDeep(get().space.localSpaces[spaceId].tabs[tabName]);
@@ -324,6 +329,7 @@ export const createSpaceStoreFunc = (
           return srcValue;
         }
       });
+      localCopy.timestamp = newTimestamp;
       console.log("localCopy", localCopy);
     }
 
@@ -335,8 +341,8 @@ export const createSpaceStoreFunc = (
       } else {
         draft.space.localSpaces[spaceId].tabs[tabName] = localCopy;
       }
-      const newTimestamp = moment().toISOString();
-      draft.space.localSpaces[spaceId].updatedAt = newTimestamp;
+      const newSpaceTimestamp = moment().toISOString();
+      draft.space.localSpaces[spaceId].updatedAt = newSpaceTimestamp;
     }, "saveLocalSpaceTab");
   },
   deleteSpaceTab: debounce(


### PR DESCRIPTION
## Summary
- ensure visited tabs use cached data if available before checking for updates
- update tab timestamps when caching locally so remote changes override cache

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn check-types` *(fails: package not in lockfile)*