### PR TITLE
Add global border radius & spacing controls

### DIFF
--- a/src/common/components/organisms/FidgetSettingsEditor.tsx
+++ b/src/common/components/organisms/FidgetSettingsEditor.tsx
@@ -24,6 +24,8 @@ import {
 import React, { useEffect, useMemo, useState } from "react";
 import { FaCircleInfo, FaTrashCan } from "react-icons/fa6";
 import BackArrowIcon from "../atoms/icons/BackArrow";
+import { Slider } from "@mui/material";
+import { useGlobalFidgetStyle } from "@/common/providers/GlobalFidgetStyleProvider";
 
 export type FidgetSettingsEditorProps = {
   fidgetId: string;
@@ -156,6 +158,8 @@ export const FidgetSettingsEditor: React.FC<FidgetSettingsEditorProps> = ({
   removeFidget,
 }) => {
   const [state, setState] = useState<FidgetSettings>(settings);
+  const { borderRadius, spacing, setBorderRadius, setSpacing } =
+    useGlobalFidgetStyle();
 
   useEffect(() => {
     setState(settings);
@@ -238,6 +242,32 @@ export const FidgetSettingsEditor: React.FC<FidgetSettingsEditorProps> = ({
               </TabsContent>
             )}
           </Tabs>
+        </div>
+      </div>
+
+      <div className="border-t pt-4 mt-4">
+        <h2 className="text-md font-semibold mb-2">Change All Borders & Spacing</h2>
+        <div className="flex flex-col gap-4">
+          <label className="flex flex-col">
+            <span className="text-sm mb-1">Border Radius</span>
+            <Slider
+              value={borderRadius}
+              min={0}
+              max={32}
+              step={1}
+              onChange={(_, v) => setBorderRadius(v as number)}
+            />
+          </label>
+          <label className="flex flex-col">
+            <span className="text-sm mb-1">Spacing</span>
+            <Slider
+              value={spacing}
+              min={0}
+              max={32}
+              step={1}
+              onChange={(_, v) => setSpacing(v as number)}
+            />
+          </label>
         </div>
       </div>
 

--- a/src/common/components/organisms/FidgetTray.tsx
+++ b/src/common/components/organisms/FidgetTray.tsx
@@ -72,7 +72,7 @@ export const FidgetTray: React.FC<FidgetTrayProps> = ({
             <div
               className={`z-20 droppable-element px-2 py-2 flex justify-center items-center border rounded-md hover:bg-sky-100 group cursor-pointer ${
                 selectedFidgetID === fidgetData.id
-                  ? "outline outline-4 outline-offset-1 outline-sky-600"
+                  ? "outline outline-4 outline-offset-[-4px] outline-sky-600"
                   : ""
               }`}
               draggable={true}

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -17,6 +17,7 @@ import {
 } from ".";
 import GrabHandleIcon from "../components/atoms/icons/GrabHandle";
 import StashIcon from "../components/atoms/icons/Stash";
+import { useGlobalFidgetStyle } from "../providers/GlobalFidgetStyleProvider";
 import {
   Tooltip,
   TooltipContent,
@@ -67,6 +68,7 @@ export function FidgetWrapper({
   const { homebaseConfig } = useAppStore((state) => ({
     homebaseConfig: state.homebase.homebaseConfig,
   }));
+  const { borderRadius, spacing } = useGlobalFidgetStyle();
 
   function onClickEdit() {
     setSelectedFidgetID(bundle.id);
@@ -186,7 +188,7 @@ export function FidgetWrapper({
             : "size-full overflow-hidden"
         }
         style={{
-          background: settingsWithDefaults.useDefaultColors 
+          background: settingsWithDefaults.useDefaultColors
             ? homebaseConfig?.theme?.properties.fidgetBackground
             : settingsWithDefaults.background,
           borderColor: settingsWithDefaults.useDefaultColors
@@ -198,6 +200,8 @@ export function FidgetWrapper({
           boxShadow: settingsWithDefaults.useDefaultColors
             ? homebaseConfig?.theme?.properties.fidgetShadow
             : settingsWithDefaults.fidgetShadow,
+          borderRadius,
+          padding: spacing,
         }}
       >
         {bundle.config.editable && (

--- a/src/common/providers/GlobalFidgetStyleProvider.tsx
+++ b/src/common/providers/GlobalFidgetStyleProvider.tsx
@@ -1,0 +1,34 @@
+"use client";
+import React, { createContext, useContext, useState } from "react";
+
+export interface GlobalFidgetStyleContextValue {
+  borderRadius: number;
+  spacing: number;
+  setBorderRadius: (val: number) => void;
+  setSpacing: (val: number) => void;
+}
+
+const GlobalFidgetStyleContext = createContext<GlobalFidgetStyleContextValue | undefined>(undefined);
+
+export const GlobalFidgetStyleProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [borderRadius, setBorderRadius] = useState<number>(8);
+  const [spacing, setSpacing] = useState<number>(16);
+
+  return (
+    <GlobalFidgetStyleContext.Provider
+      value={{ borderRadius, spacing, setBorderRadius, setSpacing }}
+    >
+      {children}
+    </GlobalFidgetStyleContext.Provider>
+  );
+};
+
+export const useGlobalFidgetStyle = (): GlobalFidgetStyleContextValue => {
+  const ctx = useContext(GlobalFidgetStyleContext);
+  if (!ctx) {
+    throw new Error("useGlobalFidgetStyle must be used within GlobalFidgetStyleProvider");
+  }
+  return ctx;
+};
+
+export default GlobalFidgetStyleProvider;

--- a/src/common/providers/index.tsx
+++ b/src/common/providers/index.tsx
@@ -7,6 +7,7 @@ import Privy from "./Privy";
 import AuthenticatorProvider from "./AutheticatorProvider";
 import { AppStoreProvider } from "@/common/data/stores/app";
 import UserThemeProvider from "@/common/lib/theme/UserThemeProvider";
+import GlobalFidgetStyleProvider from "./GlobalFidgetStyleProvider";
 import LoggedInStateProvider from "./LoggedInStateProvider";
 import AnalyticsProvider from "./AnalyticsProvider";
 import VersionCheckProivder from "./VersionCheckProvider";
@@ -23,17 +24,19 @@ export default function Providers({ children }: { children: React.ReactNode }) {
             <Theme>
               <AppStoreProvider>
                 <UserThemeProvider>
-                  <AuthenticatorProvider>
-                    <LoggedInStateProvider>
-                      <SidebarContextProvider>
-                        <AnalyticsProvider>
-                          <MiniAppSdkProvider>
-                            <ToastProvider>{children}</ToastProvider>
-                          </MiniAppSdkProvider>
-                        </AnalyticsProvider>
-                      </SidebarContextProvider>
-                    </LoggedInStateProvider>
-                  </AuthenticatorProvider>
+                  <GlobalFidgetStyleProvider>
+                    <AuthenticatorProvider>
+                      <LoggedInStateProvider>
+                        <SidebarContextProvider>
+                          <AnalyticsProvider>
+                            <MiniAppSdkProvider>
+                              <ToastProvider>{children}</ToastProvider>
+                            </MiniAppSdkProvider>
+                          </AnalyticsProvider>
+                        </SidebarContextProvider>
+                      </LoggedInStateProvider>
+                    </AuthenticatorProvider>
+                  </GlobalFidgetStyleProvider>
                 </UserThemeProvider>
               </AppStoreProvider>
             </Theme>

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -32,6 +32,7 @@ import {
 import AddFidgetIcon from "@/common/components/atoms/icons/AddFidget";
 import FidgetSettingsEditor from "@/common/components/organisms/FidgetSettingsEditor";
 import { debounce } from "lodash";
+import { useGlobalFidgetStyle } from "@/common/providers/GlobalFidgetStyleProvider";
 
 export const resizeDirections = ["s", "w", "e", "n", "sw", "nw", "se", "ne"];
 export type ResizeDirection = (typeof resizeDirections)[number];
@@ -61,7 +62,11 @@ export interface PlacedGridItem extends GridItem {
   isBounded?: boolean;
 }
 
-const makeGridDetails = (hasProfile: boolean, hasFeed: boolean) => ({
+const makeGridDetails = (
+  hasProfile: boolean,
+  hasFeed: boolean,
+  spacing: number,
+) => ({
   items: 0,
   isDroppable: true,
   isBounded: false,
@@ -73,8 +78,8 @@ const makeGridDetails = (hasProfile: boolean, hasFeed: boolean) => ({
   maxRows: hasProfile ? 8 : 10,
   rowHeight: 70,
   layout: [],
-  margin: [16, 16],
-  containerPadding: [16, 16],
+  margin: [spacing, spacing],
+  containerPadding: [spacing, spacing],
 });
 
 type GridDetails = ReturnType<typeof makeGridDetails>;
@@ -152,9 +157,10 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     useState<React.ReactNode>(<></>);
   const [isPickingFidget, setIsPickingFidget] = useState(false);
 
+  const { spacing } = useGlobalFidgetStyle();
   const gridDetails = useMemo(
-    () => makeGridDetails(hasProfile, hasFeed),
-    [hasProfile, hasFeed],
+    () => makeGridDetails(hasProfile, hasFeed, spacing),
+    [hasProfile, hasFeed, spacing],
   );
 
   const saveTrayContents = async (newTrayData: typeof fidgetTrayContents) => {
@@ -264,7 +270,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
           gridDetails.containerPadding[0] * 2) /
           gridDetails.maxRows
       : gridDetails.rowHeight;
-  }, [height, hasProfile]);
+  }, [height, hasProfile, gridDetails]);
 
   function handleDrop(
     _layout: PlacedGridItem[],

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -95,6 +95,7 @@ const Gridlines: React.FC<GridDetails> = ({
   margin,
   containerPadding,
 }) => {
+  const { borderRadius } = useGlobalFidgetStyle();
   return (
     <div
       className="relative grid-overlap w-full h-full opacity-50"
@@ -111,11 +112,11 @@ const Gridlines: React.FC<GridDetails> = ({
     >
       {[...Array(cols * maxRows)].map((_, i) => (
         <div
-          className="rounded-lg"
           key={i}
           style={{
             backgroundColor: "rgba(200, 227, 248, 0.5)",
             outline: "2px dashed rgba(200, 227, 248, 0.3)",
+            borderRadius,
           }}
         />
       ))}
@@ -543,7 +544,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
                   key={gridItem.i}
                   className={`grid-item ${
                     selectedFidgetID === gridItem.i
-                      ? "outline outline-4 outline-offset-1 outline-sky-600"
+                      ? "outline outline-4 outline-offset-1 outline-sky-600 z-20"
                       : ""
                   }`}
                   style={{ borderRadius }}

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -544,7 +544,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
                   key={gridItem.i}
                   className={`grid-item ${
                     selectedFidgetID === gridItem.i
-                      ? "outline outline-4 outline-offset-1 outline-sky-600 z-20"
+                      ? "outline outline-4 outline-offset-[-4px] outline-sky-600 z-20"
                       : ""
                   }`}
                   style={{ borderRadius }}

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -157,7 +157,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     useState<React.ReactNode>(<></>);
   const [isPickingFidget, setIsPickingFidget] = useState(false);
 
-  const { spacing } = useGlobalFidgetStyle();
+  const { spacing, borderRadius } = useGlobalFidgetStyle();
   const gridDetails = useMemo(
     () => makeGridDetails(hasProfile, hasFeed, spacing),
     [hasProfile, hasFeed, spacing],
@@ -543,9 +543,10 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
                   key={gridItem.i}
                   className={`grid-item ${
                     selectedFidgetID === gridItem.i
-                      ? "outline outline-4 outline-offset-1 rounded-2xl outline-sky-600"
+                      ? "outline outline-4 outline-offset-1 outline-sky-600"
                       : ""
                   }`}
+                  style={{ borderRadius }}
                 >
                   <FidgetWrapper
                     fidget={fidgetModule.fidget}


### PR DESCRIPTION
## Summary
- introduce `GlobalFidgetStyleProvider` for border radius and spacing
- use the provider in global app providers
- apply border radius and padding spacing in `FidgetWrapper`
- expose sliders for global settings in `FidgetSettingsEditor`
- allow grid layout to respect global spacing

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683dd65b1c6c8325baa6189c4584fcef