### PR TITLE
Remove debug logging and delays to increase performance

### DIFF
--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -501,7 +501,8 @@ const BackgroundGenerator = ({
       ? randomPrompts[Math.floor(Math.random() * randomPrompts.length)]
       : internalBackgroundHTML;
 
-    console.log(`inputText: ${inputText}`);
+    if (process.env.NODE_ENV !== "production")
+      console.log(`inputText: ${inputText}`);
       
     handleGenerateBackground(inputText);
   };

--- a/src/common/lib/utils/gridCleanup.ts
+++ b/src/common/lib/utils/gridCleanup.ts
@@ -20,38 +20,47 @@ export function cleanupLayout(
     h: number,
     excludeId?: string
   ): boolean => {
-    console.log(`\n[isSpaceAvailable] Checking position (${x},${y},${w},${h})`);
+    if (process.env.NODE_ENV !== "production")
+      console.log(`\n[isSpaceAvailable] Checking position (${x},${y},${w},${h})`);
     for (const item of cleanedLayout) {
       if (item.i === excludeId) {
-        console.log(`[isSpaceAvailable] Skipping self-check for ${item.i}`);
+        if (process.env.NODE_ENV !== "production")
+          console.log(`[isSpaceAvailable] Skipping self-check for ${item.i}`);
         continue;
       }
       
-      console.log(`[isSpaceAvailable] Comparing with ${item.i} at (${item.x},${item.y},${item.w},${item.h})`);
+      if (process.env.NODE_ENV !== "production")
+        console.log(`[isSpaceAvailable] Comparing with ${item.i} at (${item.x},${item.y},${item.w},${item.h})`);
       
       // Check if rectangles overlap
       const horizontalOverlap = !(x + w <= item.x || x >= item.x + item.w);
       const verticalOverlap = !(y + h <= item.y || y >= item.y + item.h);
       
-      console.log(`[isSpaceAvailable] Horizontal overlap: ${horizontalOverlap}`);
-      console.log(`[isSpaceAvailable] Vertical overlap: ${verticalOverlap}`);
+      if (process.env.NODE_ENV !== "production") {
+        console.log(`[isSpaceAvailable] Horizontal overlap: ${horizontalOverlap}`);
+        console.log(`[isSpaceAvailable] Vertical overlap: ${verticalOverlap}`);
+      }
       
       if (horizontalOverlap && verticalOverlap) {
-        console.log(`[isSpaceAvailable] Found overlap between (${x},${y},${w},${h}) and (${item.x},${item.y},${item.w},${item.h})`);
+        if (process.env.NODE_ENV !== "production")
+          console.log(`[isSpaceAvailable] Found overlap between (${x},${y},${w},${h}) and (${item.x},${item.y},${item.w},${item.h})`);
         return false;
       }
     }
-    console.log(`[isSpaceAvailable] Position (${x},${y},${w},${h}) is available`);
+    if (process.env.NODE_ENV !== "production")
+      console.log(`[isSpaceAvailable] Position (${x},${y},${w},${h}) is available`);
     return true;
   };
 
   // Process each fidget in the layout
   for (const item of layout) {
-    console.log(`\n[cleanupLayout] Processing fidget ${item.i} at (${item.x}, ${item.y})`);
+    if (process.env.NODE_ENV !== "production")
+      console.log(`\n[cleanupLayout] Processing fidget ${item.i} at (${item.x}, ${item.y})`);
     
     // First check if current position is valid
     if (isSpaceAvailable(item.x, item.y, item.w, item.h, item.i)) {
-      console.log(`[cleanupLayout] Keeping fidget ${item.i} at (${item.x}, ${item.y})`);
+      if (process.env.NODE_ENV !== "production")
+        console.log(`[cleanupLayout] Keeping fidget ${item.i} at (${item.x}, ${item.y})`);
       cleanedLayout.push(item);
       continue;
     }
@@ -61,7 +70,8 @@ export function cleanupLayout(
     for (let x = 0; x <= cols - item.w; x++) {
       for (let y = 0; y <= maxRows - item.h; y++) {
         if (isSpaceAvailable(x, y, item.w, item.h, item.i)) {
-          console.log(`[cleanupLayout] Moving fidget ${item.i} from (${item.x}, ${item.y}) to (${x}, ${y})`);
+          if (process.env.NODE_ENV !== "production")
+            console.log(`[cleanupLayout] Moving fidget ${item.i} from (${item.x}, ${item.y}) to (${x}, ${y})`);
           cleanedLayout.push({
             ...item,
             x,
@@ -76,7 +86,8 @@ export function cleanupLayout(
 
     // If no valid position found, mark for removal
     if (!found) {
-      console.log(`[cleanupLayout] Removing fidget ${item.i} - no valid position found`);
+      if (process.env.NODE_ENV !== "production")
+        console.log(`[cleanupLayout] Removing fidget ${item.i} - no valid position found`);
       removedFidgetIds.push(item.i);
     }
   }

--- a/src/fidgets/farcaster/utils.ts
+++ b/src/fidgets/farcaster/utils.ts
@@ -350,7 +350,6 @@ export const updateUsernameOffchain = async ({
     };
 
     const res = await axios.post(FARCASTER_FNAME_ENDPOINT, payload);
-    await new Promise((resolve) => setTimeout(resolve, 5000));
 
     return res.data;
   } catch (e: any) {

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -4,7 +4,6 @@ import React, {
   useMemo,
   useState,
   useCallback,
-  useRef,
 } from "react";
 import useWindowSize from "@/common/lib/hooks/useWindowSize";
 import RGL, { WidthProvider } from "react-grid-layout";
@@ -472,15 +471,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     );
   }
 
-  const [itemsVisible, setItemsVisible] = useState(false);
-  const initialRenderRef = useRef(true);
-
-  useEffect(() => {
-    if (initialRenderRef.current) {
-      initialRenderRef.current = false;
-      setTimeout(() => setItemsVisible(true), 100);
-    }
-  }, []);
+  const [itemsVisible] = useState(true);
 
   // Log initial config state
   useEffect(() => {

--- a/src/pages/api/farcaster/neynar/feed.ts
+++ b/src/pages/api/farcaster/neynar/feed.ts
@@ -19,7 +19,7 @@ async function loadCasts(req: NextApiRequest, res: NextApiResponse) {
     if (!fid || fid === "-1") {
       return res.status(400).json({ error: "Invalid or missing FID for 'For you' feed. Please log in to access this feature." });
     }
-    console.log("[Neynar for_you] params:", { fid, cursor, limit }); options = {
+    options = {
       method: "GET",
       url,
       headers: {


### PR DESCRIPTION
## Summary
- trim verbose logging in `gridCleanup`
- show grid items immediately instead of after a timeout
- drop 5s wait from Farcaster username update
- remove Neynar feed console log
- gate a ThemeSettingsEditor log

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*