### PR TITLE
Improve homepage loading UI

### DIFF
--- a/src/app/home/[tabname]/HomePageClient.tsx
+++ b/src/app/home/[tabname]/HomePageClient.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import React from "react";
+import { useRouter } from "next/navigation";
+import { useAppStore } from "@/common/data/stores/app";
+import SpacePage, { SpacePageArgs } from "@/app/(spaces)/SpacePage";
+import TabBar from "@/common/components/organisms/TabBar";
+import TabBarSkeleton from "@/common/components/organisms/TabBarSkeleton";
+import SpaceLoading from "@/app/(spaces)/SpaceLoading";
+import { SpaceConfig } from "@/app/(spaces)/Space";
+
+interface HomePageClientProps {
+  tabName: string;
+  tabConfig: SpaceConfig;
+}
+
+const HomePageClient = ({ tabName, tabConfig }: HomePageClientProps) => {
+  const router = useRouter();
+  const { getIsInitializing } = useAppStore((state) => ({
+    getIsInitializing: state.getIsInitializing,
+  }));
+  const isInitializing = getIsInitializing();
+
+  // Local state to manage current tab name and ordering
+  const tabOrdering = ["Nouns", "Nounspace", "Press"];
+
+  function switchTabTo(newTabName: string) {
+    router.push(`/home/${newTabName}`);
+  }
+
+  const tabBar = (
+    <TabBar
+      getSpacePageUrl={(tab) => `/home/${tab}`}
+      inHomebase={false}
+      currentTab={tabName}
+      tabList={tabOrdering}
+      switchTabTo={switchTabTo}
+      inEditMode={false}
+      updateTabOrder={async () => Promise.resolve()}
+      deleteTab={async () => Promise.resolve()}
+      createTab={async () => Promise.resolve({ tabName })}
+      renameTab={async () => Promise.resolve({ tabName })}
+      commitTab={async () => Promise.resolve()}
+      commitTabOrder={async () => Promise.resolve()}
+    />
+  );
+
+  if (isInitializing) {
+    return (
+      <div className="user-theme-background w-full h-full relative flex-col">
+        <div className="w-full transition-all duration-100 ease-out">
+          <div className="flex flex-col h-full">
+            <TabBarSkeleton />
+            <div className="flex h-full">
+              <div className="grow">
+                <SpaceLoading hasProfile={false} hasFeed={false} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const args: SpacePageArgs = {
+    config: tabConfig,
+    saveConfig: async () => {},
+    commitConfig: async () => {},
+    resetConfig: async () => {},
+    tabBar: tabBar,
+  };
+
+  return <SpacePage key={tabName} {...args} />;
+};
+
+export default HomePageClient;

--- a/src/app/home/[tabname]/page.tsx
+++ b/src/app/home/[tabname]/page.tsx
@@ -1,97 +1,26 @@
-"use client";
+import React from "react";
+import HomePageClient from "./HomePageClient";
+import { SpaceConfig } from "@/app/(spaces)/Space";
 
-import React, { useEffect, useState } from "react";
-import { useRouter, useParams } from "next/navigation";
-import { useAppStore } from "@/common/data/stores/app";
-import SpacePage, { SpacePageArgs } from "@/app/(spaces)/SpacePage";
-import TabBar from "@/common/components/organisms/TabBar";
-import {
-  PRESS_TAB_CONFIG,
-  NOUNS_TAB_CONFIG,
-  NOUNSPACE_TAB_CONFIG,
-} from "@/constants/homePageTabsConfig";
-import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialPersonSpace";
+interface PageProps {
+  params: { tabname?: string };
+}
 
-const getTabConfig = (tabName: string) => {
+const loadTabConfig = async (tabName: string): Promise<SpaceConfig> => {
+  const configModule = await import("@/constants/homePageTabsConfig");
   switch (tabName) {
     case "Nounspace":
-      return NOUNSPACE_TAB_CONFIG;
+      return configModule.NOUNSPACE_TAB_CONFIG;
     case "Press":
-      return PRESS_TAB_CONFIG;
+      return configModule.PRESS_TAB_CONFIG;
     case "Nouns":
     default:
-      return NOUNS_TAB_CONFIG;
+      return configModule.NOUNS_TAB_CONFIG;
   }
 };
 
-const Home = () => {
-  const router = useRouter();
-  const params = useParams();
-  const { getIsLoggedIn, getIsInitializing } = useAppStore((state) => ({
-    getIsLoggedIn: state.getIsAccountReady,
-    getIsInitializing: state.getIsInitializing,
-  }));
-  const isLoggedIn = getIsLoggedIn();
-  const isInitializing = getIsInitializing();
-
-  // Local state to manage current tab name and ordering
-  const tabOrdering = ["Nouns", "Nounspace", "Press"];
-  const [tabName, setTabName] = useState<string>("Nouns");
-
-  useEffect(() => {
-    const newTabName = params?.tabname
-      ? decodeURIComponent(params.tabname as string)
-      : "Nouns";
-
-    setTabName(newTabName);
-  }, []);
-
-  function switchTabTo(newTabName: string) {
-    router.push(`/home/${newTabName}`);
-  }
-
-  const tabBar = (
-    <TabBar
-      getSpacePageUrl={(tab) => `/home/${tab}`}
-      inHomebase={false}
-      currentTab={tabName}
-      tabList={tabOrdering}
-      switchTabTo={switchTabTo}
-      inEditMode={false}
-      updateTabOrder={async () => Promise.resolve()}
-      deleteTab={async () => Promise.resolve()}
-      createTab={async () => Promise.resolve({ tabName })}
-      renameTab={async () => Promise.resolve({ tabName })}
-      commitTab={async () => Promise.resolve()}
-      commitTabOrder={async () => Promise.resolve()}
-    />
-  );
-
-  const args: SpacePageArgs = isInitializing
-    ? {
-        config: { ...INITIAL_SPACE_CONFIG_EMPTY, isEditable: false },
-        saveConfig: async () => {},
-        commitConfig: async () => {},
-        resetConfig: async () => {},
-        tabBar: tabBar,
-      }
-    : !isLoggedIn
-      ? {
-          config: getTabConfig(tabName),
-          saveConfig: async () => {},
-          commitConfig: async () => {},
-          resetConfig: async () => {},
-          tabBar: tabBar,
-        }
-      : {
-          config: getTabConfig(tabName),
-          saveConfig: async () => {},
-          commitConfig: async () => {},
-          resetConfig: async () => {},
-          tabBar: tabBar,
-        };
-
-  return <SpacePage key={tabName} {...args} />;
-};
-
-export default Home;
+export default async function Page({ params }: PageProps) {
+  const tabName = params?.tabname ? decodeURIComponent(params.tabname) : "Nouns";
+  const tabConfig = await loadTabConfig(tabName);
+  return <HomePageClient tabName={tabName} tabConfig={tabConfig} />;
+}


### PR DESCRIPTION
## Summary
- keep nav and tab bar visible while the homepage initializes

## Testing
- `npm run lint` *(fails: `next` command not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683a2a702204832588cb4f5960ec9988