### PR TITLE
Add collapsed toggle to FramesV2 fidget

### DIFF
--- a/src/fidgets/framesV2/components/FrameRenderer.tsx
+++ b/src/fidgets/framesV2/components/FrameRenderer.tsx
@@ -8,6 +8,7 @@ interface FrameRendererProps {
   frameUrl: string;
   isConnected?: boolean;
   fid?: number | null;
+  collapsed?: boolean;
 }
 
 interface FrameMetadata {
@@ -24,6 +25,7 @@ export default function FrameRenderer({
   frameUrl,
   isConnected = false,
   fid = null,
+  collapsed = false,
 }: FrameRendererProps) {
   const [frameData, setFrameData] = useState<FrameMetadata>({
     image: null,
@@ -36,7 +38,7 @@ export default function FrameRenderer({
   const [inputValue, setInputValue] = useState("");
   const [imgError, setImgError] = useState(false);
 
-  // Modal state for button actions
+  // Modal state for button actions (only used when collapsed)
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [activeButton, setActiveButton] = useState<number | null>(null);
 
@@ -206,6 +208,19 @@ export default function FrameRenderer({
         }}
       >
         <p>Error: {frameData.error}</p>
+      </div>
+    );
+  }
+
+  if (!collapsed && frameData.postUrl) {
+    return (
+      <div style={{ width: "100%", height: "100%" }}>
+        <iframe
+          src={frameData.postUrl}
+          title={frameData.title || "Frame"}
+          style={{ width: "100%", height: "100%", border: "none" }}
+          className="size-full"
+        />
       </div>
     );
   }

--- a/src/fidgets/framesV2/components/FramesFidget.tsx
+++ b/src/fidgets/framesV2/components/FramesFidget.tsx
@@ -8,11 +8,13 @@ import {
 } from "@/common/fidgets";
 import { isValidUrl } from "@/common/lib/utils/url";
 import { defaultStyleFields, ErrorWrapper } from "@/fidgets/helpers";
+import SwitchButton from "@/common/components/molecules/SwitchButton";
 import { BsCloud, BsCloudFill } from "react-icons/bs";
 import Frameslayout from "./Frameslayout";
 
 export type FramesFidgetSettings = {
   url: string;
+  collapsed?: boolean;
 } & FidgetSettingsStyle;
 
 export const WithMargin: React.FC<React.PropsWithChildren> = ({ children }) => (
@@ -38,6 +40,19 @@ const frameConfig: FidgetProperties = {
       ),
       group: "settings",
     },
+    {
+      fieldName: "collapsed",
+      displayName: "Collapsed",
+      displayNameHint: "Show a collapsed preview instead of the full Mini App",
+      default: false,
+      required: false,
+      inputSelector: (props) => (
+        <WithMargin>
+          <SwitchButton {...props} />
+        </WithMargin>
+      ),
+      group: "settings",
+    },
     ...defaultStyleFields,
   ],
   size: {
@@ -49,7 +64,7 @@ const frameConfig: FidgetProperties = {
 };
 
 const FramesFidget: React.FC<FidgetArgs<FramesFidgetSettings>> = ({
-  settings: { url },
+  settings: { url, collapsed = false },
 }) => {
   if (!url) {
     return (
@@ -59,8 +74,8 @@ const FramesFidget: React.FC<FidgetArgs<FramesFidgetSettings>> = ({
   if (!isValidUrl(url)) {
     return <ErrorWrapper icon="❌" message={`This URL is invalid (${url}).`} />;
   }
-  // Pass the URL as a prop to Frameslayout
-  return <Frameslayout frameUrl={url} />;
+  // Pass the URL and collapsed state as props to Frameslayout
+  return <Frameslayout frameUrl={url} collapsed={collapsed} />;
 };
 
 export default {

--- a/src/fidgets/framesV2/components/Frameslayout.tsx
+++ b/src/fidgets/framesV2/components/Frameslayout.tsx
@@ -3,9 +3,10 @@ import FrameRenderer from "./FrameRenderer";
 
 interface FrameslayoutProps {
   frameUrl: string;
+  collapsed?: boolean;
 }
 
-const Frameslayout: React.FC<FrameslayoutProps> = ({ frameUrl }) => {
+const Frameslayout: React.FC<FrameslayoutProps> = ({ frameUrl, collapsed = false }) => {
   if (!frameUrl || !frameUrl.startsWith("http")) {
     return null;
   }
@@ -23,7 +24,12 @@ const Frameslayout: React.FC<FrameslayoutProps> = ({ frameUrl }) => {
         overflow: "hidden",
       }}
     >
-      <FrameRenderer frameUrl={frameUrl} isConnected={true} fid={20721} />
+      <FrameRenderer
+        frameUrl={frameUrl}
+        isConnected={true}
+        fid={20721}
+        collapsed={collapsed}
+      />
     </div>
   );
 };


### PR DESCRIPTION

![2025-05-28 10 35 49](https://github.com/user-attachments/assets/56613b4f-77ac-4abd-9cb1-c564f5a7c268)


## Summary
- add `collapsed` to FramesV2 settings
- plumb collapsed setting through fidget components
- render Mini App inline when not collapsed

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition file)*