### PR TITLE
Add dynamic thumbnails for proposal spaces (and mini apps) (attempt #2)

### DIFF
--- a/src/app/(spaces)/p/[proposalId]/layout.tsx
+++ b/src/app/(spaces)/p/[proposalId]/layout.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { WEBSITE_URL } from "@/constants/app";
 import { loadProposalData } from "./utils";
 import { defaultFrame } from "@/common/lib/frames/metadata";
+import { getProposalMetadataStructure } from "@/common/lib/utils/proposalMetadata";
 
 const defaultMetadata = {
   other: {
@@ -25,9 +26,20 @@ export async function generateMetadata({ params }): Promise<Metadata> {
 
   const frameUrl = `${WEBSITE_URL}/p/${proposalId}`;
 
+  const baseMetadata = getProposalMetadataStructure({
+    id: proposalData.id,
+    title: proposalData.title,
+    forVotes: proposalData.forVotes,
+    againstVotes: proposalData.againstVotes,
+    abstainVotes: proposalData.abstainVotes,
+    quorumVotes: proposalData.quorumVotes,
+  });
+
+  const ogImageUrl = baseMetadata.openGraph?.images?.[0];
+
   const proposalFrame = {
     version: "next",
-    imageUrl: `${WEBSITE_URL}/images/nounspace_og_low.png`,
+    imageUrl: ogImageUrl,
     button: {
       title: `View Proposal ${proposalData.id}`,
       action: {
@@ -41,6 +53,7 @@ export async function generateMetadata({ params }): Promise<Metadata> {
   };
 
   const metadataWithFrame = {
+    ...baseMetadata,
     title: `Proposal: ${proposalData.title} | Nounspace`,
     description: `Proposal by ${proposalData.proposer.id} on Nounspace. Explore the details and discussions around this proposal.`,
     other: {

--- a/src/app/(spaces)/p/[proposalId]/utils.ts
+++ b/src/app/(spaces)/p/[proposalId]/utils.ts
@@ -10,6 +10,10 @@ export interface ProposalData {
     id: Address;
   }[];
   createdTimestamp?: string;
+  forVotes?: string;
+  againstVotes?: string;
+  abstainVotes?: string;
+  quorumVotes?: string;
 }
 
 export async function loadProposalData(proposalId: string): Promise<ProposalData> {
@@ -25,6 +29,10 @@ export async function loadProposalData(proposalId: string): Promise<ProposalData
               id
               title
               createdTimestamp
+              forVotes
+              againstVotes
+              abstainVotes
+              quorumVotes
               proposer {
                 id
               }

--- a/src/common/lib/utils/proposalMetadata.tsx
+++ b/src/common/lib/utils/proposalMetadata.tsx
@@ -1,0 +1,60 @@
+import { WEBSITE_URL } from "@/constants/app";
+import { merge } from "lodash";
+import { Metadata } from "next";
+
+export interface ProposalMetadata {
+  id?: string;
+  title?: string;
+  forVotes?: string;
+  againstVotes?: string;
+  abstainVotes?: string;
+  quorumVotes?: string;
+}
+
+export const getProposalMetadataStructure = (
+  proposal: ProposalMetadata,
+): Metadata => {
+  if (!proposal) {
+    return {};
+  }
+
+  const { id, title, forVotes, againstVotes, abstainVotes, quorumVotes } = proposal;
+
+  const params = new URLSearchParams({
+    id: id || "",
+    title: title || "",
+    forVotes: forVotes || "0",
+    againstVotes: againstVotes || "0",
+    abstainVotes: abstainVotes || "0",
+    quorumVotes: quorumVotes || "0",
+  });
+
+  const ogImageUrl = `${WEBSITE_URL}/api/metadata/proposal?${params.toString()}`;
+
+  const spaceUrl = id ? `https://nounspace.com/p/${id}` : undefined;
+  const propTitle = title ? `Prop ${id}: ${title}` : `Proposal ${id}`;
+
+  const metadata: Metadata = {
+    title: propTitle,
+    openGraph: {
+      title: propTitle,
+      url: spaceUrl,
+      images: [ogImageUrl],
+    },
+    twitter: {
+      title: propTitle,
+      site: "https://nounspace.com/",
+      images: [ogImageUrl],
+      card: "summary_large_image",
+    },
+  };
+
+  const description = `Against: ${againstVotes || 0} | Abstain: ${abstainVotes || 0} | For: ${forVotes || 0}`;
+  merge(metadata, {
+    description,
+    openGraph: { description },
+    twitter: { description },
+  });
+
+  return metadata;
+};

--- a/src/pages/api/metadata/proposal.tsx
+++ b/src/pages/api/metadata/proposal.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { NextApiRequest, NextApiResponse } from "next";
+import { ImageResponse } from "next/og";
+
+export const config = {
+  runtime: "edge",
+};
+
+interface ProposalCardData {
+  id: string;
+  title: string;
+  forVotes: number;
+  againstVotes: number;
+  abstainVotes: number;
+  quorumVotes: number;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ImageResponse | string>,
+) {
+  if (!req.url) {
+    return res.status(404).send("Url not found");
+  }
+
+  const params = new URLSearchParams(req.url?.split("?")[1] || "");
+  const data: ProposalCardData = {
+    id: params.get("id") || "",
+    title: params.get("title") || "",
+    forVotes: Number(params.get("forVotes") || "0"),
+    againstVotes: Number(params.get("againstVotes") || "0"),
+    abstainVotes: Number(params.get("abstainVotes") || "0"),
+    quorumVotes: Number(params.get("quorumVotes") || "0"),
+  };
+
+  return new ImageResponse(<ProposalCard data={data} />, {
+    width: 1200,
+    height: 630,
+  });
+}
+
+const ProposalCard = ({ data }: { data: ProposalCardData }) => {
+  const totalVotes = data.forVotes + data.againstVotes + data.abstainVotes;
+  const maxVotes = Math.max(totalVotes, data.quorumVotes, 1);
+  const againstPct = (data.againstVotes / maxVotes) * 100;
+  const abstainPct = (data.abstainVotes / maxVotes) * 100;
+  const forPct = (data.forVotes / maxVotes) * 100;
+  const quorumPct = (data.quorumVotes / maxVotes) * 100;
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        padding: "40px",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        background: "white",
+        fontFamily: "Arial, sans-serif",
+        gap: "24px",
+      }}
+    >
+      <div style={{ fontSize: "48px", fontWeight: "bold" }}>
+        Prop {data.id}: {data.title}
+      </div>
+      <div style={{ display: "flex", gap: "20px", fontSize: "32px" }}>
+        <span style={{ color: "#DD3333" }}>{data.againstVotes} Against</span>
+        <span style={{ color: "#777777" }}>{data.abstainVotes} Abstain</span>
+        <span style={{ color: "#33BB33" }}>{data.forVotes} For</span>
+      </div>
+      <div
+        style={{
+          position: "relative",
+          width: "100%",
+          height: "40px",
+          background: "#E5E5E5",
+          borderRadius: "8px",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            width: `${againstPct}%`,
+            background: "#DD3333",
+            height: "100%",
+            display: "inline-block",
+          }}
+        />
+        <div
+          style={{
+            width: `${abstainPct}%`,
+            background: "#777777",
+            height: "100%",
+            display: "inline-block",
+          }}
+        />
+        <div
+          style={{
+            width: `${forPct}%`,
+            background: "#33BB33",
+            height: "100%",
+            display: "inline-block",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            left: `${quorumPct}%`,
+            top: 0,
+            bottom: 0,
+            width: "4px",
+            background: "#000000",
+          }}
+        />
+      </div>
+      <div style={{ fontSize: "24px" }}>Quorum: {data.quorumVotes} votes</div>
+    </div>
+  );
+};

--- a/src/pages/api/metadata/spaces.tsx
+++ b/src/pages/api/metadata/spaces.tsx
@@ -14,7 +14,7 @@ interface UserMetadata {
   bio: string;
 }
 
-export default async function GET(
+export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ImageResponse | string>,
 ) {
@@ -22,7 +22,7 @@ export default async function GET(
     return res.status(404).send("Url not found");
   }
 
-  const params = new URLSearchParams(req.url.split("?")[1]);
+  const params = new URLSearchParams(req.url?.split("?")[1] || "");
   const userMetadata: UserMetadata = {
     username: params.get("username") || "",
     displayName: params.get("displayName") || "",

--- a/src/pages/api/metadata/token.tsx
+++ b/src/pages/api/metadata/token.tsx
@@ -16,7 +16,7 @@ interface TokenCardData {
   priceChange: string;
 }
 
-export default async function GET(
+export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ImageResponse | string>,
 ) {
@@ -24,7 +24,7 @@ export default async function GET(
     return res.status(404).send("Url not found");
   }
 
-  const params = new URLSearchParams(req.url.split("?")[1]);
+  const params = new URLSearchParams(req.url?.split("?")[1] || "");
   const data: TokenCardData = {
     name: params.get("name") || "",
     symbol: params.get("symbol") || "",

--- a/src/pages/api/metadata/youtube.ts
+++ b/src/pages/api/metadata/youtube.ts
@@ -6,7 +6,7 @@ import { youtube_v3 } from "@googleapis/youtube";
 export type YouTubeMetadataResponse =
   NounspaceResponse<youtube_v3.Schema$Video>;
 
-export default async function GET(
+export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<YouTubeMetadataResponse>,
 ) {


### PR DESCRIPTION
## Summary
- standardize metadata handlers to use `handler` naming
- handle missing URLs safely
- parse query params using URLSearchParams

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6848ad2f4c148325a3d65eb173e389a9