### PR TITLE
Fix mobile fidget switching

### DIFF
--- a/src/fidgets/layout/tabFullScreen/index.tsx
+++ b/src/fidgets/layout/tabFullScreen/index.tsx
@@ -180,9 +180,8 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
               <TabsContent
                 key="consolidated-media"
                 value="consolidated-media"
-                className="h-full w-full block"
+                className="h-full w-full data-[state=inactive]:hidden"
                 forceMount
-                style={{ visibility: 'visible', display: 'block' }}
               >
                 <div
                   className="h-full w-full"
@@ -206,9 +205,8 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
               <TabsContent
                 key="consolidated-pinned"
                 value="consolidated-pinned"
-                className="h-full w-full block"
+                className="h-full w-full data-[state=inactive]:hidden"
                 forceMount
-                style={{ visibility: 'visible', display: 'block' }}
               >
                 <div
                   className="h-full w-full"
@@ -245,9 +243,8 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
                   <TabsContent
                     key={fidgetId}
                     value={fidgetId}
-                    className="h-full w-full block"
+                    className="h-full w-full data-[state=inactive]:hidden"
                     forceMount
-                    style={{ visibility: 'visible', display: 'block' }}
                   >
                     <FidgetContent
                       fidgetId={fidgetId}


### PR DESCRIPTION
## Summary
- hide inactive tab contents so only the selected fidget shows

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definition files for 'node', 'react', 'react-dom')*