### PR TITLE
Fix viewing specific casts in feed fidget

### DIFF
--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -379,26 +379,29 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings, FeedFidgetData>> = ({ settin
       });
 
   const router = useRouter();
-  const threadStackRef = React.useRef(useLifoQueue<string>());
-  const threadStack = threadStackRef.current;
+  const threadStack = useLifoQueue<string>();
 
   const [ref, inView] = useInView();
+
+  const { push, pop, clear, last } = threadStack;
 
   useEffect(() => {
     if (prevFeedType !== feedType) {
       setIsTransitioning(true);
-      threadStack.clear();
+      clear();
       setTimeout(() => {
-        refetch().then(() => {
-          setIsTransitioning(false);
-          setPrevFeedType(feedType);
-        }).catch(() => {
-          setIsTransitioning(false);
-          setPrevFeedType(feedType);
-        });
+        refetch()
+          .then(() => {
+            setIsTransitioning(false);
+            setPrevFeedType(feedType);
+          })
+          .catch(() => {
+            setIsTransitioning(false);
+            setPrevFeedType(feedType);
+          });
       }, 200);
     }
-  }, [feedType, prevFeedType, refetch]);
+  }, [feedType, prevFeedType, refetch, clear]);
 
   useEffect(() => {
     if (inView && hasNextPage && !isTransitioning) {
@@ -408,29 +411,29 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings, FeedFidgetData>> = ({ settin
 
 
   useEffect(() => {
-    threadStack.clear();
+    clear();
     if (initialData?.initialHash) {
-      threadStack.push(initialData.initialHash);
+      push(initialData.initialHash);
     }
-  }, [settings, threadStack, initialData?.initialHash]);
+  }, [settings, initialData?.initialHash, clear, push]);
 
   const onSelectCast = useCallback(
     (hash: string, username: string) => {
-      threadStack.push(hash);
+      push(hash);
       router.push(`/homebase/c/${username}/${hash}`);
     },
-    [threadStack, router],
+    [push, router],
   );
 
   const handleBack = useCallback(() => {
-    threadStack.pop();
+    pop();
     router.push(`/homebase`);
-  }, [threadStack, router]);
+  }, [pop, router]);
 
   const renderThread = () => (
     <CastThreadView
       cast={{
-        hash: threadStack.last || "",
+        hash: last || "",
         author: { fid },
       }}
       onBack={handleBack}
@@ -566,7 +569,7 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings, FeedFidgetData>> = ({ settin
     );
   };
 
-  const isThreadView = threadStack.last !== undefined;
+  const isThreadView = last !== undefined;
 
   return (
     <div


### PR DESCRIPTION
## Summary
- ensure feed fidget thread stack updates across renders
- show cast conversation instead of reloading feed when navigating to a cast

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683df859609c8325be95954a87c6ff30