### PR TITLE
Add optional title to FramesV2

### DIFF
--- a/src/fidgets/framesV2/components/FramesFidget.tsx
+++ b/src/fidgets/framesV2/components/FramesFidget.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import TextInput from "@/common/components/molecules/TextInput";
+import FontSelector from "@/common/components/molecules/FontSelector";
 import {
   FidgetArgs,
   FidgetModule,
@@ -15,6 +16,8 @@ import Frameslayout from "./Frameslayout";
 export type FramesFidgetSettings = {
   url: string;
   collapsed?: boolean;
+  title?: string;
+  headingFont?: string;
 } & FidgetSettingsStyle;
 
 export const WithMargin: React.FC<React.PropsWithChildren> = ({ children }) => (
@@ -53,7 +56,34 @@ const frameConfig: FidgetProperties = {
       ),
       group: "settings",
     },
+    {
+      fieldName: "title",
+      displayName: "Title",
+      displayNameHint: "Optional title to display above the Frame.",
+      default: "",
+      required: false,
+      inputSelector: (props) => (
+        <WithMargin>
+          <TextInput {...props} />
+        </WithMargin>
+      ),
+      group: "settings",
+    },
     ...defaultStyleFields,
+    {
+      fieldName: "headingFont",
+      displayName: "Heading Font",
+      displayNameHint:
+        "Font used for the title. Set to Theme Font to inherit the Title Font from the Theme.",
+      default: "var(--user-theme-headings-font)",
+      required: false,
+      inputSelector: (props) => (
+        <WithMargin>
+          <FontSelector {...props} />
+        </WithMargin>
+      ),
+      group: "style",
+    },
   ],
   size: {
     minHeight: 2,
@@ -64,7 +94,7 @@ const frameConfig: FidgetProperties = {
 };
 
 const FramesFidget: React.FC<FidgetArgs<FramesFidgetSettings>> = ({
-  settings: { url, collapsed = false },
+  settings: { url, collapsed = false, title, headingFont },
 }) => {
   if (!url) {
     return (
@@ -75,7 +105,14 @@ const FramesFidget: React.FC<FidgetArgs<FramesFidgetSettings>> = ({
     return <ErrorWrapper icon="❌" message={`This URL is invalid (${url}).`} />;
   }
   // Pass the URL and collapsed state as props to Frameslayout
-  return <Frameslayout frameUrl={url} collapsed={collapsed} />;
+  return (
+    <Frameslayout
+      frameUrl={url}
+      collapsed={collapsed}
+      title={title}
+      headingFont={headingFont}
+    />
+  );
 };
 
 export default {

--- a/src/fidgets/framesV2/components/Frameslayout.tsx
+++ b/src/fidgets/framesV2/components/Frameslayout.tsx
@@ -4,9 +4,16 @@ import FrameRenderer from "./FrameRenderer";
 interface FrameslayoutProps {
   frameUrl: string;
   collapsed?: boolean;
+  title?: string;
+  headingFont?: string;
 }
 
-const Frameslayout: React.FC<FrameslayoutProps> = ({ frameUrl, collapsed = false }) => {
+const Frameslayout: React.FC<FrameslayoutProps> = ({
+  frameUrl,
+  collapsed = false,
+  title,
+  headingFont,
+}) => {
   if (!frameUrl || !frameUrl.startsWith("http")) {
     return null;
   }
@@ -17,6 +24,7 @@ const Frameslayout: React.FC<FrameslayoutProps> = ({ frameUrl, collapsed = false
         height: "100%",
         background: "#fff",
         display: "flex",
+        flexDirection: "column",
         alignItems: "stretch",
         justifyContent: "stretch",
         padding: 0,
@@ -24,12 +32,26 @@ const Frameslayout: React.FC<FrameslayoutProps> = ({ frameUrl, collapsed = false
         overflow: "hidden",
       }}
     >
-      <FrameRenderer
-        frameUrl={frameUrl}
-        isConnected={true}
-        fid={20721}
-        collapsed={collapsed}
-      />
+      {!collapsed && title ? (
+        <div style={{ padding: "12px" }}>
+          <h2
+            className="text-xl font-bold"
+            style={{
+              fontFamily: headingFont || "var(--user-theme-headings-font)",
+            }}
+          >
+            {title}
+          </h2>
+        </div>
+      ) : null}
+      <div style={{ flex: 1 }}>
+        <FrameRenderer
+          frameUrl={frameUrl}
+          isConnected={true}
+          fid={20721}
+          collapsed={collapsed}
+        />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- allow setting a title for the FramesV2 mini app
- support custom heading font
- display the title when not collapsed

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*