### PR TITLE
Improve mobile preview mockup

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -20,6 +20,7 @@ import SpaceLoading from "./SpaceLoading";
 import { LayoutFidgets } from "@/fidgets";
 import { useIsMobile } from "@/common/lib/hooks/useIsMobile";
 import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
+import Image from "next/image";
 import { PlacedGridItem } from "@/fidgets/layout/Grid";
 import { cleanupLayout } from '@/common/lib/utils/gridCleanup';
 import { TAB_HEIGHT } from "@/constants/layout";
@@ -380,15 +381,27 @@ export default function Space({
         <div className="w-full transition-all duration-100 ease-out">
           {showMobileContainer ? (
             <div className="flex justify-center">
-              <div
-                className="user-theme-background w-[390px] h-[844px] relative overflow-auto"
-                style={{ paddingBottom: `${TAB_HEIGHT}px` }}
-              >
-                <CustomHTMLBackground
-                  html={config.theme?.properties.backgroundHTML}
-                  className="absolute inset-0 pointer-events-none"
+              <div className="relative w-[430px] h-[930px] overflow-hidden">
+                <Image
+                  src="https://i.ibb.co/PsDQrqvT/Chat-GPT-Image-May-29-2025-12-17-27-PM.png"
+                  alt="Phone mockup"
+                  fill
+                  className="pointer-events-none select-none"
                 />
-                {mainContent}
+                <div
+                  className="absolute top-[44px] bottom-[44px] left-[20px] right-[20px]"
+                >
+                  <div
+                    className="user-theme-background w-full h-full relative overflow-auto"
+                    style={{ paddingBottom: `${TAB_HEIGHT}px` }}
+                  >
+                    <CustomHTMLBackground
+                      html={config.theme?.properties.backgroundHTML}
+                      className="absolute inset-0 pointer-events-none"
+                    />
+                    {mainContent}
+                  </div>
+                </div>
               </div>
             </div>
           ) : (


### PR DESCRIPTION
## Summary
- adjust smartphone mockup container to avoid overlapping bottom navigation
- update phone mockup image URL

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*