### PR TITLE
[CLIENT] ensure custom backgrounds fill mobile preview

### DIFF
--- a/src/common/components/molecules/CustomHTMLBackground.tsx
+++ b/src/common/components/molecules/CustomHTMLBackground.tsx
@@ -12,15 +12,22 @@ const CustomHTMLBackground: React.FC<CustomHTMLBackgroundProps> = ({
 }) => {
   // todo: more robust sanitization
   const sanitizedHtml = useMemo(() => {
-    return DOMPurify.sanitize(html, {
+    const sanitized = DOMPurify.sanitize(html, {
       FORCE_BODY: true,
       SAFE_FOR_TEMPLATES: false,
       USE_PROFILES: {
         html: true,
         svg: true,
       },
-      ALLOWED_TAGS: ["style"],
+      ADD_TAGS: ["style"],
+      ADD_ATTR: ["style"],
     });
+
+    // ensure iframe content always fills its container
+    const baseStyles =
+      "<style>html,body{margin:0;height:100%;width:100%;}</style>";
+
+    return `${baseStyles}${sanitized}`;
   }, [html]);
 
   return sanitizedHtml ? (


### PR DESCRIPTION
## Summary
- fix sanitization for custom backgrounds so style elements aren't stripped

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6839f87f73c48325ab82065365ed2ef2