### PR TITLE
Improve Snapshot fidget responsiveness

### DIFF
--- a/src/fidgets/snapshot/SnapShot.tsx
+++ b/src/fidgets/snapshot/SnapShot.tsx
@@ -189,7 +189,7 @@ export const SnapShot: React.FC<FidgetArgs<SnapShotSettings>> = ({
 
   return (
     <div className="size-full">
-      <CardContent className="size-full overflow-hidden p-4 flex flex-col">
+      <CardContent className="size-full overflow-y-auto overflow-x-hidden p-4 flex flex-col">
         <h1 className="text-2xl font-bold mb-4" style={headingStyle}>
           {settings.snapshotEns} Governance
         </h1>
@@ -198,7 +198,10 @@ export const SnapShot: React.FC<FidgetArgs<SnapShotSettings>> = ({
             {error}
           </p>
         )}
-        <div className="grid gap-2 overflow-auto" style={containerStyle}>
+        <div
+          className="grid gap-2 overflow-y-auto overflow-x-hidden flex-1"
+          style={containerStyle}
+        >
           {proposals.map((proposal) => (
             <ProposalItem
               key={proposal.id}
@@ -218,11 +221,13 @@ export const SnapShot: React.FC<FidgetArgs<SnapShotSettings>> = ({
           ))}
         </div>
 
-        <div className="flex justify-between mt-4">
+        <div className="flex flex-col sm:flex-row sm:justify-between gap-2 mt-4">
           <Button
             variant="primary"
             onClick={handlePrevious}
             disabled={isPreviousDisabled}
+            width="full"
+            className="sm:w-auto"
           >
             <FaAngleLeft /> Previous
           </Button>
@@ -230,6 +235,8 @@ export const SnapShot: React.FC<FidgetArgs<SnapShotSettings>> = ({
             variant="primary"
             onClick={handleNext}
             disabled={isNextDisabled}
+            width="full"
+            className="sm:w-auto"
           >
             Next <FaAngleRight />
           </Button>

--- a/src/fidgets/snapshot/components/CardButton.tsx
+++ b/src/fidgets/snapshot/components/CardButton.tsx
@@ -1,6 +1,5 @@
 import React, { memo, useCallback } from "react";
 import { Button } from "@/common/components/atoms/button";
-import { FaAngleDown } from "react-icons/fa6";
 
 interface CardButtonProps {
   label: string;
@@ -23,14 +22,8 @@ const CardButton: React.FC<CardButtonProps> = memo(
         className={`rounded-full text-slate-600 ${
           isActive ? "bg-slate-100 text-slate-700 border-slate-300" : ""
         }`}
-        withIcon
       >
-        {label}{" "}
-        <FaAngleDown
-          className={`fill-slate-400 transition-all ease-in ${
-            isActive ? "rotate-180" : ""
-          }`}
-        />
+        {label}
       </Button>
     );
   }

--- a/src/fidgets/snapshot/components/ProposalItem.tsx
+++ b/src/fidgets/snapshot/components/ProposalItem.tsx
@@ -150,7 +150,9 @@ const ProposalItem: React.FC<ProposalItemProps> = memo(
         <div
           className="grid grid-cols-1 sm:grid-cols-[4rem_1fr_auto] gap-2 sm:gap-4 items-start"
         >
-          <Badge status={status} className="sm:col-start-2" />
+          <div className="sm:col-start-2">
+            <Badge status={status} />
+          </div>
           <img
             src={currentAvatarUrl}
             alt="Avatar"

--- a/src/fidgets/snapshot/components/ProposalItem.tsx
+++ b/src/fidgets/snapshot/components/ProposalItem.tsx
@@ -147,43 +147,45 @@ const ProposalItem: React.FC<ProposalItemProps> = memo(
         className="p-4 border border-gray-200 bg-white rounded-lg"
         style={bodyStyle}
       >
-        <div className="grid grid-cols-1 sm:grid-cols-[4rem_1fr] gap-4">
+        <div
+          className="grid grid-cols-[4rem_auto] sm:grid-cols-[4rem_1fr_auto] gap-2 sm:gap-4 items-start"
+        >
           <img
             src={currentAvatarUrl}
             alt="Avatar"
             width={64}
             height={64}
-            className="w-16 h-16 rounded-md mr-4 object-cover"
+            className="w-16 h-16 rounded-md object-cover row-span-2 sm:row-auto"
             onError={handleError}
           />
-          <div className="flex flex-col flex-grow">
-            <h4
-              className="font-bold flex flex-wrap items-start gap-2"
-              style={headingStyle}
-            >
-              <span className="break-words flex-1">{proposal.title}</span>
-              <Badge status={status} />
-            </h4>
-            <div className="flex flex-wrap gap-2 mt-4">
-              <CardButton
-                label="Preview"
-                onClick={handleSectionChange}
-                isActive={visibleSection === "preview"}
-                section="preview"
-              />
-              <CardButton
-                label="Results"
-                onClick={handleSectionChange}
-                isActive={visibleSection === "results"}
-                section="results"
-              />
-              <CardButton
-                label="Voting"
-                onClick={handleSectionChange}
-                isActive={visibleSection === "voting"}
-                section="voting"
-              />
-            </div>
+          <div className="self-center">
+            <Badge status={status} />
+          </div>
+          <h4
+            className="font-bold col-span-2 sm:col-span-1 break-words"
+            style={headingStyle}
+          >
+            {proposal.title}
+          </h4>
+          <div className="grid grid-cols-3 gap-2 mt-4 col-span-2 sm:col-span-3">
+            <CardButton
+              label="Preview"
+              onClick={handleSectionChange}
+              isActive={visibleSection === "preview"}
+              section="preview"
+            />
+            <CardButton
+              label="Results"
+              onClick={handleSectionChange}
+              isActive={visibleSection === "results"}
+              section="results"
+            />
+            <CardButton
+              label="Voting"
+              onClick={handleSectionChange}
+              isActive={visibleSection === "voting"}
+              section="voting"
+            />
           </div>
         </div>
 

--- a/src/fidgets/snapshot/components/ProposalItem.tsx
+++ b/src/fidgets/snapshot/components/ProposalItem.tsx
@@ -150,7 +150,7 @@ const ProposalItem: React.FC<ProposalItemProps> = memo(
         <div
           className="grid grid-cols-1 sm:grid-cols-[4rem_1fr_auto] gap-2 sm:gap-4 items-start"
         >
-          <div className="sm:col-start-2">
+          <div className="sm:col-start-1 sm:row-start-1">
             <Badge status={status} />
           </div>
           <img
@@ -158,7 +158,7 @@ const ProposalItem: React.FC<ProposalItemProps> = memo(
             alt="Avatar"
             width={64}
             height={64}
-            className="w-16 h-16 rounded-md object-cover sm:row-span-2 sm:col-start-1"
+            className="w-16 h-16 rounded-md object-cover sm:col-start-1 sm:row-start-2"
             onError={handleError}
           />
           <h4
@@ -167,7 +167,7 @@ const ProposalItem: React.FC<ProposalItemProps> = memo(
           >
             {proposal.title}
           </h4>
-          <div className="grid grid-cols-3 gap-2 mt-4 col-span-2 sm:col-span-3">
+          <div className="grid grid-cols-3 gap-2 mt-2 col-span-2 sm:col-span-3">
             <CardButton
               label="Preview"
               onClick={handleSectionChange}

--- a/src/fidgets/snapshot/components/ProposalItem.tsx
+++ b/src/fidgets/snapshot/components/ProposalItem.tsx
@@ -148,21 +148,19 @@ const ProposalItem: React.FC<ProposalItemProps> = memo(
         style={bodyStyle}
       >
         <div
-          className="grid grid-cols-[4rem_auto] sm:grid-cols-[4rem_1fr_auto] gap-2 sm:gap-4 items-start"
+          className="grid grid-cols-1 sm:grid-cols-[4rem_1fr_auto] gap-2 sm:gap-4 items-start"
         >
+          <Badge status={status} className="sm:col-start-2" />
           <img
             src={currentAvatarUrl}
             alt="Avatar"
             width={64}
             height={64}
-            className="w-16 h-16 rounded-md object-cover row-span-2 sm:row-auto"
+            className="w-16 h-16 rounded-md object-cover sm:row-span-2 sm:col-start-1"
             onError={handleError}
           />
-          <div className="self-center">
-            <Badge status={status} />
-          </div>
           <h4
-            className="font-bold col-span-2 sm:col-span-1 break-words"
+            className="font-bold break-words sm:col-start-2"
             style={headingStyle}
           >
             {proposal.title}

--- a/src/fidgets/snapshot/components/ProposalItem.tsx
+++ b/src/fidgets/snapshot/components/ProposalItem.tsx
@@ -150,7 +150,7 @@ const ProposalItem: React.FC<ProposalItemProps> = memo(
         <div
           className="grid grid-cols-1 sm:grid-cols-[4rem_1fr_auto] gap-2 sm:gap-4 items-start"
         >
-          <div className="sm:col-start-1 sm:row-start-1">
+          <div className="sm:col-start-2 sm:row-start-1">
             <Badge status={status} />
           </div>
           <img
@@ -158,16 +158,16 @@ const ProposalItem: React.FC<ProposalItemProps> = memo(
             alt="Avatar"
             width={64}
             height={64}
-            className="w-16 h-16 rounded-md object-cover sm:col-start-1 sm:row-start-2"
+            className="w-16 h-16 rounded-md object-cover sm:col-start-1 sm:row-start-1 sm:row-span-2"
             onError={handleError}
           />
           <h4
-            className="font-bold break-words sm:col-start-2"
+            className="font-bold break-words sm:col-start-2 sm:row-start-2"
             style={headingStyle}
           >
             {proposal.title}
           </h4>
-          <div className="grid grid-cols-3 gap-2 mt-2 col-span-2 sm:col-span-3">
+          <div className="grid grid-cols-3 gap-2 mt-2 col-span-2 sm:col-span-3 sm:row-start-3">
             <CardButton
               label="Preview"
               onClick={handleSectionChange}

--- a/src/fidgets/snapshot/components/ProposalItem.tsx
+++ b/src/fidgets/snapshot/components/ProposalItem.tsx
@@ -147,25 +147,24 @@ const ProposalItem: React.FC<ProposalItemProps> = memo(
         className="p-4 border border-gray-200 bg-white rounded-lg"
         style={bodyStyle}
       >
-        <div className="grid grid-cols-[4rem_1fr] gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-[4rem_1fr] gap-4">
           <img
             src={currentAvatarUrl}
             alt="Avatar"
             width={64}
             height={64}
-            style={{ width: "auto", height: "auto" }}
-            className="rounded-md mr-4 object-cover"
+            className="w-16 h-16 rounded-md mr-4 object-cover"
             onError={handleError}
           />
           <div className="flex flex-col flex-grow">
             <h4
-              className="font-bold grid grid-cols-[1fr_auto] gap-4 items-start"
+              className="font-bold flex flex-wrap items-start gap-2"
               style={headingStyle}
             >
-              {proposal.title}
+              <span className="break-words flex-1">{proposal.title}</span>
               <Badge status={status} />
             </h4>
-            <div className="flex gap-2 mt-4">
+            <div className="flex flex-wrap gap-2 mt-4">
               <CardButton
                 label="Preview"
                 onClick={handleSectionChange}


### PR DESCRIPTION
## Summary
- make snapshot gov fidget responsive and mobile friendly

Before:
![image](https://github.com/user-attachments/assets/6bc751b7-7990-4c0b-bf07-f8a3cde97a1a)

After:
![image](https://github.com/user-attachments/assets/eb84311f-a3eb-4386-b6d1-6b97497aefc3)

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6841d03ce7c88325a17a1ef8e138fde5