### PR TITLE
Enhance RSS fidget compatibility with server-side RSS API

### DIFF
--- a/src/app/api/rss/route.ts
+++ b/src/app/api/rss/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import RSSParser from "rss-parser";
+
+// SSRF protection: Block internal IP ranges and localhost
+function isInternalUrl(url: string): boolean {
+  try {
+    const urlObj = new URL(url);
+    const hostname = urlObj.hostname;
+
+    // Block localhost variations
+    if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") {
+      return true;
+    }
+
+    // Block private IP ranges
+    const ip = hostname.split(".");
+    if (ip.length === 4 && ip.every((octet) => /^\d+$/.test(octet))) {
+      const [a, b] = ip.map(Number);
+
+      // 10.0.0.0/8
+      if (a === 10) return true;
+      // 172.16.0.0/12
+      if (a === 172 && b >= 16 && b <= 31) return true;
+      // 192.168.0.0/16
+      if (a === 192 && b === 168) return true;
+      // 169.254.0.0/16
+      if (a === 169 && b === 254) return true;
+      // 0.0.0.0/8
+      if (a === 0) return true;
+    }
+
+    // Block other localhost variations
+    if (hostname.endsWith(".localhost") || hostname.includes("local")) {
+      return true;
+    }
+
+    return false;
+  } catch {
+    return true; // If URL parsing fails, consider it unsafe
+  }
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const url = request.nextUrl.searchParams.get("url");
+
+  if (!url) {
+    return NextResponse.json({ message: "Missing URL parameter" }, { status: 400 });
+  }
+  if (typeof url !== "string" || !url.startsWith("http")) {
+    return NextResponse.json(
+      { message: "Invalid URL. Must start with http(s)://" },
+      { status: 400 },
+    );
+  }
+  if (isInternalUrl(url)) {
+    return NextResponse.json(
+      { message: "Invalid URL. Internal URLs are not allowed." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const parser = new RSSParser();
+    const feed = await parser.parseURL(url);
+
+    return NextResponse.json({
+      title: feed.title || null,
+      description: feed.description || null,
+      link: feed.link || null,
+      image: feed.image || null,
+      items: feed.items || [],
+    });
+  } catch (err) {
+    console.error("Error fetching RSS feed:", err);
+    return NextResponse.json(
+      { message: err instanceof Error ? err.message : "Unknown error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/fidgets/ui/rss.tsx
+++ b/src/fidgets/ui/rss.tsx
@@ -13,7 +13,6 @@ import { MarkdownRenderers } from "@/common/lib/utils/markdownRenderers";
 import React, { useEffect, useState } from "react";
 import { BsRss, BsRssFill } from "react-icons/bs";
 import ReactMarkdown from "react-markdown";
-import RSSParser from "rss-parser";
 import { defaultStyleFields, WithMargin } from "../helpers";
 
 export type RSSFidgetSettings = {
@@ -137,12 +136,15 @@ export const Rss: React.FC<FidgetArgs<RSSFidgetSettings>> = ({ settings }) => {
   useEffect(() => {
     const fetchRssFeed = async () => {
       try {
-        const parser = new RSSParser();
-        const feed = await parser.parseURL(settings.rssUrl);
+        const res = await fetch(`/api/rss?url=${encodeURIComponent(settings.rssUrl)}`);
+        if (!res.ok) {
+          throw new Error(`Failed to fetch RSS feed: ${res.status}`);
+        }
+        const data = await res.json();
 
-        if (feed.items && feed.items.length > 0) {
-          setRssItems(feed.items);
-          setRssFeed(feed);
+        if (data.items && data.items.length > 0) {
+          setRssItems(data.items);
+          setRssFeed({ title: data.title, image: data.image });
         } else {
           console.warn("No items found in the RSS feed.");
         }


### PR DESCRIPTION
Enables RSS feeds that were currently blocked because they were redirected and/or lacked CORS headers to successfully render (ie. https://news.google.com/rss/search?q=penguins)

## Summary
- add `/api/rss` endpoint to fetch and parse RSS feeds
- update RSS fidget to load feed data via new API

## Testing
- `npm run lint`
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_684bf130b1bc83259ba5222de338cab2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for fetching and displaying RSS feeds via a secure backend API endpoint.
- **Bug Fixes**
	- Improved error handling and validation when loading RSS feeds, including protection against unsupported or unsafe URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->