### PR TITLE
Fix mobile preview alignment

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -281,8 +281,11 @@ export default function Space({
   }
 
   return (
-    <div className="user-theme-background w-full h-full relative flex-col">
-      <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
+    <div className="user-theme-background w-full h-full relative flex-col overflow-hidden">
+      <CustomHTMLBackground
+        html={config.theme?.properties.backgroundHTML}
+        className="absolute inset-0 pointer-events-none"
+      />
       <div className="w-full transition-all duration-100 ease-out">
         <div className="flex flex-col h-full">
           <div style={{ position: "fixed", zIndex: 9999 }}>

--- a/src/app/(spaces)/SpacePage.tsx
+++ b/src/app/(spaces)/SpacePage.tsx
@@ -52,7 +52,9 @@ export default function SpacePage({
       }
     >
       <div
-        className={mobilePreview ? "w-[390px] h-[844px] border" : "w-full h-full"}
+        className={
+          mobilePreview ? "w-[390px] h-[844px] border overflow-hidden" : "w-full h-full"
+        }
       >
         {spaceElement}
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -73,7 +73,7 @@ const sidebarLayout = (page: React.ReactNode) => {
     <>
       <div className="min-h-screen max-w-screen h-screen w-screen">
         <div className="flex w-full h-full">
-          <div className="mx-auto transition-all duration-100 ease-out z-10">
+          <div className="transition-all duration-100 ease-out z-10">
             <Sidebar />
           </div>
           {page}

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -203,7 +203,7 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
       <div className="pt-12 pb-12 h-full md:block hidden">
         <div
           className={mergeClasses(
-            "flex flex-col h-full ml-auto transition-all duration-300 relative",
+            "flex flex-col h-full transition-all duration-300 relative",
             shrunk ? "w-[90px]" : "w-[270px]"
           )}
         >

--- a/src/common/components/organisms/NavigationSkeleton.tsx
+++ b/src/common/components/organisms/NavigationSkeleton.tsx
@@ -9,7 +9,7 @@ const NavigationSkeleton: React.FC = () => {
       aria-label="Sidebar Skeleton"
     >
       <div className="pt-12 pb-12 h-full md:block hidden">
-        <div className="flex flex-col h-full w-[270px] ml-auto">
+        <div className="flex flex-col h-full w-[270px]">
           <div className="flex flex-col text-lg font-medium pb-3 px-4 overflow-auto">
             <div className="flex-auto">
               <ul className="space-y-2">

--- a/src/common/components/organisms/Sidebar.tsx
+++ b/src/common/components/organisms/Sidebar.tsx
@@ -67,7 +67,7 @@ export const Sidebar: React.FC<SidebarProps> = () => {
   return (
     <>
       <div ref={portalRef} className={editMode ? "w-full" : ""}></div>
-      <div className={editMode ? "hidden" : "md:flex mx-auto h-full hidden"}>
+      <div className={editMode ? "hidden" : "md:flex h-full hidden"}>
         <Navigation
           isEditable={sidebarEditable}
           enterEditMode={enterEditMode}

--- a/src/common/lib/hooks/useIsMobile.ts
+++ b/src/common/lib/hooks/useIsMobile.ts
@@ -1,4 +1,5 @@
 import useWindowSize from './useWindowSize';
+import { useSidebarContext } from '@/common/components/organisms/Sidebar';
 
 // Mobile breakpoint (in pixels)
 export const MOBILE_BREAKPOINT = 768;
@@ -9,7 +10,8 @@ export const MOBILE_BREAKPOINT = 768;
  */
 export function useIsMobile(): boolean {
   const { width } = useWindowSize();
-  return width ? width < MOBILE_BREAKPOINT : false;
+  const { mobilePreview } = useSidebarContext();
+  return mobilePreview || (width ? width < MOBILE_BREAKPOINT : false);
 }
 
 export default useIsMobile;


### PR DESCRIPTION
## Summary
- align sidebar to the left
- display mobile layout when editing mobile preview
- contain mobile preview background

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*