### PR TITLE
Enable dynamic thumbnail images for profile space mini apps

### DIFF
--- a/src/app/(spaces)/s/[handle]/layout.tsx
+++ b/src/app/(spaces)/s/[handle]/layout.tsx
@@ -34,11 +34,18 @@ export async function generateMetadata({
     ? `${WEBSITE_URL}/s/${handle}/${encodeURIComponent(tabName)}`
     : `${WEBSITE_URL}/s/${handle}`;
     
-  const displayName = userMetadata?.displayName || userMetadata?.username || handle;
-  
+  const displayName =
+    userMetadata?.displayName || userMetadata?.username || handle;
+
+  // Build Open Graph image URL matching the dynamic metadata
+  const encodedDisplayName = encodeURIComponent(displayName || "");
+  const encodedPfpUrl = encodeURIComponent(userMetadata?.pfpUrl || "");
+  const encodedBio = encodeURIComponent(userMetadata?.bio || "");
+  const ogImageUrl = `${WEBSITE_URL}/api/metadata/spaces?username=${handle}&displayName=${encodedDisplayName}&pfpUrl=${encodedPfpUrl}&bio=${encodedBio}`;
+
   const spaceFrame = {
     version: "next",
-    imageUrl: `${WEBSITE_URL}/images/nounspace_og_low.png`,
+    imageUrl: ogImageUrl,
     button: {
       title: `Visit ${displayName}'s Space`,
       action: {


### PR DESCRIPTION
## Summary
- use dynamic Open Graph image in profile space Farcaster mini app

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6848889ec29c832596dee3da15c5d344

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Open Graph images for user space pages are now dynamically generated to reflect each user's handle, display name, profile picture, and bio, improving link previews on social platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->