### PR TITLE
Fix fidget editing disappearance

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -503,7 +503,7 @@ export default function PublicSpace({
       };
       return saveLocalSpaceTab(currentSpaceId, currentTabName, saveableConfig);
     },
-    [getCurrentSpaceId, getCurrentTabName]
+    [getCurrentSpaceId, getCurrentTabName, memoizedConfig.fidgetInstanceDatums]
   );
 
   const commitConfig = useCallback(async () => {


### PR DESCRIPTION
## Summary
- include `memoizedConfig.fidgetInstanceDatums` in `saveConfig` callback dependencies

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_683dd999eb208325872cb11e6b939936