### PR TITLE
Fix z-index for fidget action icons

### DIFF
--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -129,8 +129,8 @@ export function FidgetWrapper({
       <div
         className={
           selectedFidgetID === bundle.id
-            ? "absolute -mt-7 opacity-80 transition-opacity ease-in flex flex-row h-6 z-infinity"
-            : "absolute opacity-0 transition-opacity ease-in flex flex-row h-6 z-infinity"
+            ? "absolute -mt-7 opacity-80 transition-opacity ease-in flex flex-row h-6 z-[10000001]"
+            : "absolute opacity-0 transition-opacity ease-in flex flex-row h-6 z-[10000001]"
         }
       >
         <Card className="h-full grabbable rounded-lg w-6 flex items-center justify-center bg-[#F3F4F6] hover:bg-sky-100 text-[#1C64F2]">

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -129,8 +129,8 @@ export function FidgetWrapper({
       <div
         className={
           selectedFidgetID === bundle.id
-            ? "absolute -mt-7 opacity-80 transition-opacity ease-in flex flex-row h-6"
-            : "absolute opacity-0 transition-opacity ease-in flex flex-row h-6"
+            ? "absolute -mt-7 opacity-80 transition-opacity ease-in flex flex-row h-6 z-infinity"
+            : "absolute opacity-0 transition-opacity ease-in flex flex-row h-6 z-infinity"
         }
       >
         <Card className="h-full grabbable rounded-lg w-6 flex items-center justify-center bg-[#F3F4F6] hover:bg-sky-100 text-[#1C64F2]">

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -551,6 +551,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
                     setCurrentFidgetSettings={setCurrentFidgetSettings}
                     setSelectedFidgetID={setSelectedFidgetID}
                     selectedFidgetID={selectedFidgetID}
+                    portalNode={element}
                     bundle={{
                       ...fidgetDatum,
                       properties: fidgetModule.properties,


### PR DESCRIPTION
## Summary
- ensure edit mode action icons render above the tab bar

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6841d0fd402c8325ab0a119ffa06f043