### PR TITLE
Fix config caching when switching to uncustomized space

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -197,14 +197,10 @@ export default function PublicSpace({
       // logic for proposal
     }
 
-    if (prevSpaceId.current !== nextSpaceId) {
-      setCurrentSpaceId(nextSpaceId);
-      prevSpaceId.current = nextSpaceId;
-    }
-    if (prevTabName.current !== nextTabName) {
-      setCurrentTabName(nextTabName);
-      prevTabName.current = nextTabName;
-    }
+    setCurrentSpaceId(nextSpaceId);
+    prevSpaceId.current = nextSpaceId;
+    setCurrentTabName(nextTabName);
+    prevTabName.current = nextTabName;
     // localSpaces is not in the dependencies!
   }, [
     resolvedPageType,

--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -93,6 +93,8 @@ export default function PublicSpace({
     setCurrentSpaceId: state.currentSpace.setCurrentSpaceId,
     getCurrentTabName: state.currentSpace.getCurrentTabName,
     setCurrentTabName: state.currentSpace.setCurrentTabName,
+    currentSpaceId: state.currentSpace.currentSpaceId,
+    currentTabName: state.currentSpace.currentTabName,
     localSpaces: state.space.localSpaces,
     remoteSpaces: state.space.remoteSpaces,
     loadEditableSpaces: state.space.loadEditableSpaces,


### PR DESCRIPTION
I noticed a bug in canary where if you visited an uncustomized space right after visiting a customized space, you'd see the config for the customized space. This fixes by updating PublicSpace so the current space ID and tab name are always reset when switching spaces, ensuring uncustomized spaces no longer reuse the previous space’s config


## Summary
- ensure PublicSpace rerenders on current space change

## Steps to repro in canary:
1. Visit a space that has been customized
2. Navigate to an uncustomized space before visiting /homebase

Expected result:
1. See the default space config for that space type (ie. profile space, token space, proposal space)

Actual result:
1. See the config for the initial customized space you visited

------
https://chatgpt.com/codex/tasks/task_e_684a86b55d0c832597710c6a1ab0941d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved state management in the PublicSpace component for smoother updates of space and tab information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->