### PR TITLE
Improve web embed fidget reliability with debounce and stricter URL validation when editing

### DIFF
--- a/src/common/lib/utils/url.ts
+++ b/src/common/lib/utils/url.ts
@@ -5,3 +5,16 @@ export const isValidUrl = (url: string): boolean => {
     return false;
   }
 };
+
+export const isValidHttpUrl = (url: string): boolean => {
+  try {
+    const { protocol, hostname } = new URL(url);
+
+    const hasValidProtocol = protocol === "http:" || protocol === "https:";
+    const hasValidHost = hostname.includes(".") && hostname.split(".").pop()!.length > 1;
+
+    return hasValidProtocol && hasValidHost;
+  } catch (error) {
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary
- prevent premature iFramely requests by debouncing URL check in Web Embed fidget
- add stricter URL validation helper
- switch to lodash debounce rather than a custom hook

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683a21d5c6908325b2ca7361e613fb14