### PR TITLE
Add theme border radius and spacing controls

### DIFF
--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -49,7 +49,7 @@ export const getSettingsWithDefaults = (
       [f.fieldName]:
         f.fieldName in safeSettings
           ? safeSettings[f.fieldName]
-          : f.default ?? undefined,
+          : (f.default ?? undefined),
     }),
     {},
   );
@@ -58,6 +58,7 @@ export const getSettingsWithDefaults = (
 export function FidgetWrapper({
   fidget,
   bundle,
+  context,
   saveConfig,
   setCurrentFidgetSettings,
   setSelectedFidgetID,
@@ -68,6 +69,8 @@ export function FidgetWrapper({
   const { homebaseConfig } = useAppStore((state) => ({
     homebaseConfig: state.homebase.homebaseConfig,
   }));
+
+  const themeProps = (context?.theme ?? homebaseConfig?.theme)?.properties;
 
   function onClickEdit() {
     setSelectedFidgetID(bundle.id);
@@ -183,11 +186,11 @@ export function FidgetWrapper({
       <Card
         className={
           selectedFidgetID === bundle.id
-            ? "size-full border-solid border-sky-600 border-4 rounded-2xl overflow-hidden"
+            ? "size-full border-solid border-sky-600 border-4 overflow-hidden"
             : "size-full overflow-hidden"
         }
         style={{
-          background: settingsWithDefaults.useDefaultColors 
+          background: settingsWithDefaults.useDefaultColors
             ? homebaseConfig?.theme?.properties.fidgetBackground
             : settingsWithDefaults.background,
           borderColor: settingsWithDefaults.useDefaultColors
@@ -199,12 +202,14 @@ export function FidgetWrapper({
           boxShadow: settingsWithDefaults.useDefaultColors
             ? homebaseConfig?.theme?.properties.fidgetShadow
             : settingsWithDefaults.fidgetShadow,
+          borderRadius: themeProps?.fidgetBorderRadius,
         }}
       >
         {bundle.config.editable && (
           <button
             onMouseDown={onClickEdit}
-            className="items-center justify-center opacity-0 hover:opacity-50 duration-500 absolute inset-0 z-10 flex bg-slate-400 bg-opacity-50 rounded-md"
+            className="items-center justify-center opacity-0 hover:opacity-50 duration-500 absolute inset-0 z-10 flex bg-slate-400 bg-opacity-50"
+            style={{ borderRadius: themeProps?.fidgetBorderRadius }}
           ></button>
         )}
         <ScopedStyles cssStyles={userStyles} className="size-full">

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -184,12 +184,16 @@ export function FidgetWrapper({
         </button>
       </div>
       <Card
-        className={
-          selectedFidgetID === bundle.id
-            ? "size-full border-solid border-sky-600 border-4 overflow-hidden"
-            : "size-full overflow-hidden"
-        }
+        className="size-full overflow-hidden"
         style={{
+          outline:
+            selectedFidgetID === bundle.id
+              ? "4px solid rgb(2 132 199)" /* sky-600 */
+              : undefined,
+          outlineOffset:
+            selectedFidgetID === bundle.id
+              ? -parseInt(themeProps?.fidgetBorderWidth ?? "0")
+              : undefined,
           background: settingsWithDefaults.useDefaultColors
             ? homebaseConfig?.theme?.properties.fidgetBackground
             : settingsWithDefaults.background,

--- a/src/common/lib/theme/ThemeSettingsEditor.tsx
+++ b/src/common/lib/theme/ThemeSettingsEditor.tsx
@@ -20,6 +20,7 @@ import FontSelector from "@/common/components/molecules/FontSelector";
 import HTMLInput from "@/common/components/molecules/HTMLInput";
 import ShadowSelector from "@/common/components/molecules/ShadowSelector";
 import { VideoSelector } from "@/common/components/molecules/VideoSelector";
+import { Slider } from "@mui/material";
 import { useAppStore } from "@/common/data/stores/app";
 import { useToastStore } from "@/common/data/stores/toastStore";
 import { Color, FontFamily, ThemeSettings } from "@/common/lib/theme";
@@ -64,7 +65,9 @@ export function ThemeSettingsEditor({
   const [activeTheme, setActiveTheme] = useState(theme.id);
   const [tabValue, setTabValue] = useState("fonts");
 
-  function themePropSetter<_T extends string>(property: string): (value: string) => void {
+  function themePropSetter<_T extends string>(
+    property: string,
+  ): (value: string) => void {
     return (value: string): void => {
       const newTheme = {
         ...theme,
@@ -82,16 +85,20 @@ export function ThemeSettingsEditor({
         const fontConfig = FONT_FAMILY_OPTIONS_BY_NAME[value];
         if (fontConfig) {
           document.documentElement.style.setProperty(
-            property === "font" ? "--user-theme-font" : "--user-theme-headings-font",
-            fontConfig.config.style.fontFamily
+            property === "font"
+              ? "--user-theme-font"
+              : "--user-theme-headings-font",
+            fontConfig.config.style.fontFamily,
           );
         }
       }
 
       if (property === "fontColor" || property === "headingsFontColor") {
         document.documentElement.style.setProperty(
-          property === "fontColor" ? "--user-theme-font-color" : "--user-theme-headings-font-color",
-          value
+          property === "fontColor"
+            ? "--user-theme-font-color"
+            : "--user-theme-headings-font-color",
+          value,
         );
       }
 
@@ -110,6 +117,8 @@ export function ThemeSettingsEditor({
     fidgetBorderWidth,
     fidgetBorderColor,
     fidgetShadow,
+    fidgetBorderRadius,
+    gridSpacing,
   } = theme.properties;
 
   function saveAndClose() {
@@ -302,6 +311,38 @@ export function ThemeSettingsEditor({
                           hideGlobalSettings
                         />
                       </div>
+                      <div className="mt-2">
+                        <div className="flex flex-row gap-1">
+                          <h5 className="text-sm">Border Radius</h5>
+                          <ThemeSettingsTooltip text="Set the border radius for all Fidgets on your Space." />
+                        </div>
+                        <Slider
+                          value={parseInt(fidgetBorderRadius)}
+                          min={0}
+                          max={32}
+                          step={1}
+                          onChange={(_, v) =>
+                            themePropSetter<string>("fidgetBorderRadius")(
+                              `${v}px`,
+                            )
+                          }
+                        />
+                      </div>
+                      <div className="mt-2">
+                        <div className="flex flex-row gap-1">
+                          <h5 className="text-sm">Spacing</h5>
+                          <ThemeSettingsTooltip text="Set spacing between Fidgets on the grid." />
+                        </div>
+                        <Slider
+                          value={parseInt(gridSpacing)}
+                          min={0}
+                          max={40}
+                          step={1}
+                          onChange={(_, v) =>
+                            themePropSetter<string>("gridSpacing")(String(v))
+                          }
+                        />
+                      </div>
                     </div>
                   </div>
                 </TabsContent>
@@ -415,10 +456,11 @@ const BackgroundGenerator = ({
   const [generateText, setGenerateText] = useState("Generate");
   const [showBanner, setShowBanner] = useState(false);
   const [buttonDisabled, setButtonDisabled] = useState(false);
-  const [internalBackgroundHTML, setInternalBackgroundHTML] = useState(backgroundHTML);
+  const [internalBackgroundHTML, setInternalBackgroundHTML] =
+    useState(backgroundHTML);
   const timersRef = useRef<number[]>([]);
   const { showToast } = useToastStore();
-  
+
   // Sync internal state with props when backgroundHTML changes
   useEffect(() => {
     setInternalBackgroundHTML(backgroundHTML);
@@ -431,7 +473,7 @@ const BackgroundGenerator = ({
     "Floating bubble circles",
     "Calm teal radial glow",
     "Lush green rainforest",
-    "Animated purple gradient"
+    "Animated purple gradient",
   ];
 
   const { user } = usePrivy();
@@ -495,15 +537,16 @@ const BackgroundGenerator = ({
       setGenerateText(messages[index]);
     }, 8000);
     timersRef.current = [intervalId];
-    
+
     // If field is empty, use a random prompt from the list
-    const inputText = internalBackgroundHTML.trim() === "" 
-      ? randomPrompts[Math.floor(Math.random() * randomPrompts.length)]
-      : internalBackgroundHTML;
+    const inputText =
+      internalBackgroundHTML.trim() === ""
+        ? randomPrompts[Math.floor(Math.random() * randomPrompts.length)]
+        : internalBackgroundHTML;
 
     if (process.env.NODE_ENV !== "production")
       console.log(`inputText: ${inputText}`);
-      
+
     handleGenerateBackground(inputText);
   };
 

--- a/src/common/lib/theme/UserThemeProvider.tsx
+++ b/src/common/lib/theme/UserThemeProvider.tsx
@@ -69,6 +69,8 @@ export const UserThemeProvider = ({ children }) => {
     fidgetBorderWidth,
     fidgetBorderColor,
     fidgetShadow,
+    fidgetBorderRadius,
+    gridSpacing,
   } = userTheme.properties;
 
   useEffect(() => {
@@ -121,6 +123,17 @@ export const UserThemeProvider = ({ children }) => {
   useEffect(() => {
     setGlobalStyleProperty("--user-theme-fidget-shadow", fidgetShadow);
   }, [fidgetShadow]);
+
+  useEffect(() => {
+    setGlobalStyleProperty(
+      "--user-theme-fidget-border-radius",
+      fidgetBorderRadius,
+    );
+  }, [fidgetBorderRadius]);
+
+  useEffect(() => {
+    setGlobalStyleProperty("--user-theme-grid-spacing", gridSpacing);
+  }, [gridSpacing]);
 
   return children;
 };

--- a/src/common/lib/theme/defaultTheme.ts
+++ b/src/common/lib/theme/defaultTheme.ts
@@ -15,6 +15,8 @@ export const defaultUserTheme: UserTheme = {
     fidgetBorderWidth: "1px",
     fidgetBorderColor: "#eeeeee",
     fidgetShadow: "none",
+    fidgetBorderRadius: "12px",
+    gridSpacing: "16",
   },
 };
 

--- a/src/common/lib/theme/index.d.ts
+++ b/src/common/lib/theme/index.d.ts
@@ -17,6 +17,8 @@ export interface UserTheme extends ThemeSettings {
     fidgetBorderWidth: string;
     fidgetBorderColor: Color;
     fidgetShadow: string;
+    fidgetBorderRadius: string;
+    gridSpacing: string;
   };
 }
 

--- a/src/constants/homePageTabsConfig.tsx
+++ b/src/constants/homePageTabsConfig.tsx
@@ -114,6 +114,8 @@ export const PRESS_TAB_CONFIG: SpaceConfig = {
       headingsFont: "Poppins",
       headingsFontColor: "#000000",
       musicURL: "https://www.youtube.com/watch?v=dMXlZ4y7OK4&t=1804",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
     },
   },
   fidgetInstanceDatums: {
@@ -610,6 +612,8 @@ export const NOUNS_TAB_CONFIG: SpaceConfig = {
       headingsFont: "Poppins",
       headingsFontColor: "#000000",
       musicURL: "https://www.youtube.com/watch?v=dMXlZ4y7OK4&t=1804",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
     },
   },
   fidgetInstanceDatums: {
@@ -1122,6 +1126,8 @@ export const NOUNSPACE_TAB_CONFIG: SpaceConfig = {
       headingsFont: "Poppins",
       headingsFontColor: "#000000",
       musicURL: "https://www.youtube.com/watch?v=dMXlZ4y7OK4&t=1804",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
     },
   },
 };

--- a/src/constants/initialContractSpace.ts
+++ b/src/constants/initialContractSpace.ts
@@ -426,6 +426,8 @@ export const createInitialContractSpaceConfigForAddress = (
       headingsFont: "Inter",
       headingsFontColor: "#000000",
       musicURL: "https://www.youtube.com/watch?v=dMXlZ4y7OK4&t=1804",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
     },
   };
 

--- a/src/constants/initialProposalSpace.ts
+++ b/src/constants/initialProposalSpace.ts
@@ -390,6 +390,8 @@ export const createInitalProposalSpaceConfigForProposalId = (
       headingsFont: "Londrina Solid",
       headingsFontColor: "#000000",
       musicURL: "https://www.youtube.com/watch?v=dMXlZ4y7OK4&t=1804",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
     },
   };
 

--- a/src/constants/themes.ts
+++ b/src/constants/themes.ts
@@ -26,6 +26,8 @@ export const THEMES = [
       fidgetBorderWidth: "1px",
       fidgetBorderColor: "#C0C0C0",
       fidgetShadow: "none",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
     },
   },
   {
@@ -43,6 +45,8 @@ export const THEMES = [
       fidgetBorderWidth: "1px",
       fidgetBorderColor: "#ffffff",
       fidgetShadow: "none",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
     },
   },
   {
@@ -60,6 +64,8 @@ export const THEMES = [
       fidgetBorderWidth: "1px",
       fidgetBorderColor: "#ffffff",
       fidgetShadow: "none",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
     },
   },
   {
@@ -77,6 +83,8 @@ export const THEMES = [
       fidgetBorderWidth: "0",
       fidgetBorderColor: "transparent",
       fidgetShadow: "none",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
     },
   },
   {
@@ -94,6 +102,8 @@ export const THEMES = [
       fidgetBorderWidth: "0",
       fidgetBorderColor: "transparent",
       fidgetShadow: "0 5px 15px rgba(0,0,0,0.55)",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
     },
   },
   {
@@ -111,6 +121,8 @@ export const THEMES = [
       fidgetBorderWidth: "1px",
       fidgetBorderColor: "#FACA15",
       fidgetShadow: "none",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
     },
   },
   {
@@ -128,6 +140,8 @@ export const THEMES = [
       fidgetBorderWidth: "4px",
       fidgetBorderColor: "#FFFFFF",
       fidgetShadow: "none",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
     },
   },
   {
@@ -145,6 +159,8 @@ export const THEMES = [
       fidgetBorderWidth: "2px",
       fidgetBorderColor: "#F8B4D9",
       fidgetShadow: "none",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
     },
   },
   {
@@ -163,6 +179,8 @@ export const THEMES = [
       fidgetBorderWidth: "2px",
       fidgetBorderColor: "#90A5B9",
       fidgetShadow: "none",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
     },
   },
   {
@@ -180,6 +198,8 @@ export const THEMES = [
       fidgetBorderWidth: "2px",
       fidgetBorderColor: "#F05252",
       fidgetShadow: "0 5px 15px rgba(0,0,0,0.55)",
+      fidgetBorderRadius: "12px",
+      gridSpacing: "16",
     },
   },
 ];

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -561,12 +561,18 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
               return (
                 <div
                   key={gridItem.i}
-                  className={`grid-item ${
-                    selectedFidgetID === gridItem.i
-                      ? "outline outline-4 outline-offset-1 outline-sky-600"
-                      : ""
-                  }`}
-                  style={{ borderRadius: gridDetails.borderRadius }}
+                  className="grid-item"
+                  style={{
+                    borderRadius: gridDetails.borderRadius,
+                    outline:
+                      selectedFidgetID === gridItem.i
+                        ? "4px solid rgb(2 132 199)" /* sky-600 */
+                        : undefined,
+                    outlineOffset:
+                      selectedFidgetID === gridItem.i
+                        ? -parseInt(theme.properties.fidgetBorderWidth ?? "0")
+                        : undefined,
+                  }}
                 >
                   <FidgetWrapper
                     fidget={fidgetModule.fidget}

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -61,7 +61,12 @@ export interface PlacedGridItem extends GridItem {
   isBounded?: boolean;
 }
 
-const makeGridDetails = (hasProfile: boolean, hasFeed: boolean) => ({
+const makeGridDetails = (
+  hasProfile: boolean,
+  hasFeed: boolean,
+  spacing: number,
+  borderRadius: string,
+) => ({
   items: 0,
   isDroppable: true,
   isBounded: false,
@@ -73,8 +78,9 @@ const makeGridDetails = (hasProfile: boolean, hasFeed: boolean) => ({
   maxRows: hasProfile ? 8 : 10,
   rowHeight: 70,
   layout: [],
-  margin: [16, 16],
-  containerPadding: [16, 16],
+  margin: [spacing, spacing],
+  containerPadding: [spacing, spacing],
+  borderRadius,
 });
 
 type GridDetails = ReturnType<typeof makeGridDetails>;
@@ -89,6 +95,7 @@ const Gridlines: React.FC<GridDetails> = ({
   rowHeight,
   margin,
   containerPadding,
+  borderRadius,
 }) => {
   return (
     <div
@@ -106,11 +113,11 @@ const Gridlines: React.FC<GridDetails> = ({
     >
       {[...Array(cols * maxRows)].map((_, i) => (
         <div
-          className="rounded-lg"
           key={i}
           style={{
             backgroundColor: "rgba(200, 227, 248, 0.5)",
             outline: "2px dashed rgba(200, 227, 248, 0.3)",
+            borderRadius,
           }}
         />
       ))}
@@ -153,8 +160,19 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   const [isPickingFidget, setIsPickingFidget] = useState(false);
 
   const gridDetails = useMemo(
-    () => makeGridDetails(hasProfile, hasFeed),
-    [hasProfile, hasFeed],
+    () =>
+      makeGridDetails(
+        hasProfile,
+        hasFeed,
+        parseInt(theme.properties.gridSpacing ?? "16"),
+        theme.properties.fidgetBorderRadius ?? "12px",
+      ),
+    [
+      hasProfile,
+      hasFeed,
+      theme.properties.gridSpacing,
+      theme.properties.fidgetBorderRadius,
+    ],
   );
 
   const saveTrayContents = async (newTrayData: typeof fidgetTrayContents) => {
@@ -203,7 +221,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     debounce((config) => {
       saveConfig(config);
     }, 100),
-    [saveConfig]
+    [saveConfig],
   );
 
   function unselectFidget() {
@@ -264,7 +282,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
           gridDetails.containerPadding[0] * 2) /
           gridDetails.maxRows
       : gridDetails.rowHeight;
-  }, [height, hasProfile]);
+  }, [height, hasProfile, gridDetails.margin, gridDetails.containerPadding]);
 
   function handleDrop(
     _layout: PlacedGridItem[],
@@ -326,28 +344,35 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     saveLayout(newLayout);
   }
 
-  function removeFidgetFromInstanceDatums(fidgetId: string){
-      // New set of instances - use computed property name to remove the correct fidget
-      const { [fidgetId]: removed, ...newFidgetInstanceDatums } = fidgetInstanceDatums;
+  function removeFidgetFromInstanceDatums(fidgetId: string) {
+    // New set of instances - use computed property name to remove the correct fidget
+    const { [fidgetId]: removed, ...newFidgetInstanceDatums } =
+      fidgetInstanceDatums;
 
-      saveFidgetInstanceDatums(newFidgetInstanceDatums);
+    saveFidgetInstanceDatums(newFidgetInstanceDatums);
   }
 
   function removeFidget(fidgetId: string) {
     unselectFidget();
 
     // Create new state objects
-    const newLayout = layoutConfig.layout.filter(item => item.i !== fidgetId);
-    const newTrayContents = fidgetTrayContents.filter(fidget => fidget.id !== fidgetId);
-    const { [fidgetId]: removed, ...newFidgetInstanceDatums } = fidgetInstanceDatums;
-    
+    const newLayout = layoutConfig.layout.filter((item) => item.i !== fidgetId);
+    const newTrayContents = fidgetTrayContents.filter(
+      (fidget) => fidget.id !== fidgetId,
+    );
+    const { [fidgetId]: removed, ...newFidgetInstanceDatums } =
+      fidgetInstanceDatums;
+
     console.log("newFidgetInstanceDatums", newFidgetInstanceDatums);
     // Only save if we have fidgets left or if we're removing the last one
-    if (Object.keys(newFidgetInstanceDatums).length > 0 || newLayout.length === 0) {
+    if (
+      Object.keys(newFidgetInstanceDatums).length > 0 ||
+      newLayout.length === 0
+    ) {
       debouncedSaveConfig({
         layoutConfig: { layout: newLayout },
         fidgetTrayContents: newTrayContents,
-        fidgetInstanceDatums: newFidgetInstanceDatums
+        fidgetInstanceDatums: newFidgetInstanceDatums,
       });
     }
   }
@@ -372,7 +397,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
       newLayout.length === layoutConfig.layout.length
     ) {
       debouncedSaveConfig({
-        layoutConfig: { layout: newLayout }
+        layoutConfig: { layout: newLayout },
       });
     }
   }
@@ -427,7 +452,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
           // Save both layout and fidgetInstanceDatums in a single operation
           debouncedSaveConfig({
             layoutConfig: { layout: [...layoutConfig.layout, newItem] },
-            fidgetInstanceDatums: { ...fidgetInstanceDatums, [id]: fidget }
+            fidgetInstanceDatums: { ...fidgetInstanceDatums, [id]: fidget },
           });
 
           analytics.track(AnalyticsEvent.ADD_FIDGET, {
@@ -538,9 +563,10 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
                   key={gridItem.i}
                   className={`grid-item ${
                     selectedFidgetID === gridItem.i
-                      ? "outline outline-4 outline-offset-1 rounded-2xl outline-sky-600"
+                      ? "outline outline-4 outline-offset-1 outline-sky-600"
                       : ""
                   }`}
+                  style={{ borderRadius: gridDetails.borderRadius }}
                 >
                   <FidgetWrapper
                     fidget={fidgetModule.fidget}


### PR DESCRIPTION
## Summary
- allow configuring fidget border radius and grid spacing in theme
- store new values in themes and default theme
- apply radius and spacing in grid layout and fidget wrapper
- expose CSS variables for new theme values
- add sliders in theme editor for new settings

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f1159b8f4832593456fd1c26acb4d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added customizable border radius and grid spacing options to theme settings, allowing users to adjust the appearance of fidgets and grid layouts.
  - Introduced sliders in the theme editor for real-time adjustment of border radius and spacing values.

- **Style**
  - Updated fidget and grid components to use dynamic, theme-driven border radius and spacing, providing a more consistent and customizable look across the app.
  - Improved selection outlines and styling for fidgets based on theme properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->