### PR TITLE
Add share link copy for casts

### DIFF
--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -32,6 +32,8 @@ import ExpandableText from "@/common/components/molecules/ExpandableText";
 import { trackAnalyticsEvent } from "@/common/lib/utils/analyticsUtils";
 import { AnalyticsEvent } from "@/common/providers/AnalyticsProvider";
 import { FaReply } from "react-icons/fa6";
+import { IoMdShare } from "react-icons/io";
+import { toast } from "sonner";
 
 function isEmbedUrl(maybe: unknown): maybe is EmbedUrl {
   return isObject(maybe) && typeof maybe["url"] === "string";
@@ -420,7 +422,7 @@ const CastReactions = ({ cast }: { cast: CastWithInteractions }) => {
           <CreateCast initialDraft={replyCastDraft} />
         </div>
       </Modal>
-      <div className="-ml-1.5 flex space-x-3">
+      <div className="-ml-1.5 flex items-center space-x-3 w-full">
         {Object.entries(reactions).map(([key, reactionInfo]) => {
           const isActive = get(reactionInfo, "isActive", false);
           const icon = getIconForCastReactionType(
@@ -468,6 +470,17 @@ const CastReactions = ({ cast }: { cast: CastWithInteractions }) => {
             /{cast.channel.name}
           </div>
         )}
+        <div
+          className="ml-auto mt-1.5 flex cursor-pointer text-sm opacity-50 hover:text-foreground/85 hover:bg-background/85 py-1 px-1.5 rounded-md"
+          onClick={(e) => {
+            e.stopPropagation();
+            const url = `${window.location.origin}/homebase/c/${cast.author.username}/${cast.hash}`;
+            navigator.clipboard.writeText(url);
+            toast("Link copied to clipboard.");
+          }}
+        >
+          <IoMdShare className="w-4 h-4" aria-hidden="true" />
+        </div>
       </div>
     </>
   );

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -33,7 +33,7 @@ import { trackAnalyticsEvent } from "@/common/lib/utils/analyticsUtils";
 import { AnalyticsEvent } from "@/common/providers/AnalyticsProvider";
 import { FaReply } from "react-icons/fa6";
 import { IoMdShare } from "react-icons/io";
-import { toast } from "sonner";
+import { useToastStore } from "@/common/data/stores/toastStore";
 
 function isEmbedUrl(maybe: unknown): maybe is EmbedUrl {
   return isObject(maybe) && typeof maybe["url"] === "string";
@@ -245,6 +245,7 @@ const CastReactions = ({ cast }: { cast: CastWithInteractions }) => {
   const [didLike, setDidLike] = useState(false);
   const [didRecast, setDidRecast] = useState(false);
   const { signer, fid: userFid } = useFarcasterSigner("render-cast");
+  const { showToast } = useToastStore();
 
   const authorFid = cast.author.fid;
   const castHashBytes = hexToBytes(cast.hash.slice(2));
@@ -476,7 +477,7 @@ const CastReactions = ({ cast }: { cast: CastWithInteractions }) => {
             e.stopPropagation();
             const url = `${window.location.origin}/homebase/c/${cast.author.username}/${cast.hash}`;
             navigator.clipboard.writeText(url);
-            toast("Link copied to clipboard.");
+            showToast("Link copied", 2000);
           }}
         >
           <IoMdShare className="w-4 h-4" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- allow copying cast links to clipboard

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683f2a2487408325b3d4bd547d9aa7bd