### PR TITLE
Fix: Improve cast formatting

### DIFF
--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -132,7 +132,6 @@ export function FidgetWrapper({
             ? "absolute -mt-7 opacity-80 transition-opacity ease-in flex flex-row h-6"
             : "absolute opacity-0 transition-opacity ease-in flex flex-row h-6"
         }
-        style={{ zIndex: 999999 }}
       >
         <Card className="h-full grabbable rounded-lg w-6 flex items-center justify-center bg-[#F3F4F6] hover:bg-sky-100 text-[#1C64F2]">
           <TooltipProvider>

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -132,6 +132,7 @@ export function FidgetWrapper({
             ? "absolute -mt-7 opacity-80 transition-opacity ease-in flex flex-row h-6"
             : "absolute opacity-0 transition-opacity ease-in flex flex-row h-6"
         }
+        style={{ zIndex: 999999 }}
       >
         <Card className="h-full grabbable rounded-lg w-6 flex items-center justify-center bg-[#F3F4F6] hover:bg-sky-100 text-[#1C64F2]">
           <TooltipProvider>

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -453,25 +453,17 @@ const CreateCast: React.FC<CreateCastProps> = ({
           const mentions = [];
           mentionsText = text;
 
-          for (let i = 0; i < mentionsText.length; i++) {
-            if (
-              mentionsText[i] === "@" &&
-              ((mentionsText[i - 1] !== "/" &&
-                !/^[a-zA-Z0-9]+$/.test(mentionsText[i - 1])) ||
-                mentionsText[i - 1] === undefined)
-            ) {
-              let mentionIndex = i + 1;
-              while (
-                mentionIndex < mentionsText.length &&
-                mentionsText[mentionIndex] !== " " &&
-                mentionsText[mentionIndex] !== "\n"
-              )
-                mentionIndex++;
-              const mention = mentionsText.substring(i + 1, mentionIndex);
-              const position = i;
-              mentionsPositions.push(position);
-              mentionsText = mentionsText.replace(`@${mention}`, "");
-            }
+          // Use the same regex pattern to find mentions for text replacement
+          const mentionMatches = [...mentionsText.matchAll(usernamePattern)];
+          
+          for (const match of mentionMatches) {
+            const fullMatch = match[0]; // Full match including leading space/parenthesis
+            const username = match[1]; // Just the username
+            const position = match.index! + fullMatch.indexOf("@");
+            
+            mentionsPositions.push(position);
+            // Only replace the @username part, preserving any trailing punctuation
+            mentionsText = mentionsText.replace(`@${username}`, "");
           }
 
           if (mentions.length > 10)

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -401,8 +401,8 @@ const CreateCast: React.FC<CreateCastProps> = ({
       const newEmbeds = initialEmbeds ? [...embeds, ...initialEmbeds] : embeds;
 
       // Regex to match pure @username mentions, ensuring it's not part of a URL
-      // const usernamePattern = /(?:^|\s|^)@([a-zA-Z0-9_.]+)(?=\s|$)/g;
-      const usernamePattern = /(?:^|\s)@([a-zA-Z0-9_.-]+)(?=\s|$)/g;
+      // Updated to handle punctuation after mentions and parentheses before mentions
+      const usernamePattern = /(?:^|\s|[(])@([a-zA-Z0-9_-]+(?:\.[a-zA-Z0-9_-]+)*)/g;
 
       // The working copy of the text for position calculation
       const workingText = text;

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -360,7 +360,7 @@ const CreateCast: React.FC<CreateCastProps> = ({
     fetchUrlMetadata: getUrlMetadata,
     onError,
     onSubmit: onSubmitPost,
-    linkClassName: "text-blue-300",
+    linkClassName: "text-blue-800",
     renderChannelsSuggestionConfig: createRenderMentionsSuggestionConfig({
       getResults: debouncedGetChannels,
       RenderList: ChannelList,

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -99,9 +99,9 @@ const getUrlMetadata = fetchUrlMetadata(API_URL);
 
 const onError = (err) => {
   console.error(err);
-  // if (process.env.NEXT_PUBLIC_VERCEL_ENV === "development") {
-  //   window.alert(err.message);
-  // }
+  if (process.env.NEXT_PUBLIC_VERCEL_ENV === "development") {
+    window.alert(err.message);
+  }
 };
 
 export type ParentCastIdType = {
@@ -397,8 +397,7 @@ const CreateCast: React.FC<CreateCastProps> = ({
     if (isPublishing) return;
 
     const fetchMentionsAndSetDraft = async () => {
-      console.group("Mention Parsing");
-
+      // console.group("Mention Parsing");
       const newEmbeds = initialEmbeds ? [...embeds, ...initialEmbeds] : embeds;
 
       // Regex to match pure @username mentions, ensuring it's not part of a URL
@@ -424,7 +423,7 @@ const CreateCast: React.FC<CreateCastProps> = ({
         new Set(usernamesWithPositions.map((u) => u.username)),
       );
 
-      console.log("Parsed mentions from text:", usernamesWithPositions);
+      // console.log("Parsed mentions from text:", usernamesWithPositions);
 
       const mentionsToFids: { [key: string]: string } = {};
       const mentionsPositions: number[] = [];
@@ -480,7 +479,7 @@ const CreateCast: React.FC<CreateCastProps> = ({
         //   }
 
 
-          console.log("Resolved mentions to FIDs:", mentionsToFids);
+          // console.log("Resolved mentions to FIDs:", mentionsToFids);
 
           let cumulativeOffset = 0;
           const mentionMatches = [...text.matchAll(usernamePattern)];
@@ -519,7 +518,7 @@ const CreateCast: React.FC<CreateCastProps> = ({
         // }
       }
 
-      console.groupEnd();
+      // console.groupEnd();
 
       // Update the draft regardless of mentions
       setDraft((prevDraft) => {
@@ -531,7 +530,7 @@ const CreateCast: React.FC<CreateCastProps> = ({
           mentionsToFids,
           mentionsPositions,
         };
-        console.log("Updated Draft before posting:", updatedDraft);
+        // console.log("Updated Draft before posting:", updatedDraft);
         return updatedDraft;
       });
     };

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -430,7 +430,7 @@ const CreateCast: React.FC<CreateCastProps> = ({
       console.log("Parsed mentions from text:", usernamesWithPositions);
 
       let mentionsToFids: { [key: string]: string } = {};
-      let mentionsPositions: number[] = [];
+      const mentionsPositions: number[] = [];
       let mentionsText = text; // Initialize mentionsText with current text
 
       if (uniqueUsernames.length > 0) {


### PR DESCRIPTION
This improves the regex pattern used for formatting casts and fixes the issue where users could not publish casts that contained punctuation right after a mention.

The updated regex now properly handles:

- Punctuation after mentions: "hey @vitalik, what's up?" now works correctly
- Mentions in parentheses: "(@user)" scenarios are handled
- Multiple edge cases: Periods, exclamation marks, colons, etc.
- URL exclusion: Still prevents matching @mentions within URLs
- Domain usernames: Supports usernames like @alice.eth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved mention parsing to support ENS-style usernames and trailing punctuation.
  - Mentions are now resolved more efficiently with caching, resulting in faster and more reliable mention handling.

- **Bug Fixes**
  - Enhanced error messages now provide more detailed feedback when cast data is invalid.

- **Style**
  - Updated editor link color for better visibility.

- **Chores**
  - Cleaned up unused imports and removed legacy commented code for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->