### PR TITLE
Fix whitespace in TabBar

### DIFF
--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -15,6 +15,7 @@ import ProposalDataHeader from "./ProposalDataHeader";
 import ClaimButtonWithModal from "../molecules/ClaimButtonWithModal";
 import useIsMobile from "@/common/lib/hooks/useIsMobile";
 import { SpacePageType } from "@/app/(spaces)/PublicSpace";
+import { mergeClasses } from "@/common/lib/utils/mergeClasses";
 
 interface TabBarProps {
   inHome?: boolean;
@@ -195,6 +196,8 @@ function TabBar({
   }, [switchTabTo]);
 
   const isLoggedIn = getIsLoggedIn();
+  const showButtons =
+    inEditMode || (!inEditMode && !isMobile && isLoggedIn && sidebarEditable);
 
   return (
     <TooltipProvider>
@@ -204,7 +207,12 @@ function TabBar({
             <TokenDataHeader />
           </div>
         )}
-        <div className="flex w-64 flex-auto justify-start h-16 z-70 bg-white pr-8 md:pr-0 flex-nowrap overflow-y-scroll">
+        <div
+          className={mergeClasses(
+            "flex flex-auto justify-start h-16 z-70 bg-white md:pr-0 flex-nowrap overflow-y-scroll",
+            showButtons && "w-64 pr-8",
+          )}
+        >
           {tabList && (
             <Reorder.Group
               as="ol"


### PR DESCRIPTION
Currently in prod, there's a white rectangle on the right side of the tab bar that covers up tab names when a user has multiple tabs, especially on mobile.

Before:
![image](https://github.com/user-attachments/assets/4529e3d4-6031-4dde-80b9-3430e98d98d1)

After:
![Uploading image.png…]()


## Summary
- show the TabBar's right padding only when buttons are visible

Before:
![image](https://github.com/user-attachments/assets/19049aee-aaf8-428d-bce7-2bdcce938bd9)


## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6843067fc2388325b78b84707ab6eb54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the layout of the tab container so that its width and padding adjust dynamically based on user login status, device type, and edit mode.
- **Style**
  - Tab container styling now adapts to provide a more responsive and context-aware interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->