### PR TITLE
Fix mention suggestion type mismatch

### DIFF
--- a/src/fidgets/farcaster/useTiptapEditor.ts
+++ b/src/fidgets/farcaster/useTiptapEditor.ts
@@ -4,7 +4,6 @@ import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import Mention from "@tiptap/extension-mention";
 import Link from "@tiptap/extension-link";
-import suggestion from "@tiptap/suggestion";
 import { Channel } from "./types";
 import { FarcasterEmbed } from "./utils";
 
@@ -22,9 +21,10 @@ export function useTiptapEditor({ onSubmit }: UseTiptapEditorProps) {
       Link,
       Placeholder,
       Mention.configure({
-        suggestion: suggestion({
+        // Provide SuggestionOptions directly rather than the plugin instance
+        suggestion: {
           items: () => [],
-        }),
+        },
       }),
     ],
   });


### PR DESCRIPTION
## Summary
- correct the Mention suggestion configuration in `useTiptapEditor`

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run check-types` *(fails: Cannot find type definition file)*