### PR TITLE
Fix bottom nav gap and tab switching

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -379,8 +379,7 @@ export default function Space({
           {showMobileContainer ? (
             <div className="flex justify-center">
               <div
-                className="user-theme-background w-[390px] h-[844px] relative overflow-auto"
-                style={{ paddingBottom: `${TAB_HEIGHT}px` }}
+                className="user-theme-background w-[390px] h-[844px] relative overflow-hidden"
               >
                 <CustomHTMLBackground
                   html={config.theme?.properties.backgroundHTML}

--- a/src/fidgets/layout/tabFullScreen/index.tsx
+++ b/src/fidgets/layout/tabFullScreen/index.tsx
@@ -180,9 +180,8 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
               <TabsContent
                 key="consolidated-media"
                 value="consolidated-media"
-                className="h-full w-full block"
+                className="h-full w-full"
                 forceMount
-                style={{ visibility: 'visible', display: 'block' }}
               >
                 <div
                   className="h-full w-full"
@@ -206,9 +205,8 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
               <TabsContent
                 key="consolidated-pinned"
                 value="consolidated-pinned"
-                className="h-full w-full block"
+                className="h-full w-full"
                 forceMount
-                style={{ visibility: 'visible', display: 'block' }}
               >
                 <div
                   className="h-full w-full"
@@ -245,9 +243,8 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
                   <TabsContent
                     key={fidgetId}
                     value={fidgetId}
-                    className="h-full w-full block"
+                    className="h-full w-full"
                     forceMount
-                    style={{ visibility: 'visible', display: 'block' }}
                   >
                     <FidgetContent
                       fidgetId={fidgetId}


### PR DESCRIPTION
## Summary
- keep mobile preview overflow hidden so bottom nav stays flush
- ensure TabFullScreen tabs only show the selected content

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run check-types` *(fails: Cannot find type definition file)*