### PR TITLE
Add global border radius and spacing controls

### DIFF
--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -183,11 +183,11 @@ export function FidgetWrapper({
       <Card
         className={
           selectedFidgetID === bundle.id
-            ? "size-full border-solid border-sky-600 border-4 rounded-2xl overflow-hidden"
+            ? "size-full border-solid border-sky-600 border-4 overflow-hidden"
             : "size-full overflow-hidden"
         }
         style={{
-          background: settingsWithDefaults.useDefaultColors 
+          background: settingsWithDefaults.useDefaultColors
             ? homebaseConfig?.theme?.properties.fidgetBackground
             : settingsWithDefaults.background,
           borderColor: settingsWithDefaults.useDefaultColors
@@ -199,6 +199,7 @@ export function FidgetWrapper({
           boxShadow: settingsWithDefaults.useDefaultColors
             ? homebaseConfig?.theme?.properties.fidgetShadow
             : settingsWithDefaults.fidgetShadow,
+          borderRadius: 'var(--user-theme-fidget-border-radius)',
         }}
       >
         {bundle.config.editable && (

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -19,6 +19,7 @@ import ColorSelector from "@/common/components/molecules/ColorSelector";
 import FontSelector from "@/common/components/molecules/FontSelector";
 import HTMLInput from "@/common/components/molecules/HTMLInput";
 import ShadowSelector from "@/common/components/molecules/ShadowSelector";
+import { Slider } from "@mui/material";
 import { VideoSelector } from "@/common/components/molecules/VideoSelector";
 import { useAppStore } from "@/common/data/stores/app";
 import { useToastStore } from "@/common/data/stores/toastStore";
@@ -110,6 +111,8 @@ export function ThemeSettingsEditor({
     fidgetBorderWidth,
     fidgetBorderColor,
     fidgetShadow,
+    fidgetBorderRadius,
+    fidgetSpacing,
   } = theme.properties;
 
   function saveAndClose() {
@@ -295,12 +298,48 @@ export function ThemeSettingsEditor({
                           <h5 className="text-sm">Shadow</h5>
                           <ThemeSettingsTooltip text="Set the default shadow for all Fidgets on your Space." />
                         </div>
-                        <ShadowSelector
+                      <ShadowSelector
                           className="ring-0 focus:ring-0 border-0 shadow-none"
                           value={fidgetShadow as string}
                           onChange={themePropSetter<string>("fidgetShadow")}
                           hideGlobalSettings
                         />
+                      </div>
+                      <div>
+                        <div className="flex flex-row gap-1">
+                          <h5 className="text-sm">Change All Borders & Spacing</h5>
+                          <ThemeSettingsTooltip text="Set border radius and spacing for all Fidgets on this tab." />
+                        </div>
+                        <div className="flex flex-col gap-2 p-1">
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs w-24">Border Radius</span>
+                            <Slider
+                              value={parseInt(fidgetBorderRadius as string)}
+                              min={0}
+                              max={30}
+                              step={1}
+                              onChange={(_, value) =>
+                                themePropSetter<string>("fidgetBorderRadius")(
+                                  `${value}px`,
+                                )
+                              }
+                            />
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs w-24">Spacing</span>
+                            <Slider
+                              value={parseInt(fidgetSpacing as string)}
+                              min={0}
+                              max={32}
+                              step={1}
+                              onChange={(_, value) =>
+                                themePropSetter<string>("fidgetSpacing")(
+                                  `${value}`,
+                                )
+                              }
+                            />
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/common/lib/theme/UserThemeProvider.tsx
+++ b/src/common/lib/theme/UserThemeProvider.tsx
@@ -69,6 +69,8 @@ export const UserThemeProvider = ({ children }) => {
     fidgetBorderWidth,
     fidgetBorderColor,
     fidgetShadow,
+    fidgetBorderRadius,
+    fidgetSpacing,
   } = userTheme.properties;
 
   useEffect(() => {
@@ -121,6 +123,20 @@ export const UserThemeProvider = ({ children }) => {
   useEffect(() => {
     setGlobalStyleProperty("--user-theme-fidget-shadow", fidgetShadow);
   }, [fidgetShadow]);
+
+  useEffect(() => {
+    setGlobalStyleProperty(
+      "--user-theme-fidget-border-radius",
+      fidgetBorderRadius,
+    );
+  }, [fidgetBorderRadius]);
+
+  useEffect(() => {
+    setGlobalStyleProperty(
+      "--user-theme-fidget-spacing",
+      `${fidgetSpacing}px`,
+    );
+  }, [fidgetSpacing]);
 
   return children;
 };

--- a/src/common/lib/theme/defaultTheme.ts
+++ b/src/common/lib/theme/defaultTheme.ts
@@ -15,6 +15,8 @@ export const defaultUserTheme: UserTheme = {
     fidgetBorderWidth: "1px",
     fidgetBorderColor: "#eeeeee",
     fidgetShadow: "none",
+    fidgetBorderRadius: "8px",
+    fidgetSpacing: "16",
   },
 };
 

--- a/src/common/lib/theme/index.d.ts
+++ b/src/common/lib/theme/index.d.ts
@@ -17,6 +17,8 @@ export interface UserTheme extends ThemeSettings {
     fidgetBorderWidth: string;
     fidgetBorderColor: Color;
     fidgetShadow: string;
+    fidgetBorderRadius: string;
+    fidgetSpacing: string;
   };
 }
 

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -61,7 +61,11 @@ export interface PlacedGridItem extends GridItem {
   isBounded?: boolean;
 }
 
-const makeGridDetails = (hasProfile: boolean, hasFeed: boolean) => ({
+const makeGridDetails = (
+  hasProfile: boolean,
+  hasFeed: boolean,
+  spacing: number,
+) => ({
   items: 0,
   isDroppable: true,
   isBounded: false,
@@ -73,8 +77,8 @@ const makeGridDetails = (hasProfile: boolean, hasFeed: boolean) => ({
   maxRows: hasProfile ? 8 : 10,
   rowHeight: 70,
   layout: [],
-  margin: [16, 16],
-  containerPadding: [16, 16],
+  margin: [spacing, spacing],
+  containerPadding: [spacing, spacing],
 });
 
 type GridDetails = ReturnType<typeof makeGridDetails>;
@@ -153,8 +157,13 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   const [isPickingFidget, setIsPickingFidget] = useState(false);
 
   const gridDetails = useMemo(
-    () => makeGridDetails(hasProfile, hasFeed),
-    [hasProfile, hasFeed],
+    () =>
+      makeGridDetails(
+        hasProfile,
+        hasFeed,
+        Number(theme.properties.fidgetSpacing ?? "16"),
+      ),
+    [hasProfile, hasFeed, theme.properties.fidgetSpacing],
   );
 
   const saveTrayContents = async (newTrayData: typeof fidgetTrayContents) => {
@@ -257,14 +266,16 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     // 64 = 4rem = magic number here is the height of the tabs bar above the grid
     // 160 = 10rem = magic number for the profile height
     const magicBase = hasProfile ? 64 + 160 : 64;
+    const spacing = Number(theme.properties.fidgetSpacing ?? "16");
     return height
-      ? (height -
-          magicBase -
-          gridDetails.margin[0] * (gridDetails.maxRows - 1) -
-          gridDetails.containerPadding[0] * 2) /
+      ?
+          (height -
+            magicBase -
+            spacing * (gridDetails.maxRows - 1) -
+            spacing * 2) /
           gridDetails.maxRows
       : gridDetails.rowHeight;
-  }, [height, hasProfile]);
+  }, [height, hasProfile, theme.properties.fidgetSpacing, gridDetails.maxRows, gridDetails.rowHeight]);
 
   function handleDrop(
     _layout: PlacedGridItem[],


### PR DESCRIPTION
## Summary
- support fidget border radius and spacing in theme types
- store new props in the default theme
- expose new CSS variables in `UserThemeProvider`
- use global border radius in `FidgetWrapper`
- apply spacing to grid layout
- add sliders to theme editor for border radius and spacing

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683e01ff5de08325ad412d154dd24dc9