### PR TITLE
Fix navigation flicker on first load

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -12,7 +12,6 @@ import { UserTheme } from "@/common/lib/theme";
 import CustomHTMLBackground from "@/common/components/molecules/CustomHTMLBackground";
 import { isNil, isUndefined } from "lodash";
 import InfoToast from "@/common/components/organisms/InfoBanner";
-import TabBarSkeleton from "@/common/components/organisms/TabBarSkeleton";
 import SpaceLoading from "./SpaceLoading";
 // Import the LayoutFidgets directly
 import { LayoutFidgets } from "@/fidgets";
@@ -332,7 +331,7 @@ export default function Space({
           ) : null}
 
           <div className="relative">
-            <Suspense fallback={<TabBarSkeleton />}>{tabBar}</Suspense>
+            {tabBar}
             {/* Gradient overlay for tabs on mobile */}
             {isMobile && (
               <div

--- a/src/app/home/[tabname]/HomePageClient.tsx
+++ b/src/app/home/[tabname]/HomePageClient.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import React from "react";
+import { useRouter } from "next/navigation";
+import { useAppStore } from "@/common/data/stores/app";
+import SpacePage, { SpacePageArgs } from "@/app/(spaces)/SpacePage";
+import TabBar from "@/common/components/organisms/TabBar";
+import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialPersonSpace";
+import { SpaceConfig } from "@/app/(spaces)/Space";
+
+interface HomePageClientProps {
+  tabName: string;
+  tabConfig: SpaceConfig;
+}
+
+const HomePageClient = ({ tabName, tabConfig }: HomePageClientProps) => {
+  const router = useRouter();
+  const isLoggedIn = useAppStore((state) => state.getIsAccountReady());
+  const isInitializing = useAppStore((state) => state.getIsInitializing());
+
+  // Local state to manage current tab name and ordering
+  const tabOrdering = ["Nouns", "Nounspace", "Press"];
+
+  function switchTabTo(newTabName: string) {
+    router.push(`/home/${newTabName}`);
+  }
+
+  const tabBar = (
+    <TabBar
+      getSpacePageUrl={(tab) => `/home/${tab}`}
+      inHomebase={false}
+      currentTab={tabName}
+      tabList={tabOrdering}
+      switchTabTo={switchTabTo}
+      inEditMode={false}
+      updateTabOrder={async () => Promise.resolve()}
+      deleteTab={async () => Promise.resolve()}
+      createTab={async () => Promise.resolve({ tabName })}
+      renameTab={async () => Promise.resolve({ tabName })}
+      commitTab={async () => Promise.resolve()}
+      commitTabOrder={async () => Promise.resolve()}
+    />
+  );
+
+  const args: SpacePageArgs = isInitializing
+    ? {
+        config: { ...INITIAL_SPACE_CONFIG_EMPTY, isEditable: false },
+        saveConfig: async () => {},
+        commitConfig: async () => {},
+        resetConfig: async () => {},
+        tabBar: tabBar,
+      }
+    : !isLoggedIn
+      ? {
+          config: tabConfig,
+          saveConfig: async () => {},
+          commitConfig: async () => {},
+          resetConfig: async () => {},
+          tabBar: tabBar,
+        }
+      : {
+          config: tabConfig,
+          saveConfig: async () => {},
+          commitConfig: async () => {},
+          resetConfig: async () => {},
+          tabBar: tabBar,
+        };
+
+  return <SpacePage key={tabName} {...args} />;
+};
+
+export default HomePageClient;

--- a/src/app/home/[tabname]/page.tsx
+++ b/src/app/home/[tabname]/page.tsx
@@ -1,97 +1,26 @@
-"use client";
+import React from "react";
+import HomePageClient from "./HomePageClient";
+import { SpaceConfig } from "@/app/(spaces)/Space";
 
-import React, { useEffect, useState } from "react";
-import { useRouter, useParams } from "next/navigation";
-import { useAppStore } from "@/common/data/stores/app";
-import SpacePage, { SpacePageArgs } from "@/app/(spaces)/SpacePage";
-import TabBar from "@/common/components/organisms/TabBar";
-import {
-  PRESS_TAB_CONFIG,
-  NOUNS_TAB_CONFIG,
-  NOUNSPACE_TAB_CONFIG,
-} from "@/constants/homePageTabsConfig";
-import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialPersonSpace";
+interface PageProps {
+  params: { tabname?: string };
+}
 
-const getTabConfig = (tabName: string) => {
+const loadTabConfig = async (tabName: string): Promise<SpaceConfig> => {
+  const configModule = await import("@/constants/homePageTabsConfig");
   switch (tabName) {
     case "Nounspace":
-      return NOUNSPACE_TAB_CONFIG;
+      return configModule.NOUNSPACE_TAB_CONFIG;
     case "Press":
-      return PRESS_TAB_CONFIG;
+      return configModule.PRESS_TAB_CONFIG;
     case "Nouns":
     default:
-      return NOUNS_TAB_CONFIG;
+      return configModule.NOUNS_TAB_CONFIG;
   }
 };
 
-const Home = () => {
-  const router = useRouter();
-  const params = useParams();
-  const { getIsLoggedIn, getIsInitializing } = useAppStore((state) => ({
-    getIsLoggedIn: state.getIsAccountReady,
-    getIsInitializing: state.getIsInitializing,
-  }));
-  const isLoggedIn = getIsLoggedIn();
-  const isInitializing = getIsInitializing();
-
-  // Local state to manage current tab name and ordering
-  const tabOrdering = ["Nouns", "Nounspace", "Press"];
-  const [tabName, setTabName] = useState<string>("Nouns");
-
-  useEffect(() => {
-    const newTabName = params?.tabname
-      ? decodeURIComponent(params.tabname as string)
-      : "Nouns";
-
-    setTabName(newTabName);
-  }, []);
-
-  function switchTabTo(newTabName: string) {
-    router.push(`/home/${newTabName}`);
-  }
-
-  const tabBar = (
-    <TabBar
-      getSpacePageUrl={(tab) => `/home/${tab}`}
-      inHomebase={false}
-      currentTab={tabName}
-      tabList={tabOrdering}
-      switchTabTo={switchTabTo}
-      inEditMode={false}
-      updateTabOrder={async () => Promise.resolve()}
-      deleteTab={async () => Promise.resolve()}
-      createTab={async () => Promise.resolve({ tabName })}
-      renameTab={async () => Promise.resolve({ tabName })}
-      commitTab={async () => Promise.resolve()}
-      commitTabOrder={async () => Promise.resolve()}
-    />
-  );
-
-  const args: SpacePageArgs = isInitializing
-    ? {
-        config: { ...INITIAL_SPACE_CONFIG_EMPTY, isEditable: false },
-        saveConfig: async () => {},
-        commitConfig: async () => {},
-        resetConfig: async () => {},
-        tabBar: tabBar,
-      }
-    : !isLoggedIn
-      ? {
-          config: getTabConfig(tabName),
-          saveConfig: async () => {},
-          commitConfig: async () => {},
-          resetConfig: async () => {},
-          tabBar: tabBar,
-        }
-      : {
-          config: getTabConfig(tabName),
-          saveConfig: async () => {},
-          commitConfig: async () => {},
-          resetConfig: async () => {},
-          tabBar: tabBar,
-        };
-
-  return <SpacePage key={tabName} {...args} />;
-};
-
-export default Home;
+export default async function Page({ params }: PageProps) {
+  const tabName = params?.tabname ? decodeURIComponent(params.tabname) : "Nouns";
+  const tabConfig = await loadTabConfig(tabName);
+  return <HomePageClient tabName={tabName} tabConfig={tabConfig} />;
+}

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -69,13 +69,9 @@ const NavIconBadge = ({ children }) => {
 
 const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
   const searchRef = useRef<HTMLInputElement>(null);
-  const { setModalOpen, getIsLoggedIn, getIsInitializing } = useAppStore(
-    (state) => ({
-      setModalOpen: state.setup.setModalOpen,
-      getIsLoggedIn: state.getIsAccountReady,
-      getIsInitializing: state.getIsInitializing,
-    })
-  );
+  const setModalOpen = useAppStore((state) => state.setup.setModalOpen);
+  const isLoggedIn = useAppStore((state) => state.getIsAccountReady());
+  const isInitializing = useAppStore((state) => state.getIsInitializing());
   const userTheme: UserTheme = useUserTheme();
 
   const logout = useLogout();
@@ -106,8 +102,6 @@ const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode }) => {
     setShowCastModal(true);
   }
   const { fid } = useFarcasterSigner("navigation");
-  const isLoggedIn = getIsLoggedIn();
-  const isInitializing = getIsInitializing();
   const { data } = useLoadFarcasterUser(fid);
   const user = useMemo(() => first(data?.users), [data]);
   const username = useMemo(() => user?.username, [user]);

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -64,11 +64,9 @@ function TabBar({
 }: TabBarProps) {
   const isMobile = useIsMobile();
 
-  const { getIsLoggedIn, getIsInitializing } = useAppStore((state) => ({
-    setModalOpen: state.setup.setModalOpen,
-    getIsLoggedIn: state.getIsAccountReady,
-    getIsInitializing: state.getIsInitializing,
-  }));
+  const setModalOpen = useAppStore((state) => state.setup.setModalOpen);
+  const isLoggedIn = useAppStore((state) => state.getIsAccountReady());
+  const isInitializing = useAppStore((state) => state.getIsInitializing());
 
   function generateNewTabName() {
     const endIndex = tabList.length + 1;
@@ -190,7 +188,6 @@ function TabBar({
     switchTabTo(tabName, true);
   }, [switchTabTo]);
 
-  const isLoggedIn = getIsLoggedIn();
 
   return (
     <TooltipProvider>
@@ -236,7 +233,7 @@ function TabBar({
             </Reorder.Group>
           )}
         </div>
-        {isTokenPage && !getIsInitializing() && !isLoggedIn && !isMobile && (
+        {isTokenPage && !isInitializing && !isLoggedIn && !isMobile && (
           <ClaimButtonWithModal contractAddress={contractAddress} />
         )}
         {inEditMode ? (


### PR DESCRIPTION
## Summary
- keep navigation visible by subscribing to store state changes
- remove suspense wrapper from tab bar to prevent brief disappearance during page load

## Testing
- `npm run lint` *(fails: `next` command not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683a2a702204832588cb4f5960ec9988