### PR TITLE
Fix login prompt when visiting cast links

### DIFF
--- a/src/app/(spaces)/homebase/PrivateSpace.tsx
+++ b/src/app/(spaces)/homebase/PrivateSpace.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, lazy, useState } from "react";
+import React, { lazy, useEffect, useMemo, useRef } from "react";
 import { useAppStore } from "@/common/data/stores/app";
 import SpacePage, { SpacePageArgs } from "@/app/(spaces)/SpacePage";
 import FeedModule, { FilterType } from "@/fidgets/farcaster/Feed";
@@ -10,7 +10,6 @@ import { useRouter } from "next/navigation";
 import { useSidebarContext } from "@/common/components/organisms/Sidebar";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialPersonSpace";
 import { HOMEBASE_ID } from "@/common/data/stores/app/currentSpace";
-import { LoginModal } from "@privy-io/react-auth";
 import { FeedType } from "@neynar/nodejs-sdk/build/api";
 
 // Lazy load the TabBar component to improve performance
@@ -93,19 +92,19 @@ function PrivateSpace({ tabName, castHash }: { tabName: string; castHash?: strin
 
   const { editMode } = useSidebarContext(); // Get the edit mode status from the sidebar context
 
-  // Track hydration so login modal doesn't show before params are available
-  const [hydrated, setHydrated] = useState(false);
+  // Track hydration without causing a re-render
+  const hasHydrated = useRef(false);
   useEffect(() => {
-    setHydrated(true);
+    hasHydrated.current = true;
   }, []);
 
   // Effect to handle login modal when user is not logged in and not viewing a cast
   useEffect(() => {
-    if (hydrated && !isLoggedIn && !castHash) {
+    if (hasHydrated.current && !isLoggedIn && !castHash) {
       // Open the login modal if user is not logged in
       setModalOpen(true);
     }
-  }, [hydrated, isLoggedIn, castHash, setModalOpen]);
+  }, [isLoggedIn, castHash, setModalOpen]);
 
   // Effect to set the current space and tab name, and load the tab configuration
   useEffect(() => {

--- a/src/app/(spaces)/homebase/PrivateSpace.tsx
+++ b/src/app/(spaces)/homebase/PrivateSpace.tsx
@@ -93,13 +93,13 @@ function PrivateSpace({ tabName, castHash }: { tabName: string; castHash?: strin
 
   const { editMode } = useSidebarContext(); // Get the edit mode status from the sidebar context
 
-  // Effect to handle login modal when user is not logged in
+  // Effect to handle login modal when user is not logged in and not viewing a cast
   useEffect(() => {
-    if (!isLoggedIn) {
+    if (!isLoggedIn && !castHash) {
       // Open the login modal if user is not logged in
       setModalOpen(true);
     }
-  }, [isLoggedIn, setModalOpen]);
+  }, [isLoggedIn, castHash, setModalOpen]);
 
   // Effect to set the current space and tab name, and load the tab configuration
   useEffect(() => {

--- a/src/app/(spaces)/homebase/PrivateSpace.tsx
+++ b/src/app/(spaces)/homebase/PrivateSpace.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, lazy } from "react";
+import React, { useEffect, useMemo, lazy, useState } from "react";
 import { useAppStore } from "@/common/data/stores/app";
 import SpacePage, { SpacePageArgs } from "@/app/(spaces)/SpacePage";
 import FeedModule, { FilterType } from "@/fidgets/farcaster/Feed";
@@ -93,13 +93,19 @@ function PrivateSpace({ tabName, castHash }: { tabName: string; castHash?: strin
 
   const { editMode } = useSidebarContext(); // Get the edit mode status from the sidebar context
 
+  // Track hydration so login modal doesn't show before params are available
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
   // Effect to handle login modal when user is not logged in and not viewing a cast
   useEffect(() => {
-    if (!isLoggedIn && !castHash) {
+    if (hydrated && !isLoggedIn && !castHash) {
       // Open the login modal if user is not logged in
       setModalOpen(true);
     }
-  }, [isLoggedIn, castHash, setModalOpen]);
+  }, [hydrated, isLoggedIn, castHash, setModalOpen]);
 
   // Effect to set the current space and tab name, and load the tab configuration
   useEffect(() => {


### PR DESCRIPTION
## Summary
- prevent automatic login modal when viewing casts

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684a54a19234832582591fdfd4e2e286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the timing of the login modal so it only appears after the page is fully loaded, preventing it from opening prematurely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->