### PR TITLE
Fix space loading loop

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -236,12 +236,11 @@ export default function PublicSpace({
         !!localSpaces[currentSpaceId]?.order &&
         localSpaces[currentSpaceId].order.length > 0;
 
-      if (hasCachedTab && hasCachedOrder) {
+      if (!hasCachedTab || !hasCachedOrder) {
+        setLoading(true);
+      } else {
         setLoading(false);
-        return;
       }
-
-      setLoading(true);
       loadSpaceTabOrder(currentSpaceId)
         .then(() => {
           console.log("Loaded space tab order");

--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -217,7 +217,6 @@ export default function PublicSpace({
     contractAddress,
     tokenData?.network,
     spaceOwnerFid,
-    localSpaces,
   ]);
 
   // Loads and sets up the user's space tab when providedSpaceId or providedTabName changes
@@ -237,12 +236,12 @@ export default function PublicSpace({
         !!localSpaces[currentSpaceId]?.order &&
         localSpaces[currentSpaceId].order.length > 0;
 
-      if (!hasCachedTab || !hasCachedOrder) {
-        setLoading(true);
-      } else {
+      if (hasCachedTab && hasCachedOrder) {
         setLoading(false);
+        return;
       }
 
+      setLoading(true);
       loadSpaceTabOrder(currentSpaceId)
         .then(() => {
           console.log("Loaded space tab order");
@@ -265,7 +264,7 @@ export default function PublicSpace({
           setLoading(false);
         });
     }
-  }, [getCurrentSpaceId, getCurrentTabName, localSpaces]);
+  }, [getCurrentSpaceId, getCurrentTabName]);
 
   // Function to load remaining tabs
   const loadRemainingTabs = useCallback(


### PR DESCRIPTION
Solves an issue in canary where the app was getting stuck in an infinite requests loop, which was introduced in #752 

## Summary
- avoid reloading tab info when local data is updated
- bail out early if a tab and its order are already cached

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_683f66939cc8832591759dc7e9434703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved performance by reducing unnecessary updates when switching spaces or tabs. The app now responds only to relevant changes, resulting in a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->