### PR TITLE
Fix nav flicker on initial load

### DIFF
--- a/src/common/lib/hooks/useWindowSize.ts
+++ b/src/common/lib/hooks/useWindowSize.ts
@@ -12,19 +12,21 @@ export default function useWindowSize() {
     };
   }
 
-  const [windowDimensions, setWindowDimensions] = useState(
-    getWindowDimensions(),
-  );
-
-  function handleResize() {
-    setWindowDimensions(getWindowDimensions());
-  }
+  const [windowDimensions, setWindowDimensions] = useState(() => ({
+    width: null as number | null,
+    height: null as number | null,
+  }));
 
   useEffect(() => {
-    if (hasWindow) {
-      window.addEventListener("resize", handleResize);
-      return () => window.removeEventListener("resize", handleResize);
+    if (!hasWindow) return;
+
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
     }
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
   }, [hasWindow]);
 
   return windowDimensions;


### PR DESCRIPTION
## Summary
- ensure useWindowSize starts with consistent dimensions on server and client

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_683a3bc0fe1c8325a9711625cd598109