### PR TITLE
Add mobile preview background

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -378,6 +378,14 @@ export default function Space({
           showMobileContainer ? "" : "user-theme-background"
         }`}
       >
+        {showMobileContainer && (
+          <Image
+            src="https://i.ibb.co/pjYr9zFr/Chat-GPT-Image-May-29-2025-01-35-55-PM.png"
+            alt="Mobile preview background"
+            fill
+            className="object-cover pointer-events-none select-none -z-10"
+          />
+        )}
         <div className="w-full transition-all duration-100 ease-out">
           {showMobileContainer ? (
             <div className="flex justify-center">


### PR DESCRIPTION
## Summary
- wrap the mobile preview background with an image when viewing the mobile tab

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*