### PR TITLE
Fix image flashing on partial visibility & improve feed/app performance by minimizing resource load

### DIFF
--- a/src/fidgets/farcaster/components/LazyLoad.tsx
+++ b/src/fidgets/farcaster/components/LazyLoad.tsx
@@ -52,8 +52,8 @@ const LazyImageComponent = ({
 }) => {
   const [loaded, setLoaded] = useState(false);
   const { ref, isIntersecting: isVisible } = useIntersectionObserver({
-    rootMargin: '200px', 
-    threshold: 0.1,
+    rootMargin: '200px',
+    threshold: 0,
   });
 
   const handleLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {

--- a/src/fidgets/farcaster/components/LazyLoad.tsx
+++ b/src/fidgets/farcaster/components/LazyLoad.tsx
@@ -51,10 +51,17 @@ const LazyImageComponent = ({
   referrerPolicy?: string;
 }) => {
   const [loaded, setLoaded] = useState(false);
-  const { ref, isIntersecting: isVisible } = useIntersectionObserver({
+  const [shouldLoad, setShouldLoad] = useState(false);
+  const { ref, isIntersecting } = useIntersectionObserver({
     rootMargin: '200px',
     threshold: 0,
   });
+
+  useEffect(() => {
+    if (isIntersecting) {
+      setShouldLoad(true);
+    }
+  }, [isIntersecting]);
 
   const handleLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
     setLoaded(true);
@@ -85,8 +92,8 @@ const LazyImageComponent = ({
 
   return (
     <div ref={ref} className="relative">
-      {(!isVisible || !loaded) && placeholder}
-      {isVisible && (
+      {(!shouldLoad || !loaded) && placeholder}
+      {shouldLoad && (
         <img
           src={src}
           alt={alt}


### PR DESCRIPTION
This fixes an issue in canary introduced by the optimizations where if only the top ~10% of an image is visible in a feed fidget viewport, the image would repeatedly flash

![2025-06-13 15 15 53](https://github.com/user-attachments/assets/92a0e9a1-76ed-4883-bbbe-965d7d9b1a99)


## Summary
- fix LazyImage intersection observer threshold

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684bd0c3d6008325a55c097d7626e090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved image lazy loading to ensure images load only once when they enter the viewport and prevent repeated triggers.
- **Performance**
	- Enhanced efficiency by disconnecting the observer after an image starts loading, reducing unnecessary resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->