### PR TITLE
Enable scrolling in RSS and X feed fidgets

### DIFF
--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -447,17 +447,15 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
       "https://syndication.twitter.com/srv/timeline-profile/screen-name/" +
       `${Xhandle}?${params.toString()}`;
 
-    const iframeStyle: React.CSSProperties = {
-      border: "none",
-      width: "100%",
-      height: "100%",
-      overflowY: "auto",
-      overflowX: "auto",
-    };
-        style={iframeStyle}
       <iframe
         src={url}
-        style={{ border: "none", width: "100%", height: "100%" }}
+        style={{
+          border: "none",
+          width: "100%",
+          height: "100%",
+          overflowY: "auto",
+          overflowX: "auto",
+        }}
         title="Twitter Feed"
         scrolling="yes"
         frameBorder="0"

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -427,7 +427,7 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
   );
 
   const renderXFeed = () => {
-    const themeSetting = style || "light";
+    const theme = style || "light";
 
     const params = new URLSearchParams({
       dnt: "true",
@@ -439,7 +439,7 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
       hideScrollBar: "false",
       lang: "en",
       origin: "https://publish.twitter.com/#",
-      theme: themeSetting,
+      theme: theme,
       widgetsVersion: "2615f7e52b7e0:1702314776716",
     });
 

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -352,6 +352,13 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
     ? usernameFid.toString()
     : users;
 
+  const extraQueryParams =
+    feedType === FeedType.Filter &&
+    filterType === FilterType.Channel &&
+    membersOnly !== undefined
+      ? { membersOnly }
+      : {};
+
   const {
     data,
     isFetchingNextPage,
@@ -359,19 +366,18 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
     hasNextPage,
     isError,
     isPending,
-    refetch
+    refetch,
   } =
     filterType === FilterType.Keyword
       ? useGetCastsByKeyword({ keyword: keyword || "" })
       : useGetCasts({
-        feedType,
-        fid,
-        filterType,
-        fids: effectiveFids,
-        channel,
-        ...(feedType === FeedType.Filter && filterType === 
-          FilterType.Channel && membersOnly !== undefined ? { membersOnly } : {}),
-      });
+          feedType,
+          fid,
+          filterType,
+          fids: effectiveFids,
+          channel,
+          ...extraQueryParams,
+        });
 
   const threadStackRef = React.useRef(useLifoQueue<string>());
   const threadStack = threadStackRef.current;

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -422,8 +422,13 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
 
   const renderXFeed = () => {
     const theme = style || "light";
-    const url = `https://syndication.twitter.com/srv/timeline-profile/screen-name/${Xhandle}?dnt=true&embedId=twitter-widget-0&frame=false&hideBorder=true&hideFooter=false&hideHeader=false&hideScrollBar=true&lang=en&origin=https%3A%2F%2Fpublish.twitter.com%2F%23&theme=${theme}&widgetsVersion=2615f7e52b7e0%3A1702314776716`;
-
+        style={{
+          border: "none",
+          width: "100%",
+          height: "100%",
+          overflowY: "auto",
+          overflowX: "auto",
+        }}
     return (
       <iframe
         src={url}

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -337,7 +337,7 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
   const {
     selectPlatform = { name: "Farcaster", icon: "/images/farcaster.jpeg" },
     Xhandle,
-    style,
+    style: themeName,
   } = settings;
   const { feedType, users, username, channel, filterType, keyword, membersOnly } = settings;
   const { fid } = useFarcasterSigner("feed");
@@ -427,7 +427,7 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
   );
 
   const renderXFeed = () => {
-    const theme = style || "light";
+    const theme = themeName || "light";
 
     const params = new URLSearchParams({
       dnt: "true",

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -422,7 +422,7 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
 
   const renderXFeed = () => {
     const theme = style || "light";
-    const url = `https://syndication.twitter.com/srv/timeline-profile/screen-name/${Xhandle}?dnt=true&embedId=twitter-widget-0&frame=false&hideBorder=true&hideFooter=false&hideHeader=false&hideScrollBar=false&lang=en&origin=https%3A%2F%2Fpublish.twitter.com%2F%23&theme=${theme}&widgetsVersion=2615f7e52b7e0%3A1702314776716`;
+    const url = `https://syndication.twitter.com/srv/timeline-profile/screen-name/${Xhandle}?dnt=true&embedId=twitter-widget-0&frame=false&hideBorder=true&hideFooter=false&hideHeader=false&hideScrollBar=true&lang=en&origin=https%3A%2F%2Fpublish.twitter.com%2F%23&theme=${theme}&widgetsVersion=2615f7e52b7e0%3A1702314776716`;
 
     return (
       <iframe

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -427,8 +427,23 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
   );
 
   const renderXFeed = () => {
-    const theme = style || "light";
-        style={{
+    const themeSetting = style || "light";
+
+    const params = new URLSearchParams({
+      dnt: "true",
+      embedId: "twitter-widget-0",
+      frame: "false",
+      hideBorder: "true",
+      hideFooter: "false",
+      hideHeader: "false",
+      hideScrollBar: "false",
+      lang: "en",
+      origin: "https://publish.twitter.com/#",
+      theme: themeSetting,
+      widgetsVersion: "2615f7e52b7e0:1702314776716",
+    });
+
+    const url = `https://syndication.twitter.com/srv/timeline-profile/screen-name/${Xhandle}?${params.toString()}`;
           border: "none",
           width: "100%",
           height: "100%",

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -422,14 +422,14 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
 
   const renderXFeed = () => {
     const theme = style || "light";
-    const url = `https://syndication.twitter.com/srv/timeline-profile/screen-name/${Xhandle}?dnt=true&embedId=twitter-widget-0&frame=false&hideBorder=true&hideFooter=false&hideHeader=false&hideScrollBar=true&lang=en&origin=https%3A%2F%2Fpublish.twitter.com%2F%23&theme=${theme}&widgetsVersion=2615f7e52b7e0%3A1702314776716`;
+    const url = `https://syndication.twitter.com/srv/timeline-profile/screen-name/${Xhandle}?dnt=true&embedId=twitter-widget-0&frame=false&hideBorder=true&hideFooter=false&hideHeader=false&hideScrollBar=false&lang=en&origin=https%3A%2F%2Fpublish.twitter.com%2F%23&theme=${theme}&widgetsVersion=2615f7e52b7e0%3A1702314776716`;
 
     return (
       <iframe
         src={url}
         style={{ border: "none", width: "100%", height: "100%" }}
         title="Twitter Feed"
-        scrolling="no"
+        scrolling="yes"
         frameBorder="0"
       />
     );

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -439,18 +439,22 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
       hideScrollBar: "false",
       lang: "en",
       origin: "https://publish.twitter.com/#",
-      theme: theme,
+      theme,
       widgetsVersion: "2615f7e52b7e0:1702314776716",
     });
 
-    const url = `https://syndication.twitter.com/srv/timeline-profile/screen-name/${Xhandle}?${params.toString()}`;
-          border: "none",
-          width: "100%",
-          height: "100%",
-          overflowY: "auto",
-          overflowX: "auto",
-        }}
-    return (
+    const url =
+      "https://syndication.twitter.com/srv/timeline-profile/screen-name/" +
+      `${Xhandle}?${params.toString()}`;
+
+    const iframeStyle: React.CSSProperties = {
+      border: "none",
+      width: "100%",
+      height: "100%",
+      overflowY: "auto",
+      overflowX: "auto",
+    };
+        style={iframeStyle}
       <iframe
         src={url}
         style={{ border: "none", width: "100%", height: "100%" }}

--- a/src/fidgets/ui/rss.tsx
+++ b/src/fidgets/ui/rss.tsx
@@ -157,8 +157,7 @@ export const Rss: React.FC<FidgetArgs<RSSFidgetSettings>> = ({ settings }) => {
   }, [settings.rssUrl]);
 
   return (
-    <div
-    >
+    <div className="h-full overflow-y-auto">
       {rssFeed?.title && (
         <CardHeader className="p-2 ml-5">
           <div className="flex-col items-center">


### PR DESCRIPTION
## Summary
- allow RSS fidget content to scroll when overflowed
- enable scrolling for X feed iframe

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6841b99980848325a18963883cb292b4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled scrolling within the embedded Twitter feed for easier content navigation.
  - Added vertical scrolling and full-height support to the RSS feed display for improved usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->