### PR TITLE
[CLIENT] replace mobile preview background

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -21,6 +21,7 @@ import { LayoutFidgets } from "@/fidgets";
 import { useIsMobile } from "@/common/lib/hooks/useIsMobile";
 import { useMobilePreview } from "@/common/providers/MobilePreviewProvider";
 import Image from "next/image";
+import MobilePreviewBackground from "@/common/components/molecules/MobilePreviewBackground";
 import { PlacedGridItem } from "@/fidgets/layout/Grid";
 import { cleanupLayout } from '@/common/lib/utils/gridCleanup';
 import { TAB_HEIGHT } from "@/constants/layout";
@@ -381,12 +382,7 @@ export default function Space({
         }`}
       >
         {showMobileContainer && (
-          <Image
-            src="https://i.ibb.co/5CSR9qd/mobile-background-optimized-min.png"
-            alt="Mobile preview background"
-            fill
-            className="object-cover pointer-events-none select-none -z-10"
-          />
+          <MobilePreviewBackground className="fixed inset-0 pointer-events-none select-none -z-10" />
         )}
         <div className="w-full transition-all duration-100 ease-out">
           {showMobileContainer ? (

--- a/src/common/components/molecules/MobilePreviewBackground.tsx
+++ b/src/common/components/molecules/MobilePreviewBackground.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useRef } from "react";
+import { mergeClasses } from "@/common/lib/utils/mergeClasses";
+
+interface MobilePreviewBackgroundProps {
+  className?: string;
+}
+
+interface SparkleConfig {
+  x: string;
+  y: string;
+  delay: string;
+  color?: string;
+}
+
+const SPARKLES: SparkleConfig[] = [
+  { x: "8%", y: "12%", delay: ".4s", color: "#8ce7ff" },
+  { x: "32%", y: "38%", delay: "1.8s" },
+  { x: "58%", y: "18%", delay: ".9s" },
+  { x: "75%", y: "50%", delay: "2.2s", color: "#f9c0ff" },
+  { x: "90%", y: "78%", delay: ".6s" },
+  { x: "14%", y: "82%", delay: "1.3s", color: "#8ce7ff" },
+];
+
+const DOT_COLORS = ["#ffffff", "#fee684", "#ffc6ff", "#9cf6ff"];
+
+const MobilePreviewBackground: React.FC<MobilePreviewBackgroundProps> = ({
+  className,
+}) => {
+  const dotsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = dotsRef.current;
+    if (!container) return;
+    container.innerHTML = "";
+
+    for (let i = 0; i < 150; i += 1) {
+      const dot = document.createElement("span");
+      dot.className = "dot";
+      dot.style.left = `${Math.random() * 100}%`;
+      dot.style.top = `${Math.random() * 100}%`;
+      dot.style.backgroundColor =
+        DOT_COLORS[Math.floor(Math.random() * DOT_COLORS.length)];
+      dot.style.setProperty("--delay", `${Math.random() * 6}s`);
+      dot.style.setProperty("--dur", `${8 + Math.random() * 6}s`);
+      container.appendChild(dot);
+    }
+
+    return () => {
+      container.innerHTML = "";
+    };
+  }, []);
+
+  return (
+    <div className={mergeClasses("sky", className)}>
+      {SPARKLES.map((s, idx) => (
+        <div
+          // eslint-disable-next-line react/no-array-index-key
+          key={idx}
+          className="sparkle"
+          style={{
+            "--x": s.x,
+            "--y": s.y,
+            "--delay": s.delay,
+            "--color": s.color ?? "#ffe76d",
+          } as React.CSSProperties}
+        />
+      ))}
+      <div ref={dotsRef} />
+    </div>
+  );
+};
+
+export default MobilePreviewBackground;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -75,6 +75,12 @@
   * {
     scrollbar-width: none;
   }
+  html,
+  body {
+    height: 100%;
+    margin: 0;
+    overflow: hidden;
+  }
 }
 
 /*  
@@ -331,3 +337,82 @@
   }
 }
 
+
+/* Mobile preview pixel-sky background */
+.sky {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(#1eade2 0%, #3ec8f4 40%, #66d5ff 100%);
+}
+
+.dot {
+  position: absolute;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  opacity: 0.35;
+  animation: dotTwinkle var(--dur, 10s) ease-in-out infinite;
+  animation-delay: var(--delay, 0s);
+}
+
+@keyframes dotTwinkle {
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 0.55;
+  }
+}
+
+.sparkle {
+  --size: 16px;
+  --color: #ffe76d;
+  --delay: 0s;
+  --dur: 10s;
+  position: absolute;
+  left: var(--x);
+  top: var(--y);
+  width: var(--size);
+  height: var(--size);
+  transform: translate(-50%, -50%) rotate(45deg);
+  animation: sparkle var(--dur) ease-in-out infinite;
+  animation-delay: var(--delay);
+}
+
+.sparkle::before,
+.sparkle::after {
+  content: "";
+  position: absolute;
+  background: var(--color);
+  border-radius: 2px;
+}
+
+.sparkle::before {
+  width: 100%;
+  height: 3px;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.sparkle::after {
+  width: 3px;
+  height: 100%;
+  left: 50%;
+  top: 0;
+  transform: translateX(-50%);
+}
+
+@keyframes sparkle {
+  0%,
+  100% {
+    opacity: 0.4;
+    transform: translate(-50%, -50%) scale(0.9) rotate(45deg);
+  }
+  50% {
+    opacity: 0.75;
+    transform: translate(-50%, -50%) scale(1.05) rotate(45deg);
+  }
+}


### PR DESCRIPTION
## Summary
- generate dynamic pixel sky for mobile preview background
- add background CSS for pixel sky animation
- ensure mobile background spans full page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definition file for 'node', 'react', 'react-dom')*

------
https://chatgpt.com/codex/tasks/task_e_683a186f55a88325bb15be1b000da4c6