### PR TITLE
Fix metadata format for App Router and add custom `fc:frame` meta tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ a protocol for decentralized social apps: https://www.farcaster.xyz
    On Mac OS, for example:
    ```bash
    brew install supabase/tap/supabase
+   
+   On Linux:
+   install docker
+   install supabase
+   npx supabase init
 4. Install dependencies
    ```bash
    yarn install
@@ -40,6 +45,9 @@ a protocol for decentralized social apps: https://www.farcaster.xyz
    ```bash
    yarn test
    ```
+
+9. cp .env.development.local .env.local
+10. yarn build
 
 ## Contributing and making Fidgets
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,45 +4,40 @@ import "@/styles/globals.css";
 import Providers from "@/common/providers";
 import Sidebar from "@/common/components/organisms/Sidebar";
 import { SpeedInsights } from "@vercel/speed-insights/next";
-import Head from "next/head";
 import { defaultFrame } from "@/common/lib/frames/metadata";
+// import Head from "next/head";
+import type { Metadata } from 'next' // Migrating next/head
 
-export const metadata = {
-  title: "Nounspace",
+export const metadata: Metadata = {
+  title: 'Nounspace',
   description:
-    "The customizable web3 social app, built on Farcaster. Create, customize, and explore on Nounspace",
+    'The customizable web3 social app, built on Farcaster. Create, customize, and explore on Nounspace',
   openGraph: {
-    siteName: "Nounspace",
-    title: "Nounspace",
-    type: "website",
+    title: 'Nounspace',
     description:
-      "The customizable web3 social app, built on Farcaster. Create, customize, and explore on Nounspace",
-    images: {
-      url: `${WEBSITE_URL}/images/nounspace_og_low.png`,
-      type: "image/png",
-      width: 1200,
-      height: 737,
-    },
+      'The customizable web3 social app, built on Farcaster. Create, customize, and explore on Nounspace',
     url: WEBSITE_URL,
+    siteName: 'Nounspace',
+    type: 'website',
+    images: [
+      {
+        url: `${WEBSITE_URL}/images/nounspace_og_low.png`,
+        type: 'image/png',
+        width: 1200,
+        height: 737,
+      },
+    ],
   },
   icons: {
     icon: [
-      {
-        url: "/images/favicon.ico",
-      },
-      {
-        url: "/images/favicon-32x32.png",
-        sizes: "32x32",
-      },
-      {
-        url: "/images/favicon-16x16.png",
-        sizes: "16x16",
-      },
+      { url: '/images/favicon.ico' },
+      { url: '/images/favicon-32x32.png', sizes: '32x32' },
+      { url: '/images/favicon-16x16.png', sizes: '16x16' },
     ],
-    apple: "/images/apple-touch-icon.png",
+    apple: '/images/apple-touch-icon.png',
   },
   other: {
-    "fc:frame": JSON.stringify(defaultFrame),
+    'fc:frame': JSON.stringify(defaultFrame),
   },
 };
 
@@ -57,9 +52,6 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <Head>
-        <meta name="fc:frame" content={JSON.stringify(defaultFrame)} />
-      </Head>
       <body>
         <SpeedInsights />
         <Providers>{sidebarLayout(children)}</Providers>


### PR DESCRIPTION
#### What this PR does

This PR updates the metadata handling in the App Router to use the [[Next.js Metadata API](https://nextjs.org/docs/app/building-your-application/optimizing/metadata)](https://nextjs.org/docs/app/building-your-application/optimizing/metadata), replacing the deprecated usage of `next/head`.

Changes include:

* ✅ Migrated custom meta tags (e.g., `fc:frame`) to `metadata.other`.
* ✅ Fixed `openGraph.images` to use an array of objects, as required by the `Metadata` type.
* ✅ Cleaned up formatting for consistency and clarity.

#### Why

While running the app, the following warning appeared:

> **Warning:** You're using `next/head` inside the `app` directory, please migrate to the Metadata API. See [https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration#step-3-migrating-nexthead](https://nextjs.org/docs/app/building-your-application/upgrading/app-router-migration#step-3-migrating-nexthead) for more details.

To comply with the App Router architecture and remove deprecated patterns, we’ve refactored all metadata to use the supported `metadata` export.

#### How to test

* Verify the `<meta name="fc:frame" ... />` tag appears correctly in the page's `<head>`.
* Check Open Graph previews (e.g. Discord, Twitter/X) to confirm the image and meta data render properly.
* Ensure no console warnings or TypeScript errors remain.
* Confirm no usage of `next/head` remains in the `app/` directory.

![image](https://github.com/user-attachments/assets/97a7d00b-7f22-4e3c-9686-86046e9a8456)
