### PR TITLE
Enable mobile preview

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -17,6 +17,9 @@ import SpaceLoading from "./SpaceLoading";
 // Import the LayoutFidgets directly
 import { LayoutFidgets } from "@/fidgets";
 import { useIsMobile } from "@/common/lib/hooks/useIsMobile";
+import { MOBILE_BREAKPOINT } from "@/common/lib/hooks/useIsMobile";
+import useWindowSize from "@/common/lib/hooks/useWindowSize";
+import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 import { PlacedGridItem } from "@/fidgets/layout/Grid";
 import { cleanupLayout } from '@/common/lib/utils/gridCleanup';
 
@@ -74,7 +77,11 @@ export default function Space({
   portalRef,
 }: SpaceArgs) {
   // Use the useIsMobile hook instead of duplicating logic
+  const { mobilePreview } = useMobilePreview();
+  const { width } = useWindowSize();
   const isMobile = useIsMobile();
+  const isScreenMobile = width ? width < MOBILE_BREAKPOINT : false;
+  const showMobileContainer = mobilePreview && !isScreenMobile;
 
   useEffect(() => {
     setSidebarEditable(config.isEditable);
@@ -243,6 +250,7 @@ export default function Space({
     }
   }, [
     isMobile,
+    isScreenMobile,
     config?.layoutDetails?.layoutConfig,
     config?.fidgetInstanceDatums,
   ]);
@@ -253,7 +261,7 @@ export default function Space({
       theme: config.theme,
       fidgetInstanceDatums: config.fidgetInstanceDatums,
       fidgetTrayContents: config.fidgetTrayContents,
-      inEditMode: !isMobile && editMode, // No edit mode on mobile
+      inEditMode: !isScreenMobile && editMode, // No edit mode on actual mobile
       saveExitEditMode: saveExitEditMode,
       cancelExitEditMode: cancelExitEditMode,
       portalRef: portalRef,
@@ -280,63 +288,72 @@ export default function Space({
     console.error("LayoutFidget is undefined");
   }
 
+  const mainContent = (
+    <div className="flex flex-col h-full">
+      <div style={{ position: "fixed", zIndex: 9999 }}>
+        <InfoToast />
+      </div>
+      {!isUndefined(profile) ? (
+        <div className="z-50 bg-white md:h-40">{profile}</div>
+      ) : null}
+
+      <div className="relative">
+        <Suspense fallback={<TabBarSkeleton />}>{tabBar}</Suspense>
+        {isMobile && (
+          <div
+            className="absolute right-0 top-0 bottom-0 w-12 pointer-events-none opacity-90 z-50"
+            style={{
+              background:
+                "linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.9) 50%, rgba(255, 255, 255, 1) 100%)",
+            }}
+          />
+        )}
+      </div>
+
+      <div className={isMobile ? "w-full h-full" : "flex h-full"}>
+        {!isUndefined(feed) && !isMobile ? (
+          <div className="w-6/12 h-[calc(100vh-64px)]">{feed}</div>
+        ) : null}
+
+        <div className={isMobile ? "w-full h-full" : "grow"}>
+          <Suspense
+            fallback={
+              <SpaceLoading
+                hasProfile={!isNil(profile)}
+                hasFeed={!isNil(feed)}
+              />
+            }
+          >
+            {LayoutFidget ? (
+              <LayoutFidget
+                layoutConfig={{ ...layoutConfig }}
+                {...layoutFidgetProps}
+              />
+            ) : (
+              <div className="flex items-center justify-center h-full">
+                <SpaceLoading
+                  hasProfile={!isNil(profile)}
+                  hasFeed={!isNil(feed)}
+                />
+              </div>
+            )}
+          </Suspense>
+        </div>
+      </div>
+    </div>
+  );
+
   return (
     <div className="user-theme-background w-full h-full relative flex-col">
       <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
       <div className="w-full transition-all duration-100 ease-out">
-        <div className="flex flex-col h-full">
-          <div style={{ position: "fixed", zIndex: 9999 }}>
-            <InfoToast />
+        {showMobileContainer ? (
+          <div className="flex justify-center">
+            <div className="w-[390px] h-[844px] relative">{mainContent}</div>
           </div>
-          {!isUndefined(profile) ? (
-            <div className="z-50 bg-white md:h-40">{profile}</div>
-          ) : null}
-
-          <div className="relative">
-            <Suspense fallback={<TabBarSkeleton />}>{tabBar}</Suspense>
-            {/* Gradient overlay for tabs on mobile */}
-            {isMobile && (
-              <div
-                className="absolute right-0 top-0 bottom-0 w-12 pointer-events-none opacity-90 z-50"
-                style={{
-                  background:
-                    "linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.9) 50%, rgba(255, 255, 255, 1) 100%)",
-                }}
-              />
-            )}
-          </div>
-
-          <div className={isMobile ? "w-full h-full" : "flex h-full"}>
-            {!isUndefined(feed) && !isMobile ? (
-              <div className="w-6/12 h-[calc(100vh-64px)]">{feed}</div>
-            ) : null}
-
-            <div className={isMobile ? "w-full h-full" : "grow"}>
-              <Suspense
-                fallback={
-                  <SpaceLoading
-                    hasProfile={!isNil(profile)}
-                    hasFeed={!isNil(feed)}
-                  />
-                }
-              >
-                {LayoutFidget ? (
-                  <LayoutFidget
-                    layoutConfig={{ ...layoutConfig }}
-                    {...layoutFidgetProps}
-                  />
-                ) : (
-                  <div className="flex items-center justify-center h-full">
-                    <SpaceLoading
-                      hasProfile={!isNil(profile)}
-                      hasFeed={!isNil(feed)}
-                    />
-                  </div>
-                )}
-              </Suspense>
-            </div>
-          </div>
-        </div>
+        ) : (
+          mainContent
+        )}
       </div>
     </div>
   );

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -12,6 +12,7 @@ import TokenDataHeader from "./TokenDataHeader";
 import ProposalDataHeader from "./ProposalDataHeader";
 import ClaimButtonWithModal from "../molecules/ClaimButtonWithModal";
 import useIsMobile from "@/common/lib/hooks/useIsMobile";
+import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 import { SpacePageType } from "@/app/(spaces)/PublicSpace";
 
 interface TabBarProps {
@@ -63,6 +64,7 @@ function TabBar({
   pageType
 }: TabBarProps) {
   const isMobile = useIsMobile();
+  const { mobilePreview } = useMobilePreview();
 
   const { getIsLoggedIn, getIsInitializing } = useAppStore((state) => ({
     setModalOpen: state.setup.setModalOpen,
@@ -239,7 +241,7 @@ function TabBar({
         {isTokenPage && !getIsInitializing() && !isLoggedIn && !isMobile && (
           <ClaimButtonWithModal contractAddress={contractAddress} />
         )}
-        {inEditMode ? (
+        {inEditMode && !mobilePreview ? (
           <div className="mr-36 flex flex-row z-infinity">
             <NogsGateButton
               onClick={() => handleCreateTab(generateNewTabName())}

--- a/src/common/lib/hooks/useIsMobile.ts
+++ b/src/common/lib/hooks/useIsMobile.ts
@@ -1,4 +1,5 @@
 import useWindowSize from './useWindowSize';
+import { useMobilePreview } from '@/common/providers/MobilePreviewProvider';
 
 // Mobile breakpoint (in pixels)
 export const MOBILE_BREAKPOINT = 768;
@@ -9,7 +10,8 @@ export const MOBILE_BREAKPOINT = 768;
  */
 export function useIsMobile(): boolean {
   const { width } = useWindowSize();
-  return width ? width < MOBILE_BREAKPOINT : false;
+  const { mobilePreview } = useMobilePreview();
+  return mobilePreview || (width ? width < MOBILE_BREAKPOINT : false);
 }
 
 export default useIsMobile;

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -51,6 +51,7 @@ import { CompleteFidgets } from "@/fidgets";
 import { DEFAULT_FIDGET_ICON_MAP } from "@/constants/mobileFidgetIcons";
 import MobileSettings from "@/common/components/organisms/MobileSettings";
 import { MiniApp } from "@/common/components/molecules/MiniAppSettings";
+import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 
 export type ThemeSettingsEditorArgs = {
   theme: ThemeSettings;
@@ -72,6 +73,11 @@ export function ThemeSettingsEditor({
   const [showConfirmCancel, setShowConfirmCancel] = useState(false);
   const [activeTheme, setActiveTheme] = useState(theme.id);
   const [tabValue, setTabValue] = useState("space");
+  const { setMobilePreview } = useMobilePreview();
+
+  useEffect(() => {
+    setMobilePreview(tabValue === "mobile");
+  }, [tabValue, setMobilePreview]);
 
   const miniApps = useMemo<MiniApp[]>(() => {
     return Object.values(fidgetInstanceDatums).map((d, i) => {

--- a/src/common/providers/MobilePreviewProvider.tsx
+++ b/src/common/providers/MobilePreviewProvider.tsx
@@ -1,0 +1,35 @@
+"use client";
+import React, { createContext, useContext, useMemo, useState } from "react";
+
+export interface MobilePreviewContextValue {
+  mobilePreview: boolean;
+  setMobilePreview: (value: boolean) => void;
+}
+
+const MobilePreviewContext = createContext<MobilePreviewContextValue>({
+  mobilePreview: false,
+  setMobilePreview: () => {},
+});
+
+export const MobilePreviewProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [mobilePreview, setMobilePreview] = useState(false);
+
+  const value = useMemo(
+    () => ({ mobilePreview, setMobilePreview }),
+    [mobilePreview],
+  );
+
+  return (
+    <MobilePreviewContext.Provider value={value}>
+      {children}
+    </MobilePreviewContext.Provider>
+  );
+};
+
+export const useMobilePreview = (): MobilePreviewContextValue => {
+  return useContext(MobilePreviewContext);
+};
+
+export default MobilePreviewProvider;

--- a/src/common/providers/index.tsx
+++ b/src/common/providers/index.tsx
@@ -13,6 +13,7 @@ import VersionCheckProivder from "./VersionCheckProvider";
 import { SidebarContextProvider } from "@/common/components/organisms/Sidebar";
 import { ToastProvider } from "../components/atoms/Toast";
 import MiniAppSdkProvider from "./MiniAppSdkProvider";
+import MobilePreviewProvider from "./MobilePreviewProvider";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
@@ -26,11 +27,13 @@ export default function Providers({ children }: { children: React.ReactNode }) {
                   <AuthenticatorProvider>
                     <LoggedInStateProvider>
                       <SidebarContextProvider>
-                        <AnalyticsProvider>
-                          <MiniAppSdkProvider>
-                            <ToastProvider>{children}</ToastProvider>
-                          </MiniAppSdkProvider>
-                        </AnalyticsProvider>
+                        <MobilePreviewProvider>
+                          <AnalyticsProvider>
+                            <MiniAppSdkProvider>
+                              <ToastProvider>{children}</ToastProvider>
+                            </MiniAppSdkProvider>
+                          </AnalyticsProvider>
+                        </MobilePreviewProvider>
                       </SidebarContextProvider>
                     </LoggedInStateProvider>
                   </AuthenticatorProvider>

--- a/src/fidgets/layout/tabFullScreen/index.tsx
+++ b/src/fidgets/layout/tabFullScreen/index.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useMemo, useEffect } from "react";
 import { TabsContent, Tabs } from "@/common/components/atoms/tabs";
 import { MOBILE_PADDING, TAB_HEIGHT } from "@/constants/layout";
-import useIsMobile from "@/common/lib/hooks/useIsMobile";
+import useIsMobile, { MOBILE_BREAKPOINT } from "@/common/lib/hooks/useIsMobile";
+import useWindowSize from "@/common/lib/hooks/useWindowSize";
+import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 import { usePathname } from "next/navigation";
 import { 
   FidgetBundle, 
@@ -44,6 +46,9 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
   tabNames,
 }) => {
   const isMobile = useIsMobile();
+  const { mobilePreview } = useMobilePreview();
+  const { width } = useWindowSize();
+  const showMobileContainer = mobilePreview && (width ? width >= MOBILE_BREAKPOINT : false);
   const pathname = usePathname();
   const isHomebasePath = pathname?.startsWith('/homebase');
   const isHomePath = pathname?.startsWith('/home');
@@ -255,8 +260,8 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
           
           {/* Tabs fixed to bottom of screen */}
           {processedFidgetIds.length > 1 && (
-            <div 
-              className="fixed bottom-0 left-0 right-0 z-50 bg-white"
+            <div
+              className={`${showMobileContainer ? 'absolute' : 'fixed'} bottom-0 left-0 right-0 z-50 bg-white`}
               style={{ height: `${TAB_HEIGHT}px` }}
             >
               <TabNavigation 


### PR DESCRIPTION
## Summary
- add MobilePreviewProvider context
- extend `useIsMobile` to include preview state
- toggle preview from `ThemeSettingsEditor`
- show mobile container in `Space`
- wrap entire app with the provider
- keep editor panel visible during mobile preview
- constrain bottom nav within preview container
- hide Add Tab button in preview

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*