### PR TITLE
Fix mobile preview overflow inside smartphone mockup

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -391,8 +391,7 @@ export default function Space({
                 />
                 <div className="absolute top-[44px] left-[20px]">
                   <div
-                    className="user-theme-background w-[390px] h-[844px] relative overflow-auto"
-                    style={{ paddingBottom: `${TAB_HEIGHT}px` }}
+                    className="user-theme-background w-[390px] h-[844px] relative overflow-hidden"
                   >
                     <CustomHTMLBackground
                       html={config.theme?.properties.backgroundHTML}


### PR DESCRIPTION
## Summary
- keep mobile preview content clipped within the phone mockup

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run check-types` *(fails: cannot find type definitions)*