### PR TITLE
Decrease padding above nav elements

### DIFF
--- a/src/common/components/organisms/LoadingSidebar.tsx
+++ b/src/common/components/organisms/LoadingSidebar.tsx
@@ -7,7 +7,7 @@ export default function LoadingSidebar() {
       className="h-full flex-row flex bg-white transition-transform -translate-x-full sm:translate-x-0"
       aria-label="Sidebar"
     >
-      <div className="flex-1 w-[270px] h-full pt-7 flex-col flex px-4 py-4 overflow-y-hidden border-r">
+      <div className="flex-1 w-[270px] h-full pt-6 flex-col flex px-4 py-4 overflow-y-hidden border-r">
         <div className="h-full flex-col">
           <div className="text-lg font-medium">
             <ul className="space-y-2"></ul>

--- a/src/common/components/organisms/LoadingSidebar.tsx
+++ b/src/common/components/organisms/LoadingSidebar.tsx
@@ -7,7 +7,7 @@ export default function LoadingSidebar() {
       className="h-full flex-row flex bg-white transition-transform -translate-x-full sm:translate-x-0"
       aria-label="Sidebar"
     >
-      <div className="flex-1 w-[270px] h-full pt-12 flex-col flex px-4 py-4 overflow-y-hidden border-r">
+      <div className="flex-1 w-[270px] h-full pt-7 flex-col flex px-4 py-4 overflow-y-hidden border-r">
         <div className="h-full flex-col">
           <div className="text-lg font-medium">
             <ul className="space-y-2"></ul>

--- a/src/common/components/organisms/LoadingSidebar.tsx
+++ b/src/common/components/organisms/LoadingSidebar.tsx
@@ -7,7 +7,7 @@ export default function LoadingSidebar() {
       className="h-full flex-row flex bg-white transition-transform -translate-x-full sm:translate-x-0"
       aria-label="Sidebar"
     >
-      <div className="flex-1 w-[270px] h-full pt-6 flex-col flex px-4 py-4 overflow-y-hidden border-r">
+      <div className="flex-1 w-[270px] h-full pt-5 flex-col flex px-4 py-4 overflow-y-hidden border-r">
         <div className="h-full flex-col">
           <div className="text-lg font-medium">
             <ul className="space-y-2"></ul>

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -203,7 +203,7 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
         <CreateCast afterSubmit={() => setShowCastModal(false)} />
       </Modal>
       <SearchModal ref={searchRef} />
-      <div className="pt-6 pb-12 h-full md:block hidden">
+      <div className="pt-5 pb-12 h-full md:block hidden">
         <div
           className={mergeClasses(
             "flex flex-col h-full ml-auto transition-all duration-300 relative",

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -203,7 +203,7 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
         <CreateCast afterSubmit={() => setShowCastModal(false)} />
       </Modal>
       <SearchModal ref={searchRef} />
-      <div className="pt-12 pb-12 h-full md:block hidden">
+      <div className="pt-7 pb-12 h-full md:block hidden">
         <div
           className={mergeClasses(
             "flex flex-col h-full ml-auto transition-all duration-300 relative",

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -203,7 +203,7 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
         <CreateCast afterSubmit={() => setShowCastModal(false)} />
       </Modal>
       <SearchModal ref={searchRef} />
-      <div className="pt-7 pb-12 h-full md:block hidden">
+      <div className="pt-6 pb-12 h-full md:block hidden">
         <div
           className={mergeClasses(
             "flex flex-col h-full ml-auto transition-all duration-300 relative",

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -212,7 +212,7 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
         >
           <button
             onClick={toggleSidebar}
-            className="absolute right-0 top-4 transform translate-x-1/2 bg-white rounded-full border border-gray-200 shadow-sm p-2 hover:bg-gray-50 z-10"
+            className="absolute right-0 top-[30px] transform translate-x-1/2 bg-white rounded-full border border-gray-200 shadow-sm p-2 hover:bg-gray-50 z-10"
             aria-label={shrunk ? "Expand sidebar" : "Collapse sidebar"}
           >
             {shrunk ? (

--- a/src/common/components/organisms/NavigationSkeleton.tsx
+++ b/src/common/components/organisms/NavigationSkeleton.tsx
@@ -8,7 +8,7 @@ const NavigationSkeleton: React.FC = () => {
       className="w-full transition-transform -translate-x-full sm:translate-x-0 border-r-2 bg-white"
       aria-label="Sidebar Skeleton"
     >
-      <div className="pt-12 pb-12 h-full md:block hidden">
+      <div className="pt-7 pb-12 h-full md:block hidden">
         <div className="flex flex-col h-full w-[270px] ml-auto">
           <div className="flex flex-col text-lg font-medium pb-3 px-4 overflow-auto">
             <div className="flex-auto">

--- a/src/common/components/organisms/NavigationSkeleton.tsx
+++ b/src/common/components/organisms/NavigationSkeleton.tsx
@@ -8,7 +8,7 @@ const NavigationSkeleton: React.FC = () => {
       className="w-full transition-transform -translate-x-full sm:translate-x-0 border-r-2 bg-white"
       aria-label="Sidebar Skeleton"
     >
-      <div className="pt-7 pb-12 h-full md:block hidden">
+      <div className="pt-6 pb-12 h-full md:block hidden">
         <div className="flex flex-col h-full w-[270px] ml-auto">
           <div className="flex flex-col text-lg font-medium pb-3 px-4 overflow-auto">
             <div className="flex-auto">

--- a/src/common/components/organisms/NavigationSkeleton.tsx
+++ b/src/common/components/organisms/NavigationSkeleton.tsx
@@ -8,7 +8,7 @@ const NavigationSkeleton: React.FC = () => {
       className="w-full transition-transform -translate-x-full sm:translate-x-0 border-r-2 bg-white"
       aria-label="Sidebar Skeleton"
     >
-      <div className="pt-6 pb-12 h-full md:block hidden">
+      <div className="pt-5 pb-12 h-full md:block hidden">
         <div className="flex flex-col h-full w-[270px] ml-auto">
           <div className="flex flex-col text-lg font-medium pb-3 px-4 overflow-auto">
             <div className="flex-auto">


### PR DESCRIPTION
## Summary
- tweak the top padding for desktop sidebar and its skeleton
- adjust loading sidebar padding to match

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*