### PR TITLE
Fix mobile preview overflow in phone mockup

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -391,8 +391,7 @@ export default function Space({
                 />
                 <div className="absolute top-[44px] left-[20px]">
                   <div
-                    className="user-theme-background w-[390px] h-[844px] relative overflow-auto"
-                    style={{ paddingBottom: `${TAB_HEIGHT}px` }}
+                    className="user-theme-background w-[390px] h-[844px] relative overflow-hidden"
                   >
                     <CustomHTMLBackground
                       html={config.theme?.properties.backgroundHTML}


### PR DESCRIPTION
## Summary
- remove padding style on the phone mockup container
- use `overflow-hidden` so preview contents are clipped

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition files)*