### PR TITLE
Improve tab load times via background preloading

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -243,6 +243,10 @@ export default function PublicSpace({
         .then(() => {
           console.log("Loaded space tab");
           setLoading(false);
+          // Preload other tabs in the background
+          if (currentSpaceId) {
+            void loadRemainingTabs(currentSpaceId);
+          }
         })
         .catch((error) => {
           console.error("Error loading space:", error);
@@ -256,11 +260,11 @@ export default function PublicSpace({
     async (spaceId: string) => {
       const currentTabName = getCurrentTabName();
       const tabOrder = localSpaces[spaceId]?.order || [];
-      for (const tabName of tabOrder) {
-        if (tabName !== currentTabName) {
-          await loadSpaceTab(spaceId, tabName);
-        }
-      }
+      await Promise.all(
+        tabOrder
+          .filter((tabName) => tabName !== currentTabName)
+          .map((tabName) => loadSpaceTab(spaceId, tabName)),
+      );
     },
     [localSpaces, getCurrentTabName, loadSpaceTab]
   );

--- a/src/app/(spaces)/homebase/PrivateSpace.tsx
+++ b/src/app/(spaces)/homebase/PrivateSpace.tsx
@@ -107,6 +107,19 @@ function PrivateSpace({ tabName }: { tabName: string }) {
     } else {
       await loadTab(tabName);
     }
+
+    // After the current tab is loaded, preload other tabs in the background
+    void loadRemainingTabs();
+  }
+
+  // Preload all tabs except the current one
+  async function loadRemainingTabs() {
+    const otherTabs = tabOrdering.local.filter((name) => name !== tabName);
+    await Promise.all(
+      otherTabs.map((name) =>
+        name === "Feed" ? loadFeedConfig() : loadTab(name),
+      ),
+    );
   }
 
   // Function to switch to a different tab


### PR DESCRIPTION
## Summary
- pre-load homebase tabs after active tab loads
- pre-load public space tabs after active tab loads

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

Note: I thought the app was already doing this, but maybe it got reverted accidentally?

------
https://chatgpt.com/codex/tasks/task_e_683a25c314f88325aa82586da133693d