### PR TITLE
Display a preview of a user's space on mobile when the Mobile tab of the Theme Editor Panel is open

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -22,6 +22,7 @@ import { useIsMobile } from "@/common/lib/hooks/useIsMobile";
 import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 import { PlacedGridItem } from "@/fidgets/layout/Grid";
 import { cleanupLayout } from '@/common/lib/utils/gridCleanup';
+import { TAB_HEIGHT } from "@/constants/layout";
 
 export type SpaceFidgetConfig = {
   instanceConfig: FidgetConfig<FidgetSettings>;
@@ -377,7 +378,10 @@ export default function Space({
         <div className="w-full transition-all duration-100 ease-out">
           {showMobileContainer ? (
             <div className="flex justify-center">
-              <div className="user-theme-background w-[390px] h-[844px] relative overflow-hidden">
+              <div
+                className="user-theme-background w-[390px] h-[844px] relative overflow-auto"
+                style={{ paddingBottom: `${TAB_HEIGHT}px` }}
+              >
                 <CustomHTMLBackground
                   html={config.theme?.properties.backgroundHTML}
                   className="absolute inset-0 pointer-events-none"

--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -79,7 +79,7 @@ export default function Space({
 }: SpaceArgs) {
   // Use the useIsMobile hook instead of duplicating logic
   const viewportMobile = useIsMobile();
-  const { mobilePreview } = useMobilePreview();
+  const { mobilePreview, setMobilePreview } = useMobilePreview();
   const isMobile = viewportMobile || mobilePreview;
   const showMobileContainer = mobilePreview && !viewportMobile;
 
@@ -188,11 +188,13 @@ export default function Space({
   function saveExitEditMode() {
     commitConfig();
     setEditMode(false);
+    setMobilePreview(false);
   }
 
   function cancelExitEditMode() {
     resetConfig();
     setEditMode(false);
+    setMobilePreview(false);
   }
 
   async function saveLocalConfig({

--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { ReactNode, useEffect, useMemo, Suspense } from "react";
+import { createPortal } from "react-dom";
 import {
   FidgetConfig,
   FidgetInstanceData,
@@ -10,6 +11,7 @@ import {
 } from "@/common/fidgets";
 import { UserTheme } from "@/common/lib/theme";
 import CustomHTMLBackground from "@/common/components/molecules/CustomHTMLBackground";
+import ThemeSettingsEditor from "@/common/lib/theme/ThemeSettingsEditor";
 import { isNil, isUndefined } from "lodash";
 import InfoToast from "@/common/components/organisms/InfoBanner";
 import TabBarSkeleton from "@/common/components/organisms/TabBarSkeleton";
@@ -341,22 +343,56 @@ export default function Space({
   );
 
   return (
-    <div className="user-theme-background w-full h-full relative flex-col">
-      <div className="w-full transition-all duration-100 ease-out">
-        {showMobileContainer ? (
-          <div className="flex justify-center">
-            <div className="w-[390px] h-[844px] relative overflow-hidden">
+    <>
+      {showMobileContainer && editMode && portalRef.current
+        ? createPortal(
+            <aside
+              id="logo-sidebar"
+              className="h-screen flex-row flex bg-white"
+              aria-label="Sidebar"
+            >
+              <div className="flex-1 w-[270px] h-full max-h-screen pt-12 flex-col flex px-4 py-4 overflow-y-auto border-r">
+                <ThemeSettingsEditor
+                  theme={config.theme}
+                  saveTheme={(newTheme) =>
+                    saveLocalConfig({ theme: newTheme })
+                  }
+                  saveExitEditMode={saveExitEditMode}
+                  cancelExitEditMode={cancelExitEditMode}
+                  fidgetInstanceDatums={config.fidgetInstanceDatums}
+                  saveFidgetInstanceDatums={(datums) =>
+                    saveLocalConfig({ fidgetInstanceDatums: datums })
+                  }
+                />
+              </div>
+            </aside>,
+            portalRef.current,
+          )
+        : null}
+      <div
+        className={`w-full h-full relative flex-col ${
+          showMobileContainer ? "" : "user-theme-background"
+        }`}
+      >
+        <div className="w-full transition-all duration-100 ease-out">
+          {showMobileContainer ? (
+            <div className="flex justify-center">
+              <div className="user-theme-background w-[390px] h-[844px] relative overflow-hidden">
+                <CustomHTMLBackground
+                  html={config.theme?.properties.backgroundHTML}
+                  className="absolute inset-0 pointer-events-none"
+                />
+                {mainContent}
+              </div>
+            </div>
+          ) : (
+            <>
               <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
               {mainContent}
-            </div>
-          </div>
-        ) : (
-          <>
-            <CustomHTMLBackground html={config.theme?.properties.backgroundHTML} />
-            {mainContent}
-          </>
-        )}
+            </>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -12,6 +12,7 @@ import TokenDataHeader from "./TokenDataHeader";
 import ProposalDataHeader from "./ProposalDataHeader";
 import ClaimButtonWithModal from "../molecules/ClaimButtonWithModal";
 import useIsMobile from "@/common/lib/hooks/useIsMobile";
+import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 import { SpacePageType } from "@/app/(spaces)/PublicSpace";
 
 interface TabBarProps {
@@ -63,6 +64,7 @@ function TabBar({
   pageType
 }: TabBarProps) {
   const isMobile = useIsMobile();
+  const { mobilePreview } = useMobilePreview();
 
   const { getIsLoggedIn, getIsInitializing } = useAppStore((state) => ({
     setModalOpen: state.setup.setModalOpen,
@@ -239,7 +241,7 @@ function TabBar({
         {isTokenPage && !getIsInitializing() && !isLoggedIn && !isMobile && (
           <ClaimButtonWithModal contractAddress={contractAddress} />
         )}
-        {inEditMode ? (
+        {inEditMode && !mobilePreview ? (
           <div className="mr-36 flex flex-row z-infinity">
             <NogsGateButton
               onClick={() => handleCreateTab(generateNewTabName())}

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -51,6 +51,7 @@ import { CompleteFidgets } from "@/fidgets";
 import { DEFAULT_FIDGET_ICON_MAP } from "@/constants/mobileFidgetIcons";
 import MobileSettings from "@/common/components/organisms/MobileSettings";
 import { MiniApp } from "@/common/components/molecules/MiniAppSettings";
+import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 
 export type ThemeSettingsEditorArgs = {
   theme: ThemeSettings;
@@ -72,6 +73,11 @@ export function ThemeSettingsEditor({
   const [showConfirmCancel, setShowConfirmCancel] = useState(false);
   const [activeTheme, setActiveTheme] = useState(theme.id);
   const [tabValue, setTabValue] = useState("space");
+  const { setMobilePreview } = useMobilePreview();
+
+  useEffect(() => {
+    setMobilePreview(tabValue === "mobile");
+  }, [tabValue, setMobilePreview]);
 
   const miniApps = useMemo<MiniApp[]>(() => {
     return Object.values(fidgetInstanceDatums).map((d, i) => {

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -72,8 +72,10 @@ export function ThemeSettingsEditor({
 }: ThemeSettingsEditorArgs) {
   const [showConfirmCancel, setShowConfirmCancel] = useState(false);
   const [activeTheme, setActiveTheme] = useState(theme.id);
-  const [tabValue, setTabValue] = useState("space");
-  const { setMobilePreview } = useMobilePreview();
+  const { mobilePreview, setMobilePreview } = useMobilePreview();
+  const [tabValue, setTabValue] = useState(
+    mobilePreview ? "mobile" : "space",
+  );
 
   useEffect(() => {
     setMobilePreview(tabValue === "mobile");

--- a/src/common/providers/MobilePreviewProvider.tsx
+++ b/src/common/providers/MobilePreviewProvider.tsx
@@ -1,0 +1,35 @@
+"use client";
+import React, { createContext, useContext, useMemo, useState } from "react";
+
+export interface MobilePreviewContextValue {
+  mobilePreview: boolean;
+  setMobilePreview: (value: boolean) => void;
+}
+
+const MobilePreviewContext = createContext<MobilePreviewContextValue>({
+  mobilePreview: false,
+  setMobilePreview: () => {},
+});
+
+export const MobilePreviewProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [mobilePreview, setMobilePreview] = useState(false);
+
+  const value = useMemo(
+    () => ({ mobilePreview, setMobilePreview }),
+    [mobilePreview],
+  );
+
+  return (
+    <MobilePreviewContext.Provider value={value}>
+      {children}
+    </MobilePreviewContext.Provider>
+  );
+};
+
+export const useMobilePreview = (): MobilePreviewContextValue => {
+  return useContext(MobilePreviewContext);
+};
+
+export default MobilePreviewProvider;

--- a/src/common/providers/index.tsx
+++ b/src/common/providers/index.tsx
@@ -13,6 +13,7 @@ import VersionCheckProivder from "./VersionCheckProvider";
 import { SidebarContextProvider } from "@/common/components/organisms/Sidebar";
 import { ToastProvider } from "../components/atoms/Toast";
 import MiniAppSdkProvider from "./MiniAppSdkProvider";
+import MobilePreviewProvider from "./MobilePreviewProvider";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
@@ -26,11 +27,13 @@ export default function Providers({ children }: { children: React.ReactNode }) {
                   <AuthenticatorProvider>
                     <LoggedInStateProvider>
                       <SidebarContextProvider>
-                        <AnalyticsProvider>
-                          <MiniAppSdkProvider>
-                            <ToastProvider>{children}</ToastProvider>
-                          </MiniAppSdkProvider>
-                        </AnalyticsProvider>
+                        <MobilePreviewProvider>
+                          <AnalyticsProvider>
+                            <MiniAppSdkProvider>
+                              <ToastProvider>{children}</ToastProvider>
+                            </MiniAppSdkProvider>
+                          </AnalyticsProvider>
+                        </MobilePreviewProvider>
                       </SidebarContextProvider>
                     </LoggedInStateProvider>
                   </AuthenticatorProvider>

--- a/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
+++ b/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
@@ -209,7 +209,7 @@ const TabNavigation: React.FC<TabNavigationProps> = ({
   };
 
   return (
-    <div className="relative w-full h-full">
+    <div className="relative w-full h-full min-h-[72px]">
       <TabsList 
         ref={tabsListRef}
         className={`

--- a/src/fidgets/layout/tabFullScreen/index.tsx
+++ b/src/fidgets/layout/tabFullScreen/index.tsx
@@ -159,14 +159,17 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
 
   return (
     <div className="flex flex-col h-full relative">
-      {/* Main content area with padding-bottom to make space for fixed tabs */}
-      <div 
-        className="w-full h-full overflow-hidden" 
-        style={{ 
-          paddingBottom: processedFidgetIds.length > 1 ? `${TAB_HEIGHT}px` : '0',
+      {/* Main content area with fixed height to keep tab bar visible */}
+      <div
+        className="w-full h-full overflow-hidden"
+        style={{
+          height:
+            processedFidgetIds.length > 1
+              ? `calc(100% - ${TAB_HEIGHT}px)`
+              : '100%',
         }}
       >
-        <Tabs 
+        <Tabs
           value={selectedTab}
           className="w-full h-full"
           onValueChange={setSelectedTab}
@@ -174,10 +177,11 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
           <div className="relative z-40 h-full">
             {/* Special case for consolidated media tab */}
             {isMobile && mediaFidgetIds.length > 1 && (
-              <TabsContent 
-                key="consolidated-media" 
+              <TabsContent
+                key="consolidated-media"
                 value="consolidated-media"
                 className="h-full w-full block"
+                forceMount
                 style={{ visibility: 'visible', display: 'block' }}
               >
                 <div
@@ -199,10 +203,11 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
 
             {/* Special case for consolidated pinned tab */}
             {isMobile && pinnedCastIds.length > 1 && (
-              <TabsContent 
-                key="consolidated-pinned" 
+              <TabsContent
+                key="consolidated-pinned"
                 value="consolidated-pinned"
                 className="h-full w-full block"
+                forceMount
                 style={{ visibility: 'visible', display: 'block' }}
               >
                 <div
@@ -237,10 +242,11 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
                 
                 // Only render the content for the selected tab
                 return (
-                  <TabsContent 
-                    key={fidgetId} 
+                  <TabsContent
+                    key={fidgetId}
                     value={fidgetId}
                     className="h-full w-full block"
+                    forceMount
                     style={{ visibility: 'visible', display: 'block' }}
                   >
                     <FidgetContent

--- a/src/fidgets/layout/tabFullScreen/index.tsx
+++ b/src/fidgets/layout/tabFullScreen/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useEffect } from "react";
 import { TabsContent, Tabs } from "@/common/components/atoms/tabs";
 import { MOBILE_PADDING, TAB_HEIGHT } from "@/constants/layout";
 import useIsMobile from "@/common/lib/hooks/useIsMobile";
+import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 import { usePathname } from "next/navigation";
 import { 
   FidgetBundle, 
@@ -43,7 +44,9 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
   saveConfig,
   tabNames,
 }) => {
-  const isMobile = useIsMobile();
+  const viewportMobile = useIsMobile();
+  const { mobilePreview } = useMobilePreview();
+  const isMobile = viewportMobile || mobilePreview;
   const pathname = usePathname();
   const isHomebasePath = pathname?.startsWith('/homebase');
   const isHomePath = pathname?.startsWith('/home');
@@ -255,11 +258,11 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
           
           {/* Tabs fixed to bottom of screen */}
           {processedFidgetIds.length > 1 && (
-            <div 
-              className="fixed bottom-0 left-0 right-0 z-50 bg-white"
+            <div
+              className={`${viewportMobile ? 'fixed' : 'absolute'} bottom-0 left-0 right-0 z-50 bg-white`}
               style={{ height: `${TAB_HEIGHT}px` }}
             >
-              <TabNavigation 
+              <TabNavigation
                 processedFidgetIds={orderedFidgetIds}
                 selectedTab={selectedTab}
                 fidgetInstanceDatums={fidgetInstanceDatums}

--- a/src/fidgets/layout/tabFullScreen/index.tsx
+++ b/src/fidgets/layout/tabFullScreen/index.tsx
@@ -180,9 +180,8 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
               <TabsContent
                 key="consolidated-media"
                 value="consolidated-media"
-                className="h-full w-full block"
+                className="h-full w-full data-[state=inactive]:hidden"
                 forceMount
-                style={{ visibility: 'visible', display: 'block' }}
               >
                 <div
                   className="h-full w-full"
@@ -206,9 +205,8 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
               <TabsContent
                 key="consolidated-pinned"
                 value="consolidated-pinned"
-                className="h-full w-full block"
+                className="h-full w-full data-[state=inactive]:hidden"
                 forceMount
-                style={{ visibility: 'visible', display: 'block' }}
               >
                 <div
                   className="h-full w-full"
@@ -245,9 +243,8 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
                   <TabsContent
                     key={fidgetId}
                     value={fidgetId}
-                    className="h-full w-full block"
+                    className="h-full w-full data-[state=inactive]:hidden"
                     forceMount
-                    style={{ visibility: 'visible', display: 'block' }}
                   >
                     <FidgetContent
                       fidgetId={fidgetId}


### PR DESCRIPTION
As a user, I want to see a mobile-sized preview of what my space will look like on mobile when the Mobile tab of the Theme Editor Panel is open.

**Summary**
add MobilePreviewProvider context
extend useIsMobile to include preview state
toggle preview from ThemeSettingsEditor
show mobile container in Space
wrap entire app with the provider
keep theme editor visible in mobile preview
contain bottom navigation within preview frame
hide Add Tab button on mobile preview
