### PR TITLE
Apply border radius to selection outline

### DIFF
--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -157,7 +157,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     useState<React.ReactNode>(<></>);
   const [isPickingFidget, setIsPickingFidget] = useState(false);
 
-  const { spacing } = useGlobalFidgetStyle();
+  const { spacing, borderRadius } = useGlobalFidgetStyle();
   const gridDetails = useMemo(
     () => makeGridDetails(hasProfile, hasFeed, spacing),
     [hasProfile, hasFeed, spacing],
@@ -543,9 +543,10 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
                   key={gridItem.i}
                   className={`grid-item ${
                     selectedFidgetID === gridItem.i
-                      ? "outline outline-4 outline-offset-1 rounded-2xl outline-sky-600"
+                      ? "outline outline-4 outline-offset-1 outline-sky-600"
                       : ""
                   }`}
+                  style={{ borderRadius }}
                 >
                   <FidgetWrapper
                     fidget={fidgetModule.fidget}


### PR DESCRIPTION
## Summary
- respect global border radius when highlighting selected fidgets

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683ddd7e723c8325a22951c7eaefa1f6