### PR TITLE
Fix mobile preview background display

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -405,6 +405,7 @@ export default function Space({
                     <CustomHTMLBackground
                       html={config.theme?.properties.backgroundHTML}
                       className="absolute inset-0 pointer-events-none"
+                      style={{ bottom: `-${TAB_HEIGHT}px` }}
                     />
                     {mainContent}
                   </div>

--- a/src/common/components/molecules/CustomHTMLBackground.tsx
+++ b/src/common/components/molecules/CustomHTMLBackground.tsx
@@ -4,11 +4,13 @@ import DOMPurify from "isomorphic-dompurify";
 type CustomHTMLBackgroundProps = {
   html: string;
   className?: string;
+  style?: React.CSSProperties;
 };
 
 const CustomHTMLBackground: React.FC<CustomHTMLBackgroundProps> = ({
   html,
   className = "fixed size-full pointer-events-none",
+  style,
 }) => {
   // todo: more robust sanitization
   const sanitizedHtml = useMemo(() => {
@@ -28,6 +30,7 @@ const CustomHTMLBackground: React.FC<CustomHTMLBackgroundProps> = ({
       title="Custom Background"
       srcDoc={sanitizedHtml}
       className={className}
+      style={style}
       sandbox="" // disallows scripts
     />
   ) : null;


### PR DESCRIPTION
## Summary
- allow passing inline style to `CustomHTMLBackground`
- extend background height inside phone mockup to cover padding

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6839fbbc6c1c83259579c0838799fc74