### PR TITLE
Fix homebase feed cast navigation

### DIFF
--- a/src/app/(spaces)/homebase/[tabname]/page.tsx
+++ b/src/app/(spaces)/homebase/[tabname]/page.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import React from "react";
-import { useParams } from "next/navigation";
-import PrivateSpace from "../PrivateSpace";
 
-const HomebaseTabPage = () => {
-  const params = useParams<{ tabname: string }>();
-  const tabName = decodeURIComponent(params?.tabname ?? "");
-
-  return <PrivateSpace tabName={tabName} />;
-};
+const HomebaseTabPage = () => null;
 
 export default HomebaseTabPage;

--- a/src/app/(spaces)/homebase/c/[caster]/[castHash]/page.tsx
+++ b/src/app/(spaces)/homebase/c/[caster]/[castHash]/page.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import React from "react";
-import { useParams } from "next/navigation";
-import PrivateSpace from "../../../PrivateSpace";
 
-const HomebaseCastPage = () => {
-  const params = useParams<{ caster: string; castHash: string }>();
-  const castHash = decodeURIComponent(params?.castHash ?? "");
-  return <PrivateSpace tabName="Feed" castHash={castHash} />;
-};
+const HomebaseCastPage = () => null;
 
 export default HomebaseCastPage;

--- a/src/app/(spaces)/homebase/layout.tsx
+++ b/src/app/(spaces)/homebase/layout.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import React from 'react';
+import { useParams } from 'next/navigation';
+import PrivateSpace from './PrivateSpace';
+
+export default function HomebaseLayout({ children }: { children: React.ReactNode }) {
+  const params = useParams<{
+    tabname?: string;
+    caster?: string;
+    castHash?: string;
+  }>();
+
+  const tabName = params?.tabname ? decodeURIComponent(params.tabname) : 'Feed';
+  const castHash = params?.castHash ? decodeURIComponent(params.castHash) : undefined;
+
+  return <PrivateSpace tabName={tabName} castHash={castHash} />;
+}

--- a/src/app/(spaces)/homebase/page.tsx
+++ b/src/app/(spaces)/homebase/page.tsx
@@ -1,8 +1,5 @@
 import React from "react";
-import PrivateSpace from "./PrivateSpace";
 
-const HomebaseFeedPage = () => {
-  return <PrivateSpace tabName="Feed" />;
-};
+const HomebaseFeedPage = () => null;
 
 export default HomebaseFeedPage;


### PR DESCRIPTION
## Summary
- create a client layout for homebase that keeps `PrivateSpace` mounted
- make homebase pages empty since layout renders the content

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683f222dab5c832597f4f3deebed4ae9