### PR TITLE
Display mobile preview when editing

### DIFF
--- a/src/common/lib/hooks/useIsMobile.ts
+++ b/src/common/lib/hooks/useIsMobile.ts
@@ -1,4 +1,5 @@
-import useWindowSize from './useWindowSize';
+import useWindowSize from "./useWindowSize";
+import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 
 // Mobile breakpoint (in pixels)
 export const MOBILE_BREAKPOINT = 768;
@@ -9,7 +10,8 @@ export const MOBILE_BREAKPOINT = 768;
  */
 export function useIsMobile(): boolean {
   const { width } = useWindowSize();
-  return width ? width < MOBILE_BREAKPOINT : false;
+  const { forceMobile } = useMobilePreview();
+  return forceMobile || (width ? width < MOBILE_BREAKPOINT : false);
 }
 
 export default useIsMobile;

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -41,6 +41,7 @@ import { THEMES } from "@/constants/themes";
 import { SparklesIcon } from "@heroicons/react/24/solid";
 import { usePrivy } from "@privy-io/react-auth";
 import { useEffect, useRef, useState, useMemo } from "react";
+import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 import { FaInfoCircle } from "react-icons/fa";
 import { FaFloppyDisk, FaTriangleExclamation, FaX } from "react-icons/fa6";
 import { MdMenuBook } from "react-icons/md";
@@ -72,6 +73,12 @@ export function ThemeSettingsEditor({
   const [showConfirmCancel, setShowConfirmCancel] = useState(false);
   const [activeTheme, setActiveTheme] = useState(theme.id);
   const [tabValue, setTabValue] = useState("space");
+  const { setForceMobile } = useMobilePreview();
+
+  useEffect(() => {
+    setForceMobile(tabValue === "mobile");
+    return () => setForceMobile(false);
+  }, [tabValue, setForceMobile]);
 
   const miniApps = useMemo<MiniApp[]>(() => {
     return Object.values(fidgetInstanceDatums).map((d, i) => {

--- a/src/common/providers/MobilePreviewProvider.tsx
+++ b/src/common/providers/MobilePreviewProvider.tsx
@@ -1,0 +1,29 @@
+"use client";
+import React, { createContext, useContext, useState } from "react";
+
+export interface MobilePreviewContextValue {
+  forceMobile: boolean;
+  setForceMobile: (value: boolean) => void;
+}
+
+const MobilePreviewContext = createContext<MobilePreviewContextValue>({
+  forceMobile: false,
+  setForceMobile: () => {},
+});
+
+export const MobilePreviewProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [forceMobile, setForceMobile] = useState(false);
+
+  return (
+    <MobilePreviewContext.Provider value={{ forceMobile, setForceMobile }}>
+      {children}
+    </MobilePreviewContext.Provider>
+  );
+};
+
+export const useMobilePreview = (): MobilePreviewContextValue =>
+  useContext(MobilePreviewContext);
+
+export default MobilePreviewProvider;

--- a/src/common/providers/index.tsx
+++ b/src/common/providers/index.tsx
@@ -13,6 +13,7 @@ import VersionCheckProivder from "./VersionCheckProvider";
 import { SidebarContextProvider } from "@/common/components/organisms/Sidebar";
 import { ToastProvider } from "../components/atoms/Toast";
 import MiniAppSdkProvider from "./MiniAppSdkProvider";
+import MobilePreviewProvider from "./MobilePreviewProvider";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
@@ -26,11 +27,13 @@ export default function Providers({ children }: { children: React.ReactNode }) {
                   <AuthenticatorProvider>
                     <LoggedInStateProvider>
                       <SidebarContextProvider>
-                        <AnalyticsProvider>
-                          <MiniAppSdkProvider>
-                            <ToastProvider>{children}</ToastProvider>
-                          </MiniAppSdkProvider>
-                        </AnalyticsProvider>
+                        <MobilePreviewProvider>
+                          <AnalyticsProvider>
+                            <MiniAppSdkProvider>
+                              <ToastProvider>{children}</ToastProvider>
+                            </MiniAppSdkProvider>
+                          </AnalyticsProvider>
+                        </MobilePreviewProvider>
                       </SidebarContextProvider>
                     </LoggedInStateProvider>
                   </AuthenticatorProvider>


### PR DESCRIPTION
## Summary
- add `MobilePreviewProvider` to manage mobile preview state
- update `useIsMobile` to respect forced mobile view
- toggle mobile preview in `ThemeSettingsEditor`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*