### PR TITLE
Display mobile preview when editing

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -17,6 +17,7 @@ import SpaceLoading from "./SpaceLoading";
 // Import the LayoutFidgets directly
 import { LayoutFidgets } from "@/fidgets";
 import { useIsMobile } from "@/common/lib/hooks/useIsMobile";
+import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 import { PlacedGridItem } from "@/fidgets/layout/Grid";
 import { cleanupLayout } from '@/common/lib/utils/gridCleanup';
 
@@ -75,6 +76,7 @@ export default function Space({
 }: SpaceArgs) {
   // Use the useIsMobile hook instead of duplicating logic
   const isMobile = useIsMobile();
+  const { forceMobile } = useMobilePreview();
 
   useEffect(() => {
     setSidebarEditable(config.isEditable);
@@ -280,7 +282,7 @@ export default function Space({
     console.error("LayoutFidget is undefined");
   }
 
-  return (
+  const spaceContent = (
     <div className="user-theme-background w-full h-full relative flex-col">
       <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
       <div className="w-full transition-all duration-100 ease-out">
@@ -340,4 +342,16 @@ export default function Space({
       </div>
     </div>
   );
+
+  if (editMode && forceMobile) {
+    return (
+      <div className="w-full h-full flex items-center justify-center">
+        <div style={{ width: 390, height: 844 }} className="relative">
+          {spaceContent}
+        </div>
+      </div>
+    );
+  }
+
+  return spaceContent;
 }

--- a/src/common/lib/hooks/useIsMobile.ts
+++ b/src/common/lib/hooks/useIsMobile.ts
@@ -1,4 +1,5 @@
-import useWindowSize from './useWindowSize';
+import useWindowSize from "./useWindowSize";
+import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 
 // Mobile breakpoint (in pixels)
 export const MOBILE_BREAKPOINT = 768;
@@ -9,7 +10,8 @@ export const MOBILE_BREAKPOINT = 768;
  */
 export function useIsMobile(): boolean {
   const { width } = useWindowSize();
-  return width ? width < MOBILE_BREAKPOINT : false;
+  const { forceMobile } = useMobilePreview();
+  return forceMobile || (width ? width < MOBILE_BREAKPOINT : false);
 }
 
 export default useIsMobile;

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -41,6 +41,7 @@ import { THEMES } from "@/constants/themes";
 import { SparklesIcon } from "@heroicons/react/24/solid";
 import { usePrivy } from "@privy-io/react-auth";
 import { useEffect, useRef, useState, useMemo } from "react";
+import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 import { FaInfoCircle } from "react-icons/fa";
 import { FaFloppyDisk, FaTriangleExclamation, FaX } from "react-icons/fa6";
 import { MdMenuBook } from "react-icons/md";
@@ -72,6 +73,12 @@ export function ThemeSettingsEditor({
   const [showConfirmCancel, setShowConfirmCancel] = useState(false);
   const [activeTheme, setActiveTheme] = useState(theme.id);
   const [tabValue, setTabValue] = useState("space");
+  const { setForceMobile } = useMobilePreview();
+
+  useEffect(() => {
+    setForceMobile(tabValue === "mobile");
+    return () => setForceMobile(false);
+  }, [tabValue, setForceMobile]);
 
   const miniApps = useMemo<MiniApp[]>(() => {
     return Object.values(fidgetInstanceDatums).map((d, i) => {

--- a/src/common/providers/MobilePreviewProvider.tsx
+++ b/src/common/providers/MobilePreviewProvider.tsx
@@ -1,0 +1,29 @@
+"use client";
+import React, { createContext, useContext, useState } from "react";
+
+export interface MobilePreviewContextValue {
+  forceMobile: boolean;
+  setForceMobile: (value: boolean) => void;
+}
+
+const MobilePreviewContext = createContext<MobilePreviewContextValue>({
+  forceMobile: false,
+  setForceMobile: () => {},
+});
+
+export const MobilePreviewProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [forceMobile, setForceMobile] = useState(false);
+
+  return (
+    <MobilePreviewContext.Provider value={{ forceMobile, setForceMobile }}>
+      {children}
+    </MobilePreviewContext.Provider>
+  );
+};
+
+export const useMobilePreview = (): MobilePreviewContextValue =>
+  useContext(MobilePreviewContext);
+
+export default MobilePreviewProvider;

--- a/src/common/providers/index.tsx
+++ b/src/common/providers/index.tsx
@@ -13,6 +13,7 @@ import VersionCheckProivder from "./VersionCheckProvider";
 import { SidebarContextProvider } from "@/common/components/organisms/Sidebar";
 import { ToastProvider } from "../components/atoms/Toast";
 import MiniAppSdkProvider from "./MiniAppSdkProvider";
+import MobilePreviewProvider from "./MobilePreviewProvider";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
@@ -26,11 +27,13 @@ export default function Providers({ children }: { children: React.ReactNode }) {
                   <AuthenticatorProvider>
                     <LoggedInStateProvider>
                       <SidebarContextProvider>
-                        <AnalyticsProvider>
-                          <MiniAppSdkProvider>
-                            <ToastProvider>{children}</ToastProvider>
-                          </MiniAppSdkProvider>
-                        </AnalyticsProvider>
+                        <MobilePreviewProvider>
+                          <AnalyticsProvider>
+                            <MiniAppSdkProvider>
+                              <ToastProvider>{children}</ToastProvider>
+                            </MiniAppSdkProvider>
+                          </AnalyticsProvider>
+                        </MobilePreviewProvider>
                       </SidebarContextProvider>
                     </LoggedInStateProvider>
                   </AuthenticatorProvider>


### PR DESCRIPTION
## Summary
- wrap `Space` in a centered 390x844 preview container when editing with mobile preview enabled

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*