### PR TITLE
Refactor feed fetch logic

### DIFF
--- a/src/common/data/queries/farcaster.ts
+++ b/src/common/data/queries/farcaster.ts
@@ -69,6 +69,7 @@ export const useGetCasts = ({
   fids,
   channel,
   membersOnly,
+  enabled = true,
 }: {
   feedType: FeedType;
   fid: number;
@@ -76,6 +77,7 @@ export const useGetCasts = ({
   fids?: string;
   channel?: string;
   membersOnly?: boolean;
+  enabled?: boolean;
 }) => {
   return useInfiniteQuery({
     queryKey: ["channelCasts", feedType, fid, filterType, fids, channel, membersOnly],
@@ -102,10 +104,17 @@ export const useGetCasts = ({
       !isUndefined(lastPage) && !isUndefined(lastPage.next)
         ? lastPage.next.cursor
         : undefined,
+    enabled,
   });
 };
 
-export const useGetCastsByKeyword = ({ keyword }: { keyword: string }) => {
+export const useGetCastsByKeyword = ({
+  keyword,
+  enabled = true,
+}: {
+  keyword: string;
+  enabled?: boolean;
+}) => {
   return useInfiniteQuery({
     queryKey: ["keywordCasts", keyword],
     staleTime: 1000 * 60 * 1,
@@ -124,6 +133,7 @@ export const useGetCastsByKeyword = ({ keyword }: { keyword: string }) => {
     },
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage?.next?.cursor ?? undefined,
+    enabled,
   });
 };
 

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -20,7 +20,10 @@ import {
   type FidgetSettingsStyle,
 } from "@/common/fidgets";
 import useLifoQueue from "@/common/lib/hooks/useLifoQueue";
-import { FeedType } from "@neynar/nodejs-sdk/build/api";
+import {
+  FeedType,
+  FilterType as NeynarFilterType,
+} from "@neynar/nodejs-sdk/build/api";
 import { isNil } from "lodash";
 import React, { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
@@ -366,7 +369,7 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings, FeedFidgetData>> = ({ settin
   const castsQuery = useGetCasts({
     feedType,
     fid,
-    filterType,
+    filterType: filterType as NeynarFilterType,
     fids: effectiveFids,
     channel,
     enabled: filterType !== FilterType.Keyword,

--- a/src/fidgets/farcaster/Feed.tsx
+++ b/src/fidgets/farcaster/Feed.tsx
@@ -363,6 +363,25 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings, FeedFidgetData>> = ({ settin
     ? usernameFid.toString()
     : users;
 
+  const castsQuery = useGetCasts({
+    feedType,
+    fid,
+    filterType,
+    fids: effectiveFids,
+    channel,
+    enabled: filterType !== FilterType.Keyword,
+    ...(feedType === FeedType.Filter &&
+      filterType === FilterType.Channel &&
+      membersOnly !== undefined
+      ? { membersOnly }
+      : {}),
+  });
+
+  const keywordQuery = useGetCastsByKeyword({
+    keyword: keyword || "",
+    enabled: filterType === FilterType.Keyword,
+  });
+
   const {
     data: castPages,
     isFetchingNextPage,
@@ -370,19 +389,8 @@ const Feed: React.FC<FidgetArgs<FeedFidgetSettings, FeedFidgetData>> = ({ settin
     hasNextPage,
     isError,
     isPending,
-    refetch
-  } =
-    filterType === FilterType.Keyword
-      ? useGetCastsByKeyword({ keyword: keyword || "" })
-      : useGetCasts({
-        feedType,
-        fid,
-        filterType,
-        fids: effectiveFids,
-        channel,
-        ...(feedType === FeedType.Filter && filterType === 
-          FilterType.Channel && membersOnly !== undefined ? { membersOnly } : {}),
-      });
+    refetch,
+  } = filterType === FilterType.Keyword ? keywordQuery : castsQuery;
 
   const router = useRouter();
   const threadStack = useLifoQueue<string>();


### PR DESCRIPTION
## Summary
- add optional `enabled` param to Farcaster queries
- call both queries in `Feed` and pick the active one

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684a5d29dd3c8325b7cb4925913b7097

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the data fetching logic in the Feed component for clearer separation between keyword and other filter types.
- **New Features**
  - Added the ability to enable or disable cast queries conditionally through an optional parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->