### PR TITLE
Add mobile preview mode to Theme Editor

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -17,6 +17,7 @@ import SpaceLoading from "./SpaceLoading";
 // Import the LayoutFidgets directly
 import { LayoutFidgets } from "@/fidgets";
 import { useIsMobile } from "@/common/lib/hooks/useIsMobile";
+import { useSidebarContext } from "@/common/components/organisms/Sidebar";
 import { PlacedGridItem } from "@/fidgets/layout/Grid";
 import { cleanupLayout } from '@/common/lib/utils/gridCleanup';
 
@@ -280,9 +281,14 @@ export default function Space({
     console.error("LayoutFidget is undefined");
   }
 
+  const { mobilePreview } = useSidebarContext();
+
   return (
     <div className="user-theme-background w-full h-full relative flex-col">
-      <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
+      <CustomHTMLBackground
+        html={config.theme?.properties.backgroundHTML}
+        className={mobilePreview ? "absolute inset-0 pointer-events-none" : undefined}
+      />
       <div className="w-full transition-all duration-100 ease-out">
         <div className="flex flex-col h-full">
           <div style={{ position: "fixed", zIndex: 9999 }}>

--- a/src/app/(spaces)/SpacePage.tsx
+++ b/src/app/(spaces)/SpacePage.tsx
@@ -21,24 +21,37 @@ export default function SpacePage({
   profile,
   feed,
 }: SpacePageArgs) {
-  const { editMode, setEditMode, setSidebarEditable, portalRef } =
-    useSidebarContext();
+  const {
+    editMode,
+    setEditMode,
+    setSidebarEditable,
+    portalRef,
+    mobilePreview,
+  } = useSidebarContext();
 
-  return (
-    <>
-      <Space
-        config={config}
-        saveConfig={saveConfig}
-        commitConfig={commitConfig}
-        resetConfig={resetConfig}
-        tabBar={tabBar}
-        profile={profile}
-        feed={feed}
-        setEditMode={setEditMode}
-        editMode={editMode}
-        setSidebarEditable={setSidebarEditable}
-        portalRef={portalRef}
-      />
-    </>
+  const spaceElement = (
+    <Space
+      config={config}
+      saveConfig={saveConfig}
+      commitConfig={commitConfig}
+      resetConfig={resetConfig}
+      tabBar={tabBar}
+      profile={profile}
+      feed={feed}
+      setEditMode={setEditMode}
+      editMode={editMode}
+      setSidebarEditable={setSidebarEditable}
+      portalRef={portalRef}
+    />
+  );
+
+  return mobilePreview ? (
+    <div className="flex items-center justify-center w-full h-full flex-1">
+      <div className="w-[390px] h-[844px] border overflow-hidden relative">
+        {spaceElement}
+      </div>
+    </div>
+  ) : (
+    <>{spaceElement}</>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -73,7 +73,7 @@ const sidebarLayout = (page: React.ReactNode) => {
     <>
       <div className="min-h-screen max-w-screen h-screen w-screen">
         <div className="flex w-full h-full">
-          <div className="mx-auto transition-all duration-100 ease-out z-10">
+          <div className="transition-all duration-100 ease-out z-10">
             <Sidebar />
           </div>
           {page}

--- a/src/common/components/organisms/Sidebar.tsx
+++ b/src/common/components/organisms/Sidebar.tsx
@@ -17,6 +17,8 @@ export type SidebarContextValue = {
   setEditMode: (value: boolean) => void;
   sidebarEditable: boolean;
   setSidebarEditable: (value: boolean) => void;
+  mobilePreview: boolean;
+  setMobilePreview: (value: boolean) => void;
   portalRef: React.RefObject<HTMLDivElement>;
 };
 
@@ -29,6 +31,7 @@ export const SidebarContextProvider: React.FC<SidebarContextProviderProps> = ({
 }) => {
   const [editMode, setEditMode] = useState(false);
   const [sidebarEditable, setSidebarEditable] = useState(false);
+  const [mobilePreview, setMobilePreview] = useState(false);
   const portalRef = useRef<HTMLDivElement>(null);
 
   const value = useMemo(
@@ -37,9 +40,11 @@ export const SidebarContextProvider: React.FC<SidebarContextProviderProps> = ({
       setEditMode,
       sidebarEditable,
       setSidebarEditable,
+      mobilePreview,
+      setMobilePreview,
       portalRef,
     }),
-    [editMode, sidebarEditable, portalRef],
+    [editMode, sidebarEditable, mobilePreview, portalRef],
   );
 
   return (
@@ -62,7 +67,7 @@ export const Sidebar: React.FC<SidebarProps> = () => {
   return (
     <>
       <div ref={portalRef} className={editMode ? "w-full" : ""}></div>
-      <div className={editMode ? "hidden" : "md:flex mx-auto h-full hidden"}>
+      <div className={editMode ? "hidden" : "md:flex h-full hidden"}>
         <Navigation
           isEditable={sidebarEditable}
           enterEditMode={enterEditMode}

--- a/src/common/lib/hooks/useIsMobile.ts
+++ b/src/common/lib/hooks/useIsMobile.ts
@@ -1,4 +1,5 @@
 import useWindowSize from './useWindowSize';
+import { useSidebarContext } from '@/common/components/organisms/Sidebar';
 
 // Mobile breakpoint (in pixels)
 export const MOBILE_BREAKPOINT = 768;
@@ -9,7 +10,8 @@ export const MOBILE_BREAKPOINT = 768;
  */
 export function useIsMobile(): boolean {
   const { width } = useWindowSize();
-  return width ? width < MOBILE_BREAKPOINT : false;
+  const { mobilePreview } = useSidebarContext();
+  return mobilePreview || (width ? width < MOBILE_BREAKPOINT : false);
 }
 
 export default useIsMobile;

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -51,6 +51,7 @@ import { CompleteFidgets } from "@/fidgets";
 import { DEFAULT_FIDGET_ICON_MAP } from "@/constants/mobileFidgetIcons";
 import MobileSettings from "@/common/components/organisms/MobileSettings";
 import { MiniApp } from "@/common/components/molecules/MiniAppSettings";
+import { useSidebarContext } from "@/common/components/organisms/Sidebar";
 
 export type ThemeSettingsEditorArgs = {
   theme: ThemeSettings;
@@ -72,6 +73,14 @@ export function ThemeSettingsEditor({
   const [showConfirmCancel, setShowConfirmCancel] = useState(false);
   const [activeTheme, setActiveTheme] = useState(theme.id);
   const [tabValue, setTabValue] = useState("space");
+  const { setMobilePreview } = useSidebarContext();
+
+  useEffect(() => {
+    setMobilePreview(tabValue === "mobile");
+  }, [tabValue, setMobilePreview]);
+
+  // Ensure preview is reset on unmount
+  useEffect(() => () => setMobilePreview(false), [setMobilePreview]);
 
   const miniApps = useMemo<MiniApp[]>(() => {
     return Object.values(fidgetInstanceDatums).map((d, i) => {


### PR DESCRIPTION
## Summary
- extend `SidebarContext` with `mobilePreview` state
- trigger mobile preview when mobile tab is active
- wrap spaces in a fixed-size container when previewing mobile
- keep nav left aligned and show mobile layout when previewing mobile

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*