### PR TITLE
Remove mobile fidget ordering overrides

### DIFF
--- a/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
+++ b/src/fidgets/layout/tabFullScreen/components/TabNavigation.tsx
@@ -48,38 +48,8 @@ const TabNavigation: React.FC<TabNavigationProps> = ({
   // Safe check for processedFidgetIds to prevent "Cannot read properties of undefined (reading 'length')" error
   if (!processedFidgetIds || processedFidgetIds.length <= 1) return null;
   
-  // Function to check if a fidget is a feed type
-  const isFeedFidget = (fidgetId: string): boolean => {
-    const fidgetDatum = fidgetInstanceDatums[fidgetId];
-    if (!fidgetDatum) return false;
-    
-    return fidgetDatum.fidgetType === 'feed';
-  };
-  
-  const pathname = usePathname();
-  const isHomebasePath = pathname?.startsWith('/homebase');
-  const isHomePath = pathname?.startsWith('/home');
-
-  // Reorder tabs to prioritize feed fidgets
-  const orderedFidgetIds = useMemo(() => {
-    if (!processedFidgetIds || processedFidgetIds.length <= 1) return processedFidgetIds;
-    if (isHomebasePath || isHomePath) return processedFidgetIds;
-    
-    // Create a copy of the array to avoid mutating the original
-    const reorderedIds = [...processedFidgetIds];
-    
-    // Sort the array to move feed fidgets to the beginning
-    reorderedIds.sort((a, b) => {
-      const aIsFeed = isFeedFidget(a);
-      const bIsFeed = isFeedFidget(b);
-      
-      if (aIsFeed && !bIsFeed) return -1; // a is feed, b is not, so a comes first
-      if (!aIsFeed && bIsFeed) return 1;  // b is feed, a is not, so b comes first
-      return 0; // Keep original relative order if both are feeds or both are not feeds
-    });
-    
-    return reorderedIds;
-  }, [processedFidgetIds, fidgetInstanceDatums, isHomebasePath, isHomePath]);
+  // Keep the provided order of fidgets
+  const orderedFidgetIds = processedFidgetIds;
 
   // Enhanced scroll handler to calculate gradient opacities based on scroll position
   const handleScroll = () => {

--- a/src/fidgets/layout/tabFullScreen/index.tsx
+++ b/src/fidgets/layout/tabFullScreen/index.tsx
@@ -47,9 +47,6 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
   const viewportMobile = useIsMobile();
   const { mobilePreview } = useMobilePreview();
   const isMobile = viewportMobile || mobilePreview;
-  const pathname = usePathname();
-  const isHomebasePath = pathname?.startsWith('/homebase');
-  const isHomePath = pathname?.startsWith('/home');
   
   // Process fidgets and prepare data for rendering
   const validFidgetIds = useMemo(() => 
@@ -85,38 +82,10 @@ const TabFullScreen: LayoutFidget<TabFullScreenProps> = ({
     return bundles;
   }, [validFidgetIds, fidgetInstanceDatums]);
 
-  // Function to check if a fidget is a feed type
-  const isFeedFidget = (fidgetId: string): boolean => {
-    const fidgetDatum = fidgetInstanceDatums[fidgetId];
-    if (!fidgetDatum) return false;
-    
-    return fidgetDatum.fidgetType === 'feed';
-  };
-  
-  // Get ordered fidget IDs with feed prioritized (except in homebase)
-  const orderedFidgetIds = useMemo(() => {
-    if (!processedFidgetIds || processedFidgetIds.length <= 1) return processedFidgetIds;
-    
-    // If we're in homebase or home path, don't reorder
-    if (isHomebasePath || isHomePath) return processedFidgetIds;
-    
-    // Create a copy of the array to avoid mutating the original
-    const reorderedIds = [...processedFidgetIds];
-    
-    // Sort the array to move feed fidgets to the beginning
-    reorderedIds.sort((a, b) => {
-      const aIsFeed = isFeedFidget(a);
-      const bIsFeed = isFeedFidget(b);
-      
-      if (aIsFeed && !bIsFeed) return -1; // a is feed, b is not, so a comes first
-      if (!aIsFeed && bIsFeed) return 1;  // b is feed, a is not, so b comes first
-      return 0; // Keep original relative order if both are feeds or both are not feeds
-    });
-    
-    return reorderedIds;
-  }, [processedFidgetIds, fidgetInstanceDatums, isHomebasePath]);
+  // Use the processed fidget order as is
+  const orderedFidgetIds = processedFidgetIds;
 
-  // Initialize with the first fidget ID from orderedFidgetIds (feed will be first if it exists)
+  // Initialize with the first fidget ID from the processed order
   const [selectedTab, setSelectedTab] = useState(
     orderedFidgetIds.length > 0 ? orderedFidgetIds[0] : ""
   );


### PR DESCRIPTION
Now that users can customize the order of fidgets on the mobile version of their space, this removes the hardcoded logic that prioritized the Feed and Media fidgets.

## Summary
- stop reordering tabs around feed fidgets
- preserve original fidget order when consolidating media on mobile

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683f1d0cba308325acfe8b6f3253e9fb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated tab navigation to use the original order of items without prioritizing "feed" type fidgets.
  - Simplified logic for processing and displaying tab fidget IDs, ensuring consolidated items appear in original order and respect mobile visibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->