### PR TITLE
Add borders and spacing controls

### DIFF
--- a/src/common/components/molecules/NumberSlider.tsx
+++ b/src/common/components/molecules/NumberSlider.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Slider } from "@mui/material";
+
+export interface NumberSliderProps {
+  min?: number;
+  max?: number;
+  step?: number;
+  value: number;
+  onChange: (value: number) => void;
+  className?: string;
+}
+
+const NumberSlider: React.FC<NumberSliderProps> = ({
+  min = 0,
+  max = 100,
+  step = 1,
+  value,
+  onChange,
+  className,
+}) => {
+  return (
+    <div className={className ?? "ml-3 mr-3"}>
+      <Slider
+        value={value}
+        step={step}
+        min={min}
+        max={max}
+        onChange={(_, v) => onChange(v as number)}
+      />
+    </div>
+  );
+};
+
+export default NumberSlider;

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -183,11 +183,12 @@ export function FidgetWrapper({
       <Card
         className={
           selectedFidgetID === bundle.id
-            ? "size-full border-solid border-sky-600 border-4 rounded-2xl overflow-hidden"
+            ? "size-full border-solid border-sky-600 border-4 overflow-hidden"
             : "size-full overflow-hidden"
         }
         style={{
-          background: settingsWithDefaults.useDefaultColors 
+          borderRadius: "var(--user-theme-fidget-border-radius)",
+          background: settingsWithDefaults.useDefaultColors
             ? homebaseConfig?.theme?.properties.fidgetBackground
             : settingsWithDefaults.background,
           borderColor: settingsWithDefaults.useDefaultColors

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -19,6 +19,7 @@ import ColorSelector from "@/common/components/molecules/ColorSelector";
 import FontSelector from "@/common/components/molecules/FontSelector";
 import HTMLInput from "@/common/components/molecules/HTMLInput";
 import ShadowSelector from "@/common/components/molecules/ShadowSelector";
+import NumberSlider from "@/common/components/molecules/NumberSlider";
 import { VideoSelector } from "@/common/components/molecules/VideoSelector";
 import { useAppStore } from "@/common/data/stores/app";
 import { useToastStore } from "@/common/data/stores/toastStore";
@@ -110,6 +111,8 @@ export function ThemeSettingsEditor({
     fidgetBorderWidth,
     fidgetBorderColor,
     fidgetShadow,
+    fidgetBorderRadius,
+    fidgetSpacing,
   } = theme.properties;
 
   function saveAndClose() {
@@ -250,6 +253,39 @@ export function ThemeSettingsEditor({
                       value={background as Color}
                       onChange={themePropSetter<Color>("background")}
                     />
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <h4 className="text-sm font-bold my-2">Change All Borders &amp; Spacing</h4>
+                    <div className="flex flex-col gap-2">
+                      <div className="flex flex-row gap-1 items-center">
+                        <h5 className="text-sm">Border Radius</h5>
+                        <ThemeSettingsTooltip text="Set the border radius for all Fidgets on this tab." />
+                      </div>
+                      <NumberSlider
+                        min={0}
+                        max={30}
+                        step={1}
+                        value={parseInt(fidgetBorderRadius)}
+                        onChange={(v) =>
+                          themePropSetter<string>("fidgetBorderRadius")(
+                            `${v}px`,
+                          )
+                        }
+                      />
+                      <div className="flex flex-row gap-1 items-center">
+                        <h5 className="text-sm">Spacing</h5>
+                        <ThemeSettingsTooltip text="Set the spacing between Fidgets on this tab." />
+                      </div>
+                      <NumberSlider
+                        min={0}
+                        max={40}
+                        step={1}
+                        value={parseInt(fidgetSpacing)}
+                        onChange={(v) =>
+                          themePropSetter<string>("fidgetSpacing")(`${v}`)
+                        }
+                      />
+                    </div>
                   </div>
                   <div className="flex flex-col gap-1">
                     <h4 className="text-sm font-bold my-2">Fidget Settings</h4>

--- a/src/common/lib/theme/UserThemeProvider.tsx
+++ b/src/common/lib/theme/UserThemeProvider.tsx
@@ -69,6 +69,8 @@ export const UserThemeProvider = ({ children }) => {
     fidgetBorderWidth,
     fidgetBorderColor,
     fidgetShadow,
+    fidgetBorderRadius,
+    fidgetSpacing,
   } = userTheme.properties;
 
   useEffect(() => {
@@ -121,6 +123,14 @@ export const UserThemeProvider = ({ children }) => {
   useEffect(() => {
     setGlobalStyleProperty("--user-theme-fidget-shadow", fidgetShadow);
   }, [fidgetShadow]);
+
+  useEffect(() => {
+    setGlobalStyleProperty("--user-theme-fidget-border-radius", fidgetBorderRadius);
+  }, [fidgetBorderRadius]);
+
+  useEffect(() => {
+    setGlobalStyleProperty("--user-theme-fidget-spacing", fidgetSpacing);
+  }, [fidgetSpacing]);
 
   return children;
 };

--- a/src/common/lib/theme/defaultTheme.ts
+++ b/src/common/lib/theme/defaultTheme.ts
@@ -15,6 +15,8 @@ export const defaultUserTheme: UserTheme = {
     fidgetBorderWidth: "1px",
     fidgetBorderColor: "#eeeeee",
     fidgetShadow: "none",
+    fidgetBorderRadius: "16px",
+    fidgetSpacing: "16",
   },
 };
 

--- a/src/common/lib/theme/index.d.ts
+++ b/src/common/lib/theme/index.d.ts
@@ -17,6 +17,8 @@ export interface UserTheme extends ThemeSettings {
     fidgetBorderWidth: string;
     fidgetBorderColor: Color;
     fidgetShadow: string;
+    fidgetBorderRadius: string;
+    fidgetSpacing: string;
   };
 }
 

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -61,7 +61,12 @@ export interface PlacedGridItem extends GridItem {
   isBounded?: boolean;
 }
 
-const makeGridDetails = (hasProfile: boolean, hasFeed: boolean) => ({
+const makeGridDetails = (
+  hasProfile: boolean,
+  hasFeed: boolean,
+  spacing: number,
+  borderRadius: string,
+) => ({
   items: 0,
   isDroppable: true,
   isBounded: false,
@@ -73,8 +78,9 @@ const makeGridDetails = (hasProfile: boolean, hasFeed: boolean) => ({
   maxRows: hasProfile ? 8 : 10,
   rowHeight: 70,
   layout: [],
-  margin: [16, 16],
-  containerPadding: [16, 16],
+  margin: [spacing, spacing],
+  containerPadding: [spacing, spacing],
+  borderRadius,
 });
 
 type GridDetails = ReturnType<typeof makeGridDetails>;
@@ -89,6 +95,7 @@ const Gridlines: React.FC<GridDetails> = ({
   rowHeight,
   margin,
   containerPadding,
+  borderRadius,
 }) => {
   return (
     <div
@@ -106,9 +113,10 @@ const Gridlines: React.FC<GridDetails> = ({
     >
       {[...Array(cols * maxRows)].map((_, i) => (
         <div
-          className="rounded-lg"
+          className=""
           key={i}
           style={{
+            borderRadius,
             backgroundColor: "rgba(200, 227, 248, 0.5)",
             outline: "2px dashed rgba(200, 227, 248, 0.3)",
           }}
@@ -153,8 +161,14 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   const [isPickingFidget, setIsPickingFidget] = useState(false);
 
   const gridDetails = useMemo(
-    () => makeGridDetails(hasProfile, hasFeed),
-    [hasProfile, hasFeed],
+    () =>
+      makeGridDetails(
+        hasProfile,
+        hasFeed,
+        parseInt(theme.properties.fidgetSpacing ?? "16"),
+        theme.properties.fidgetBorderRadius ?? "16px",
+      ),
+    [hasProfile, hasFeed, theme.properties.fidgetSpacing, theme.properties.fidgetBorderRadius],
   );
 
   const saveTrayContents = async (newTrayData: typeof fidgetTrayContents) => {
@@ -538,9 +552,12 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
                   key={gridItem.i}
                   className={`grid-item ${
                     selectedFidgetID === gridItem.i
-                      ? "outline outline-4 outline-offset-1 rounded-2xl outline-sky-600"
+                      ? "outline outline-4 outline-offset-1 outline-sky-600"
                       : ""
                   }`}
+                  style={{
+                    borderRadius: selectedFidgetID === gridItem.i ? 'var(--user-theme-fidget-border-radius)' : undefined,
+                  }}
                 >
                   <FidgetWrapper
                     fidget={fidgetModule.fidget}


### PR DESCRIPTION
## Summary
- allow changing border radius and fidget spacing via theme
- propagate border radius and spacing to grids and fidgets
- store new values in the theme provider
- add generic NumberSlider component

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definition file for 'node', 'react', 'react-dom')*

------
https://chatgpt.com/codex/tasks/task_e_683e0998b14c83259f9775e994dbed05