### PR TITLE
Add mobile preview mode

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -16,7 +16,9 @@ import TabBarSkeleton from "@/common/components/organisms/TabBarSkeleton";
 import SpaceLoading from "./SpaceLoading";
 // Import the LayoutFidgets directly
 import { LayoutFidgets } from "@/fidgets";
-import { useIsMobile } from "@/common/lib/hooks/useIsMobile";
+import { useIsMobile, MOBILE_BREAKPOINT } from "@/common/lib/hooks/useIsMobile";
+import useWindowSize from "@/common/lib/hooks/useWindowSize";
+import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 import { PlacedGridItem } from "@/fidgets/layout/Grid";
 import { cleanupLayout } from '@/common/lib/utils/gridCleanup';
 
@@ -75,6 +77,9 @@ export default function Space({
 }: SpaceArgs) {
   // Use the useIsMobile hook instead of duplicating logic
   const isMobile = useIsMobile();
+  const { mobilePreview } = useMobilePreview();
+  const { width } = useWindowSize();
+  const showPreviewFrame = mobilePreview && (width ? width >= MOBILE_BREAKPOINT : false);
 
   useEffect(() => {
     setSidebarEditable(config.isEditable);
@@ -280,64 +285,74 @@ export default function Space({
     console.error("LayoutFidget is undefined");
   }
 
-  return (
-    <div className="user-theme-background w-full h-full relative flex-col">
-      <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
-      <div className="w-full transition-all duration-100 ease-out">
-        <div className="flex flex-col h-full">
-          <div style={{ position: "fixed", zIndex: 9999 }}>
-            <InfoToast />
-          </div>
-          {!isUndefined(profile) ? (
-            <div className="z-50 bg-white md:h-40">{profile}</div>
+  const layoutContent = (
+    <div className="w-full transition-all duration-100 ease-out">
+      <div className="flex flex-col h-full">
+        <div style={{ position: "fixed", zIndex: 9999 }}>
+          <InfoToast />
+        </div>
+        {!isUndefined(profile) ? (
+          <div className="z-50 bg-white md:h-40">{profile}</div>
+        ) : null}
+
+        <div className="relative">
+          <Suspense fallback={<TabBarSkeleton />}>{tabBar}</Suspense>
+          {/* Gradient overlay for tabs on mobile */}
+          {isMobile && (
+            <div
+              className="absolute right-0 top-0 bottom-0 w-12 pointer-events-none opacity-90 z-50"
+              style={{
+                background:
+                  "linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.9) 50%, rgba(255, 255, 255, 1) 100%)",
+              }}
+            />
+          )}
+        </div>
+
+        <div className={isMobile ? "w-full h-full" : "flex h-full"}>
+          {!isUndefined(feed) && !isMobile ? (
+            <div className="w-6/12 h-[calc(100vh-64px)]">{feed}</div>
           ) : null}
 
-          <div className="relative">
-            <Suspense fallback={<TabBarSkeleton />}>{tabBar}</Suspense>
-            {/* Gradient overlay for tabs on mobile */}
-            {isMobile && (
-              <div
-                className="absolute right-0 top-0 bottom-0 w-12 pointer-events-none opacity-90 z-50"
-                style={{
-                  background:
-                    "linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.9) 50%, rgba(255, 255, 255, 1) 100%)",
-                }}
-              />
-            )}
-          </div>
-
-          <div className={isMobile ? "w-full h-full" : "flex h-full"}>
-            {!isUndefined(feed) && !isMobile ? (
-              <div className="w-6/12 h-[calc(100vh-64px)]">{feed}</div>
-            ) : null}
-
-            <div className={isMobile ? "w-full h-full" : "grow"}>
-              <Suspense
-                fallback={
+          <div className={isMobile ? "w-full h-full" : "grow"}>
+            <Suspense
+              fallback={
+                <SpaceLoading
+                  hasProfile={!isNil(profile)}
+                  hasFeed={!isNil(feed)}
+                />
+              }
+            >
+              {LayoutFidget ? (
+                <LayoutFidget
+                  layoutConfig={{ ...layoutConfig }}
+                  {...layoutFidgetProps}
+                />
+              ) : (
+                <div className="flex items-center justify-center h-full">
                   <SpaceLoading
                     hasProfile={!isNil(profile)}
                     hasFeed={!isNil(feed)}
                   />
-                }
-              >
-                {LayoutFidget ? (
-                  <LayoutFidget
-                    layoutConfig={{ ...layoutConfig }}
-                    {...layoutFidgetProps}
-                  />
-                ) : (
-                  <div className="flex items-center justify-center h-full">
-                    <SpaceLoading
-                      hasProfile={!isNil(profile)}
-                      hasFeed={!isNil(feed)}
-                    />
-                  </div>
-                )}
-              </Suspense>
-            </div>
+                </div>
+              )}
+            </Suspense>
           </div>
         </div>
       </div>
+    </div>
+  );
+
+  return (
+    <div className="user-theme-background w-full h-full relative flex-col">
+      <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
+      {showPreviewFrame ? (
+        <div className="flex w-full justify-center">
+          <div className="w-[390px] h-[844px] overflow-hidden">{layoutContent}</div>
+        </div>
+      ) : (
+        layoutContent
+      )}
     </div>
   );
 }

--- a/src/common/lib/hooks/useIsMobile.ts
+++ b/src/common/lib/hooks/useIsMobile.ts
@@ -1,4 +1,5 @@
-import useWindowSize from './useWindowSize';
+import useWindowSize from "./useWindowSize";
+import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 
 // Mobile breakpoint (in pixels)
 export const MOBILE_BREAKPOINT = 768;
@@ -9,7 +10,8 @@ export const MOBILE_BREAKPOINT = 768;
  */
 export function useIsMobile(): boolean {
   const { width } = useWindowSize();
-  return width ? width < MOBILE_BREAKPOINT : false;
+  const { mobilePreview } = useMobilePreview();
+  return mobilePreview || (width ? width < MOBILE_BREAKPOINT : false);
 }
 
 export default useIsMobile;

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -51,6 +51,7 @@ import { CompleteFidgets } from "@/fidgets";
 import { DEFAULT_FIDGET_ICON_MAP } from "@/constants/mobileFidgetIcons";
 import MobileSettings from "@/common/components/organisms/MobileSettings";
 import { MiniApp } from "@/common/components/molecules/MiniAppSettings";
+import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 
 export type ThemeSettingsEditorArgs = {
   theme: ThemeSettings;
@@ -72,6 +73,12 @@ export function ThemeSettingsEditor({
   const [showConfirmCancel, setShowConfirmCancel] = useState(false);
   const [activeTheme, setActiveTheme] = useState(theme.id);
   const [tabValue, setTabValue] = useState("space");
+  const { setMobilePreview } = useMobilePreview();
+
+  useEffect(() => {
+    setMobilePreview(tabValue === "mobile");
+    return () => setMobilePreview(false);
+  }, [tabValue, setMobilePreview]);
 
   const miniApps = useMemo<MiniApp[]>(() => {
     return Object.values(fidgetInstanceDatums).map((d, i) => {

--- a/src/common/providers/MobilePreviewProvider.tsx
+++ b/src/common/providers/MobilePreviewProvider.tsx
@@ -1,0 +1,33 @@
+"use client";
+import React, { createContext, useContext, useState } from "react";
+
+interface MobilePreviewContextValue {
+  mobilePreview: boolean;
+  setMobilePreview: (value: boolean) => void;
+}
+
+const MobilePreviewContext = createContext<MobilePreviewContextValue | undefined>(
+  undefined,
+);
+
+export const MobilePreviewProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [mobilePreview, setMobilePreview] = useState(false);
+
+  return (
+    <MobilePreviewContext.Provider value={{ mobilePreview, setMobilePreview }}>
+      {children}
+    </MobilePreviewContext.Provider>
+  );
+};
+
+export const useMobilePreview = (): MobilePreviewContextValue => {
+  const context = useContext(MobilePreviewContext);
+  if (!context) {
+    throw new Error("useMobilePreview must be used within a MobilePreviewProvider");
+  }
+  return context;
+};
+
+export default MobilePreviewProvider;

--- a/src/common/providers/index.tsx
+++ b/src/common/providers/index.tsx
@@ -13,33 +13,36 @@ import VersionCheckProivder from "./VersionCheckProvider";
 import { SidebarContextProvider } from "@/common/components/organisms/Sidebar";
 import { ToastProvider } from "../components/atoms/Toast";
 import MiniAppSdkProvider from "./MiniAppSdkProvider";
+import MobilePreviewProvider from "./MobilePreviewProvider";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <VersionCheckProivder>
-      <Privy>
-        <Query>
-          <Wagmi>
-            <Theme>
-              <AppStoreProvider>
-                <UserThemeProvider>
-                  <AuthenticatorProvider>
-                    <LoggedInStateProvider>
-                      <SidebarContextProvider>
-                        <AnalyticsProvider>
-                          <MiniAppSdkProvider>
-                            <ToastProvider>{children}</ToastProvider>
-                          </MiniAppSdkProvider>
-                        </AnalyticsProvider>
-                      </SidebarContextProvider>
-                    </LoggedInStateProvider>
-                  </AuthenticatorProvider>
-                </UserThemeProvider>
-              </AppStoreProvider>
-            </Theme>
-          </Wagmi>
-        </Query>
-      </Privy>
-    </VersionCheckProivder>
+    <MobilePreviewProvider>
+      <VersionCheckProivder>
+        <Privy>
+          <Query>
+            <Wagmi>
+              <Theme>
+                <AppStoreProvider>
+                  <UserThemeProvider>
+                    <AuthenticatorProvider>
+                      <LoggedInStateProvider>
+                        <SidebarContextProvider>
+                          <AnalyticsProvider>
+                            <MiniAppSdkProvider>
+                              <ToastProvider>{children}</ToastProvider>
+                            </MiniAppSdkProvider>
+                          </AnalyticsProvider>
+                        </SidebarContextProvider>
+                      </LoggedInStateProvider>
+                    </AuthenticatorProvider>
+                  </UserThemeProvider>
+                </AppStoreProvider>
+              </Theme>
+            </Wagmi>
+          </Query>
+        </Privy>
+      </VersionCheckProivder>
+    </MobilePreviewProvider>
   );
 }


### PR DESCRIPTION
## Summary
- support toggling mobile preview in theme editor
- provide MobilePreviewProvider and integrate with other providers
- use provider inside useIsMobile hook
- adjust Space layout when mobile preview is active

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*