### PR TITLE
Improve fidget fly-in animation

### DIFF
--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -497,11 +497,9 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     );
   }
 
-  const [itemsVisible, setItemsVisible] = useState(false);
-
-  useEffect(() => {
-    setItemsVisible(true);
-  }, []);
+  const [itemsVisible] = useState(true);
+  // Consider using CSS animations or useLayoutEffect for the fade-in effect,
+  // so that SSR and hydration don’t render blank content.
 
   // Log initial config state
   useEffect(() => {

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -497,7 +497,11 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     );
   }
 
-  const [itemsVisible] = useState(true);
+  const [itemsVisible, setItemsVisible] = useState(false);
+
+  useEffect(() => {
+    setItemsVisible(true);
+  }, []);
 
   // Log initial config state
   useEffect(() => {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -171,6 +171,7 @@
 
 .items-visible .react-grid-item {
   opacity: 1;
+  transition: opacity 200ms ease;
 }
 
 .react-grid-item.react-grid-placeholder {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -141,11 +141,14 @@
   width: 100%;
   height: 100%;
 }
-.react-grid-item {
-  border-color: lightgray;
-  opacity: 0;
-  transition: opacity 200ms ease;
-}
+.grid-overlap:not(.items-visible) .react-grid-item {
+    opacity: 0;
+    transition: opacity 200ms ease;
+  }
+  
+  .react-grid-item {         /* preserve generic styling */
+    border-color: lightgray;
+  }
 .react-grid-item img {
   pointer-events: none;
   user-select: none;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -143,8 +143,8 @@
 }
 .react-grid-item {
   border-color: lightgray;
-  transition: all 200ms ease;
-  transition-property: left, top, width, height;
+  opacity: 0;
+  transition: opacity 200ms ease;
 }
 .react-grid-item img {
   pointer-events: none;
@@ -167,6 +167,10 @@
 
 .react-grid-item.dropping {
   visibility: hidden;
+}
+
+.items-visible .react-grid-item {
+  opacity: 1;
 }
 
 .react-grid-item.react-grid-placeholder {


### PR DESCRIPTION
## Summary
- fade fidgets in when a space loads
- remove slide animation from grid items

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_684a6c224388832592e00c6f8ca3ba8a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated grid item appearance to fade in smoothly using an opacity transition, providing a visually improved loading effect.
- **New Features**
  - Grid items now appear with a fade-in animation after the grid loads, enhancing user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->