### PR TITLE
Fix mobile preview bottom nav gap

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -22,7 +22,6 @@ import { useIsMobile } from "@/common/lib/hooks/useIsMobile";
 import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 import { PlacedGridItem } from "@/fidgets/layout/Grid";
 import { cleanupLayout } from '@/common/lib/utils/gridCleanup';
-import { TAB_HEIGHT } from "@/constants/layout";
 
 export type SpaceFidgetConfig = {
   instanceConfig: FidgetConfig<FidgetSettings>;
@@ -378,10 +377,7 @@ export default function Space({
         <div className="w-full transition-all duration-100 ease-out">
           {showMobileContainer ? (
             <div className="flex justify-center">
-              <div
-                className="user-theme-background w-[390px] h-[844px] relative overflow-auto"
-                style={{ paddingBottom: `${TAB_HEIGHT}px` }}
-              >
+              <div className="user-theme-background w-[390px] h-[844px] relative overflow-auto">
                 <CustomHTMLBackground
                   html={config.theme?.properties.backgroundHTML}
                   className="absolute inset-0 pointer-events-none"


### PR DESCRIPTION
## Summary
- fix placement of bottom nav by removing extra padding on mobile preview container

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*