### PR TITLE
Fix sidebar layout and mobile preview crash

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -58,6 +58,7 @@ type SpaceArgs = {
   editMode: boolean;
   setSidebarEditable: (v: boolean) => void;
   portalRef: React.RefObject<HTMLDivElement>;
+  mobilePreview?: boolean;
 };
 
 export default function Space({
@@ -72,9 +73,10 @@ export default function Space({
   editMode,
   setSidebarEditable,
   portalRef,
+  mobilePreview = false,
 }: SpaceArgs) {
-  // Use the useIsMobile hook instead of duplicating logic
-  const isMobile = useIsMobile();
+  // Use the useIsMobile hook with override for mobile preview
+  const isMobile = mobilePreview || useIsMobile();
 
   useEffect(() => {
     setSidebarEditable(config.isEditable);
@@ -282,7 +284,14 @@ export default function Space({
 
   return (
     <div className="user-theme-background w-full h-full relative flex-col">
-      <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
+      <CustomHTMLBackground
+        html={config.theme?.properties.backgroundHTML}
+        className={
+          mobilePreview
+            ? "absolute inset-0 pointer-events-none"
+            : "fixed size-full pointer-events-none"
+        }
+      />
       <div className="w-full transition-all duration-100 ease-out">
         <div className="flex flex-col h-full">
           <div style={{ position: "fixed", zIndex: 9999 }}>

--- a/src/app/(spaces)/SpacePage.tsx
+++ b/src/app/(spaces)/SpacePage.tsx
@@ -42,17 +42,22 @@ export default function SpacePage({
       editMode={editMode}
       setSidebarEditable={setSidebarEditable}
       portalRef={portalRef}
+      mobilePreview={mobilePreview}
     />
   );
 
   return (
     <div
       className={
-        mobilePreview ? "flex items-center justify-center w-full h-full" : ""
+        mobilePreview ? "flex items-center justify-center w-full h-full" : "w-full h-full"
       }
     >
       <div
-        className={mobilePreview ? "w-[390px] h-[844px] border" : "w-full h-full"}
+        className={
+          mobilePreview
+            ? "relative w-[390px] h-[844px] border overflow-hidden"
+            : "w-full h-full"
+        }
       >
         {spaceElement}
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -73,10 +73,12 @@ const sidebarLayout = (page: React.ReactNode) => {
     <>
       <div className="min-h-screen max-w-screen h-screen w-screen">
         <div className="flex w-full h-full">
-          <div className="mx-auto transition-all duration-100 ease-out z-10">
+          <div className="shrink-0 transition-all duration-100 ease-out z-10">
             <Sidebar />
           </div>
-          {page}
+          <div className="flex-1">
+            {page}
+          </div>
         </div>
       </div>
     </>

--- a/src/common/components/organisms/MobileSettings.tsx
+++ b/src/common/components/organisms/MobileSettings.tsx
@@ -43,6 +43,10 @@ export function MobileSettings({
   const [items, setItems] = useState<MiniApp[]>([])
 
   useEffect(() => {
+    if (!miniApps) {
+      setItems([])
+      return
+    }
     const sorted = [...miniApps].sort((a, b) => a.order - b.order)
     setItems(sorted)
   }, [miniApps])

--- a/src/common/components/organisms/Sidebar.tsx
+++ b/src/common/components/organisms/Sidebar.tsx
@@ -67,7 +67,7 @@ export const Sidebar: React.FC<SidebarProps> = () => {
   return (
     <>
       <div ref={portalRef} className={editMode ? "w-full" : ""}></div>
-      <div className={editMode ? "hidden" : "md:flex mx-auto h-full hidden"}>
+      <div className={editMode ? "hidden" : "md:flex h-full hidden"}>
         <Navigation
           isEditable={sidebarEditable}
           enterEditMode={enterEditMode}


### PR DESCRIPTION
## Summary
- expand content area next to sidebar
- guard against undefined mini-app lists
- ensure SpacePage container fills width

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*