### PR TITLE
Fix cast button size in collapsed nav

### DIFF
--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -323,7 +323,6 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
                     onClick={turnOnEditMode}
                     size="icon"
                     variant="secondary"
-                    className="flex items-center justify-center w-12 h-12"
                   >
                     <div className="flex items-center p-1">
                       <FaPaintbrush />
@@ -334,7 +333,6 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
                   onClick={openCastModal}
                   variant="primary"
                   width="auto"
-                  className="flex items-center justify-center w-12 h-12"
                 >
                   {shrunk ? <span className="sr-only">Cast</span> : "Cast"}
                   {shrunk && (


### PR DESCRIPTION
## Summary
- keep the new RiQuillPenLine icon on the Cast button
- revert Cast button styles so its size matches the original collapsed nav

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition files)*