### PR TITLE
Rename "FramesV2" Fidget to "Farcaster Mini App" ("Mini App" on mobile) and move to the top of the list

### DIFF
--- a/src/fidgets/framesV2/components/FramesFidget.tsx
+++ b/src/fidgets/framesV2/components/FramesFidget.tsx
@@ -20,8 +20,8 @@ export const WithMargin: React.FC<React.PropsWithChildren> = ({ children }) => (
 );
 
 const frameConfig: FidgetProperties = {
-  fidgetName: "FramesV2",
-  mobileFidgetName: "Frame",
+  fidgetName: "Farcaster Mini App",
+  mobileFidgetName: "Mini App",
   icon: 0x1f310, // 🌐
   mobileIcon: <BsCloud size={24} />,
   mobileIconSelected: <BsCloudFill size={24} />,

--- a/src/fidgets/index.ts
+++ b/src/fidgets/index.ts
@@ -26,6 +26,7 @@ export const CompleteFidgets = {
   //
   example:
     process.env.NEXT_PUBLIC_VERCEL_ENV === "development" ? Example : undefined,
+  FramesV2: FramesFidget,
   profile:
     process.env.NEXT_PUBLIC_VERCEL_ENV === "development" ? Profile : undefined,
   // Farcaster
@@ -49,7 +50,6 @@ export const CompleteFidgets = {
   Market: marketData,
   Portfolio: Portfolio,
   Chat: chat,
-  FramesV2: FramesFidget,
 };
 
 export const LayoutFidgets = {


### PR DESCRIPTION
## Summary
- rename the FramesV2 fidget to **Farcaster Mini App**
- update mobile display name to "Mini App"
- place the fidget at the top of the fidget list

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*