### PR TITLE
Fix mobile preview tab nav

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -377,7 +377,9 @@ export default function Space({
         <div className="w-full transition-all duration-100 ease-out">
           {showMobileContainer ? (
             <div className="flex justify-center">
-              <div className="user-theme-background w-[390px] h-[844px] relative overflow-hidden">
+              <div
+                className="user-theme-background w-[390px] h-[844px] relative overflow-auto"
+              >
                 <CustomHTMLBackground
                   html={config.theme?.properties.backgroundHTML}
                   className="absolute inset-0 pointer-events-none"


### PR DESCRIPTION
## Summary
- remove padding from the mobile preview container so the bottom navigation sticks to the preview frame

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails to find type definitions)*