### PR TITLE
Prevent homebase grid rerender

### DIFF
--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -120,7 +120,7 @@ const Gridlines: React.FC<GridDetails> = ({
 
 type GridLayoutProps = LayoutFidgetProps<GridLayoutConfig>;
 
-const Grid: LayoutFidget<GridLayoutProps> = ({
+const GridComponent: LayoutFidget<GridLayoutProps> = ({
   fidgetInstanceDatums,
   fidgetTrayContents,
   layoutConfig,
@@ -566,5 +566,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     </>
   );
 };
+
+const Grid = React.memo(GridComponent) as LayoutFidget<GridLayoutProps>;
 
 export default Grid;


### PR DESCRIPTION
## Summary
- memoize `Grid` layout component to avoid unnecessary rerenders when fidget content changes

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683f204001e48325a333c667886568d4