### PR TITLE
Fix mobile preview panel visibility and styling

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { ReactNode, useEffect, useMemo, Suspense } from "react";
+import { createPortal } from "react-dom";
 import {
   FidgetConfig,
   FidgetInstanceData,
@@ -10,6 +11,7 @@ import {
 } from "@/common/fidgets";
 import { UserTheme } from "@/common/lib/theme";
 import CustomHTMLBackground from "@/common/components/molecules/CustomHTMLBackground";
+import ThemeSettingsEditor from "@/common/lib/theme/ThemeSettingsEditor";
 import { isNil, isUndefined } from "lodash";
 import InfoToast from "@/common/components/organisms/InfoBanner";
 import TabBarSkeleton from "@/common/components/organisms/TabBarSkeleton";
@@ -341,22 +343,56 @@ export default function Space({
   );
 
   return (
-    <div className="user-theme-background w-full h-full relative flex-col">
-      <div className="w-full transition-all duration-100 ease-out">
-        {showMobileContainer ? (
-          <div className="flex justify-center">
-            <div className="w-[390px] h-[844px] relative overflow-hidden">
+    <>
+      {showMobileContainer && editMode && portalRef.current
+        ? createPortal(
+            <aside
+              id="logo-sidebar"
+              className="h-screen flex-row flex bg-white"
+              aria-label="Sidebar"
+            >
+              <div className="flex-1 w-[270px] h-full max-h-screen pt-12 flex-col flex px-4 py-4 overflow-y-auto border-r">
+                <ThemeSettingsEditor
+                  theme={config.theme}
+                  saveTheme={(newTheme) =>
+                    saveLocalConfig({ theme: newTheme })
+                  }
+                  saveExitEditMode={saveExitEditMode}
+                  cancelExitEditMode={cancelExitEditMode}
+                  fidgetInstanceDatums={config.fidgetInstanceDatums}
+                  saveFidgetInstanceDatums={(datums) =>
+                    saveLocalConfig({ fidgetInstanceDatums: datums })
+                  }
+                />
+              </div>
+            </aside>,
+            portalRef.current,
+          )
+        : null}
+      <div
+        className={`w-full h-full relative flex-col ${
+          showMobileContainer ? "" : "user-theme-background"
+        }`}
+      >
+        <div className="w-full transition-all duration-100 ease-out">
+          {showMobileContainer ? (
+            <div className="flex justify-center">
+              <div className="user-theme-background w-[390px] h-[844px] relative overflow-hidden">
+                <CustomHTMLBackground
+                  html={config.theme?.properties.backgroundHTML}
+                  className="absolute inset-0 pointer-events-none"
+                />
+                {mainContent}
+              </div>
+            </div>
+          ) : (
+            <>
               <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
               {mainContent}
-            </div>
-          </div>
-        ) : (
-          <>
-            <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
-            {mainContent}
-          </>
-        )}
+            </>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -72,8 +72,10 @@ export function ThemeSettingsEditor({
 }: ThemeSettingsEditorArgs) {
   const [showConfirmCancel, setShowConfirmCancel] = useState(false);
   const [activeTheme, setActiveTheme] = useState(theme.id);
-  const [tabValue, setTabValue] = useState("space");
-  const { setMobilePreview } = useMobilePreview();
+  const { mobilePreview, setMobilePreview } = useMobilePreview();
+  const [tabValue, setTabValue] = useState(
+    mobilePreview ? "mobile" : "space",
+  );
 
   useEffect(() => {
     setMobilePreview(tabValue === "mobile");

--- a/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
+++ b/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
@@ -209,7 +209,7 @@ const TabNavigation: React.FC<TabNavigationProps> = ({
   };
 
   return (
-    <div className="relative w-full h-full">
+    <div className="relative w-full h-full min-h-[72px]">
       <TabsList 
         ref={tabsListRef}
         className={`


### PR DESCRIPTION
## Summary
- keep theme editor panel visible when previewing mobile layout
- contain custom backgrounds within the mobile preview
- stabilize mobile tab navigation height
- preserve active mobile preview when editor is portaled

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*