### PR TITLE
Fix scrolling for RSS and X feeds

### DIFF
--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -427,7 +427,7 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
     return (
       <iframe
         src={url}
-        style={{ border: "none", width: "100%", height: "100%" }}
+        style={{ border: "none", width: "100%" }}
         title="Twitter Feed"
         scrolling="no"
         frameBorder="0"
@@ -552,7 +552,7 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
 
   return (
     <div
-      className="h-full"
+      className="h-full overflow-y-auto"
       style={{
         fontFamily: settings.useDefaultColors ? 'var(--user-theme-font)' : settings.fontFamily,
         color: settings.useDefaultColors ? 'var(--user-theme-font-color)' : settings.fontColor,
@@ -564,11 +564,11 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
           <Loading />
         </div>
       ) : isThreadView ? (
-        <div className="h-full overflow-y-auto">
+        <div className="h-full">
           {renderThread()}
         </div>
       ) : (
-        <div className="h-full overflow-y-auto">
+        <div className="h-full">
           {renderFeedContent()}
         </div>
       )}

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -427,10 +427,11 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings>> = ({ settings }) => {
     return (
       <iframe
         src={url}
-        style={{ border: "none", width: "100%" }}
+        style={{ border: "none", width: "100%", height: "100%" }}
         title="Twitter Feed"
-        scrolling="no"
+        scrolling="yes"
         frameBorder="0"
+        className="scrollbar-none"
       />
     );
   };

--- a/src/fidgets/ui/rss.tsx
+++ b/src/fidgets/ui/rss.tsx
@@ -157,8 +157,7 @@ export const Rss: React.FC<FidgetArgs<RSSFidgetSettings>> = ({ settings }) => {
   }, [settings.rssUrl]);
 
   return (
-    <div
-    >
+    <div className="h-full overflow-y-auto">
       {rssFeed?.title && (
         <CardHeader className="p-2 ml-5">
           <div className="flex-col items-center">


### PR DESCRIPTION
## Summary
- allow scrolling in Feed fidget container
- keep Twitter iframe auto‑sizing
- make RSS fidget container scrollable

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6841d9427d4c8325a09b789848576041

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved vertical scrolling behavior for both Twitter and RSS feed components, ensuring smoother navigation within feed containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->