### PR TITLE
Fix import path for PrivateSpace in cast page

### DIFF
--- a/src/app/(spaces)/homebase/c/[caster]/[castHash]/page.tsx
+++ b/src/app/(spaces)/homebase/c/[caster]/[castHash]/page.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { useParams } from "next/navigation";
-import PrivateSpace from "../../PrivateSpace";
+import PrivateSpace from "../../../PrivateSpace";
 
 const HomebaseCastPage = () => {
   const params = useParams<{ caster: string; castHash: string }>();


### PR DESCRIPTION
## Summary
- adjust the relative import for `PrivateSpace` in cast page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_683de520f7e88325b808a4fe3ea960e3