### PR TITLE
Fix mobile theme preview alignment

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -58,6 +58,7 @@ type SpaceArgs = {
   editMode: boolean;
   setSidebarEditable: (v: boolean) => void;
   portalRef: React.RefObject<HTMLDivElement>;
+  mobilePreview?: boolean;
 };
 
 export default function Space({
@@ -72,6 +73,7 @@ export default function Space({
   editMode,
   setSidebarEditable,
   portalRef,
+  mobilePreview = false,
 }: SpaceArgs) {
   // Use the useIsMobile hook instead of duplicating logic
   const isMobile = useIsMobile();
@@ -282,7 +284,14 @@ export default function Space({
 
   return (
     <div className="user-theme-background w-full h-full relative flex-col">
-      <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
+      <CustomHTMLBackground
+        html={config.theme?.properties.backgroundHTML}
+        className={
+          mobilePreview
+            ? "absolute inset-0 pointer-events-none"
+            : "fixed size-full pointer-events-none"
+        }
+      />
       <div className="w-full transition-all duration-100 ease-out">
         <div className="flex flex-col h-full">
           <div style={{ position: "fixed", zIndex: 9999 }}>

--- a/src/app/(spaces)/SpacePage.tsx
+++ b/src/app/(spaces)/SpacePage.tsx
@@ -42,6 +42,7 @@ export default function SpacePage({
       editMode={editMode}
       setSidebarEditable={setSidebarEditable}
       portalRef={portalRef}
+      mobilePreview={mobilePreview}
     />
   );
 
@@ -52,7 +53,11 @@ export default function SpacePage({
       }
     >
       <div
-        className={mobilePreview ? "w-[390px] h-[844px] border" : "w-full h-full"}
+        className={
+          mobilePreview
+            ? "relative w-[390px] h-[844px] border overflow-hidden"
+            : "w-full h-full"
+        }
       >
         {spaceElement}
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -73,7 +73,7 @@ const sidebarLayout = (page: React.ReactNode) => {
     <>
       <div className="min-h-screen max-w-screen h-screen w-screen">
         <div className="flex w-full h-full">
-          <div className="mx-auto transition-all duration-100 ease-out z-10">
+          <div className="transition-all duration-100 ease-out z-10">
             <Sidebar />
           </div>
           {page}

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -203,7 +203,7 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
       <div className="pt-12 pb-12 h-full md:block hidden">
         <div
           className={mergeClasses(
-            "flex flex-col h-full ml-auto transition-all duration-300 relative",
+            "flex flex-col h-full transition-all duration-300 relative",
             shrunk ? "w-[90px]" : "w-[270px]"
           )}
         >

--- a/src/common/lib/hooks/useIsMobile.ts
+++ b/src/common/lib/hooks/useIsMobile.ts
@@ -1,4 +1,5 @@
 import useWindowSize from './useWindowSize';
+import { useSidebarContext } from '@/common/components/organisms/Sidebar';
 
 // Mobile breakpoint (in pixels)
 export const MOBILE_BREAKPOINT = 768;
@@ -8,8 +9,9 @@ export const MOBILE_BREAKPOINT = 768;
  * @returns boolean indicating if the viewport is mobile-sized
  */
 export function useIsMobile(): boolean {
+  const { mobilePreview } = useSidebarContext();
   const { width } = useWindowSize();
-  return width ? width < MOBILE_BREAKPOINT : false;
+  return mobilePreview || (width ? width < MOBILE_BREAKPOINT : false);
 }
 
 export default useIsMobile;


### PR DESCRIPTION
## Summary
- ensure sidebar sits left by removing centering styles
- align navigation container to the left
- treat mobile preview as mobile in `useIsMobile`
- contain background and render mobile layout in preview

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*
- `npm run test` *(fails: vitest not found)*