### PR TITLE
Fix bottom nav interactions

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -379,7 +379,7 @@ export default function Space({
           {showMobileContainer ? (
             <div className="flex justify-center">
               <div
-                className="user-theme-background w-[390px] h-[844px] relative overflow-auto"
+                className="user-theme-background w-[390px] h-[844px] relative overflow-hidden"
                 style={{ paddingBottom: `${TAB_HEIGHT}px` }}
               >
                 <CustomHTMLBackground


### PR DESCRIPTION
## Summary
- keep the mobile preview nav height padding but switch container back to `overflow-hidden` to keep navigation clickable

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*