### PR TITLE
Fix outline position for selected fidgets

### DIFF
--- a/src/common/components/organisms/FidgetTray.tsx
+++ b/src/common/components/organisms/FidgetTray.tsx
@@ -72,7 +72,7 @@ export const FidgetTray: React.FC<FidgetTrayProps> = ({
             <div
               className={`z-20 droppable-element px-2 py-2 flex justify-center items-center border rounded-md hover:bg-sky-100 group cursor-pointer ${
                 selectedFidgetID === fidgetData.id
-                  ? "outline outline-4 outline-offset-1 outline-sky-600"
+                  ? "outline outline-4 outline-offset-[-4px] outline-sky-600"
                   : ""
               }`}
               draggable={true}

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -544,7 +544,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
                   key={gridItem.i}
                   className={`grid-item ${
                     selectedFidgetID === gridItem.i
-                      ? "outline outline-4 outline-offset-1 outline-sky-600 z-20"
+                      ? "outline outline-4 outline-offset-[-4px] outline-sky-600 z-20"
                       : ""
                   }`}
                   style={{ borderRadius }}


### PR DESCRIPTION
## Summary
- keep selection outline flush to the fidget border by using a negative outline-offset

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683de7cd5b648325811f028f9a43f2bc