### PR TITLE
Fix embedded cast navigation

### DIFF
--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -152,7 +152,10 @@ const CastEmbeds = ({ cast, onSelectCast }) => {
             onClick={(event) => {
               event.stopPropagation();
               if (embedData?.castId?.hash) {
-                onSelectCast(embedData.castId.hash, cast.author.username);
+                const authorIdentifier = embedData.castId.fid
+                  ? String(embedData.castId.fid)
+                  : cast.author.username;
+                onSelectCast(embedData.castId.hash, authorIdentifier);
               }
             }}
           >


### PR DESCRIPTION
## Summary
- ensure embedded cast row navigation uses the embed author's identifier

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684b5813480083259377dfd79bbb57e8