### PR TITLE
Add dynamic thumbnail images and open graph metadata for casts

### DIFF
--- a/src/app/(spaces)/homebase/c/[caster]/[castHash]/layout.tsx
+++ b/src/app/(spaces)/homebase/c/[caster]/[castHash]/layout.tsx
@@ -23,6 +23,7 @@ export async function generateMetadata({
     const username: string = cast?.author?.username || caster;
     const pfpUrl: string = cast?.author?.pfp_url || "";
     const text: string = cast?.text || "";
+    const timestamp: number | string | undefined = cast?.timestamp;
     let imageUrl: string | undefined;
 
     if (Array.isArray(cast.embeds)) {
@@ -42,6 +43,7 @@ export async function generateMetadata({
       pfpUrl,
       text: truncated,
       imageUrl,
+      timestamp,
     });
   } catch (error) {
     console.error("Error generating cast metadata:", error);

--- a/src/app/(spaces)/homebase/c/[caster]/[castHash]/layout.tsx
+++ b/src/app/(spaces)/homebase/c/[caster]/[castHash]/layout.tsx
@@ -1,6 +1,6 @@
 import { WEBSITE_URL } from "@/constants/app";
-import { Metadata } from "next/types";
-import axios from "axios";
+import type { Metadata } from "next";
+// axios adds ~30 kB; built-in fetch is sufficient here
 import { getCastMetadataStructure } from "@/common/lib/utils/castMetadata";
 import { isImageUrl } from "@/common/lib/utils/urls";
 
@@ -12,12 +12,8 @@ export async function generateMetadata({
   }
 
   try {
-    const { data } = await axios.get(
-      `${WEBSITE_URL}/api/farcaster/neynar/cast`,
-      {
-        params: { identifier: castHash, type: "hash" },
-      },
-    );
+    const url = `${WEBSITE_URL}/api/farcaster/neynar/cast?identifier=${castHash}&type=hash`;
+    const data = await fetch(url).then((r) => r.json());
 
     const cast = data.cast || data;
     const username: string = cast?.author?.username || caster;

--- a/src/app/(spaces)/homebase/c/[caster]/[castHash]/layout.tsx
+++ b/src/app/(spaces)/homebase/c/[caster]/[castHash]/layout.tsx
@@ -1,0 +1,58 @@
+import { WEBSITE_URL } from "@/constants/app";
+import { Metadata } from "next/types";
+import axios from "axios";
+import { getCastMetadataStructure } from "@/common/lib/utils/castMetadata";
+import { isImageUrl } from "@/common/lib/utils/urls";
+
+export async function generateMetadata({
+  params: { caster, castHash },
+}): Promise<Metadata> {
+  if (!caster || !castHash) {
+    return {};
+  }
+
+  try {
+    const { data } = await axios.get(
+      `${WEBSITE_URL}/api/farcaster/neynar/cast`,
+      {
+        params: { identifier: castHash, type: "hash" },
+      },
+    );
+
+    const cast = data.cast || data;
+    const username: string = cast?.author?.username || caster;
+    const pfpUrl: string = cast?.author?.pfp_url || "";
+    const text: string = cast?.text || "";
+    let imageUrl: string | undefined;
+
+    if (Array.isArray(cast.embeds)) {
+      for (const embed of cast.embeds) {
+        if ("url" in embed && isImageUrl(embed.url)) {
+          imageUrl = embed.url;
+          break;
+        }
+      }
+    }
+
+    const truncated =
+      text.length > 320 ? `${text.slice(0, 320)}...` : text;
+
+    return getCastMetadataStructure({
+      username,
+      pfpUrl,
+      text: truncated,
+      imageUrl,
+    });
+  } catch (error) {
+    console.error("Error generating cast metadata:", error);
+    return {};
+  }
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/(spaces)/homebase/c/[caster]/[castHash]/layout.tsx
+++ b/src/app/(spaces)/homebase/c/[caster]/[castHash]/layout.tsx
@@ -21,6 +21,7 @@ export async function generateMetadata({
 
     const cast = data.cast || data;
     const username: string = cast?.author?.username || caster;
+    const displayName: string = cast?.author?.display_name || "";
     const pfpUrl: string = cast?.author?.pfp_url || "";
     const text: string = cast?.text || "";
     const timestamp: number | string | undefined = cast?.timestamp;
@@ -40,6 +41,7 @@ export async function generateMetadata({
 
     return getCastMetadataStructure({
       username,
+      displayName,
       pfpUrl,
       text: truncated,
       imageUrl,

--- a/src/app/api/metadata/cast/route.tsx
+++ b/src/app/api/metadata/cast/route.tsx
@@ -1,11 +1,8 @@
 import React from "react";
-import { NextApiRequest, NextApiResponse } from "next";
 import { ImageResponse } from "next/og";
 import { WEBSITE_URL } from "@/constants/app";
 
-export const config = {
-  runtime: "edge",
-};
+export const runtime = "edge";
 
 interface CastCardData {
   username: string;
@@ -16,22 +13,15 @@ interface CastCardData {
   timestamp?: number | string;
 }
 
-export default async function GET(
-  req: NextApiRequest,
-  res: NextApiResponse<ImageResponse | string>,
-) {
-  if (!req.url) {
-    return res.status(404).send("Url not found");
-  }
-
-  const params = new URLSearchParams(req.url.split("?")[1]);
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
   const data: CastCardData = {
-    username: params.get("username") || "",
-    displayName: params.get("displayName") || "",
-    pfpUrl: params.get("pfpUrl") || "",
-    text: params.get("text") || "",
-    imageUrl: params.get("imageUrl") || undefined,
-    timestamp: params.get("timestamp") || undefined,
+    username: searchParams.get("username") || "",
+    displayName: searchParams.get("displayName") || "",
+    pfpUrl: searchParams.get("pfpUrl") || "",
+    text: searchParams.get("text") || "",
+    imageUrl: searchParams.get("imageUrl") || undefined,
+    timestamp: searchParams.get("timestamp") || undefined,
   };
 
   return new ImageResponse(<CastCard data={data} />, {
@@ -128,3 +118,4 @@ const CastCard = ({ data }: { data: CastCardData }) => {
     </div>
   );
 };
+

--- a/src/common/lib/utils/castMetadata.tsx
+++ b/src/common/lib/utils/castMetadata.tsx
@@ -7,6 +7,7 @@ export type CastMetadata = {
   pfpUrl?: string;
   text?: string;
   imageUrl?: string;
+  timestamp?: number | string;
 };
 
 export const getCastMetadataStructure = (
@@ -16,9 +17,19 @@ export const getCastMetadataStructure = (
     return {};
   }
 
-  const { username, pfpUrl, text, imageUrl } = cast;
+  const { username, pfpUrl, text, imageUrl, timestamp } = cast;
 
-  const title = username ? `Cast by @${username}` : "Cast on Nounspace";
+  const dateTitle = timestamp
+    ? new Date(
+        typeof timestamp === "string"
+          ? timestamp
+          : timestamp.toString().length === 10
+            ? timestamp * 1000
+            : timestamp,
+      ).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
+    : undefined;
+
+  const title = dateTitle || (username ? `Cast by @${username}` : "Cast on Nounspace");
 
   const params = new URLSearchParams({
     username: username || "",

--- a/src/common/lib/utils/castMetadata.tsx
+++ b/src/common/lib/utils/castMetadata.tsx
@@ -1,5 +1,5 @@
 import { WEBSITE_URL } from "@/constants/app";
-import { merge } from "lodash";
+// Avoid pulling in the whole lodash/merge for three shallow merges
 import { Metadata } from "next";
 
 export type CastMetadata = {
@@ -37,7 +37,7 @@ export const getCastMetadataStructure = (
 
   const ogImageUrl = `${WEBSITE_URL}/api/metadata/cast?${params.toString()}`;
 
-  const metadata: Metadata = {
+  let metadata: Metadata = {
     title,
     openGraph: {
       title,
@@ -51,11 +51,12 @@ export const getCastMetadataStructure = (
   };
 
   if (text) {
-    merge(metadata, {
+    metadata = {
+      ...metadata,
       description: text,
-      openGraph: { description: text },
-      twitter: { description: text },
-    });
+      openGraph: { ...metadata.openGraph, description: text },
+      twitter: { ...metadata.twitter, description: text },
+    };
   }
 
   return metadata;

--- a/src/common/lib/utils/castMetadata.tsx
+++ b/src/common/lib/utils/castMetadata.tsx
@@ -1,0 +1,54 @@
+import { WEBSITE_URL } from "@/constants/app";
+import { merge } from "lodash";
+import { Metadata } from "next";
+
+export type CastMetadata = {
+  username?: string;
+  pfpUrl?: string;
+  text?: string;
+  imageUrl?: string;
+};
+
+export const getCastMetadataStructure = (
+  cast: CastMetadata,
+): Metadata => {
+  if (!cast) {
+    return {};
+  }
+
+  const { username, pfpUrl, text, imageUrl } = cast;
+
+  const title = username ? `Cast by @${username}` : "Cast on Nounspace";
+
+  const params = new URLSearchParams({
+    username: username || "",
+    pfpUrl: pfpUrl || "",
+    text: text || "",
+    imageUrl: imageUrl || "",
+  });
+
+  const ogImageUrl = `${WEBSITE_URL}/api/metadata/cast?${params.toString()}`;
+
+  const metadata: Metadata = {
+    title,
+    openGraph: {
+      title,
+      images: [ogImageUrl],
+    },
+    twitter: {
+      title,
+      images: [ogImageUrl],
+      card: "summary_large_image",
+    },
+  };
+
+  if (text) {
+    merge(metadata, {
+      description: text,
+      openGraph: { description: text },
+      twitter: { description: text },
+    });
+  }
+
+  return metadata;
+};

--- a/src/common/lib/utils/castMetadata.tsx
+++ b/src/common/lib/utils/castMetadata.tsx
@@ -20,7 +20,25 @@ export const getCastMetadataStructure = (
 
   const { username, displayName, pfpUrl, text, imageUrl, timestamp } = cast;
 
-  const title = username ? `@${username} on Nounspace` : "Cast on Nounspace";
+  const dateTitle = timestamp
+    ? new Date(
+        typeof timestamp === "string"
+          ? timestamp
+          : timestamp.toString().length === 10
+            ? timestamp * 1000
+            : timestamp,
+      ).toLocaleDateString("en-US", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+      })
+    : undefined;
+
+  const title = dateTitle
+    ? dateTitle
+    : username
+      ? `@${username} on Nounspace`
+      : "Cast on Nounspace";
 
   const params = new URLSearchParams({
     username: username || "",

--- a/src/common/lib/utils/castMetadata.tsx
+++ b/src/common/lib/utils/castMetadata.tsx
@@ -4,6 +4,7 @@ import { Metadata } from "next";
 
 export type CastMetadata = {
   username?: string;
+  displayName?: string;
   pfpUrl?: string;
   text?: string;
   imageUrl?: string;
@@ -17,25 +18,17 @@ export const getCastMetadataStructure = (
     return {};
   }
 
-  const { username, pfpUrl, text, imageUrl, timestamp } = cast;
+  const { username, displayName, pfpUrl, text, imageUrl, timestamp } = cast;
 
-  const dateTitle = timestamp
-    ? new Date(
-        typeof timestamp === "string"
-          ? timestamp
-          : timestamp.toString().length === 10
-            ? timestamp * 1000
-            : timestamp,
-      ).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
-    : undefined;
-
-  const title = dateTitle || (username ? `Cast by @${username}` : "Cast on Nounspace");
+  const title = username ? `@${username} on Nounspace` : "Cast on Nounspace";
 
   const params = new URLSearchParams({
     username: username || "",
+    displayName: displayName || "",
     pfpUrl: pfpUrl || "",
     text: text || "",
     imageUrl: imageUrl || "",
+    timestamp: timestamp ? String(timestamp) : "",
   });
 
   const ogImageUrl = `${WEBSITE_URL}/api/metadata/cast?${params.toString()}`;

--- a/src/common/lib/utils/castMetadata.tsx
+++ b/src/common/lib/utils/castMetadata.tsx
@@ -20,22 +20,8 @@ export const getCastMetadataStructure = (
 
   const { username, displayName, pfpUrl, text, imageUrl, timestamp } = cast;
 
-  const dateTitle = timestamp
-    ? new Date(
-        typeof timestamp === "string"
-          ? timestamp
-          : timestamp.toString().length === 10
-            ? timestamp * 1000
-            : timestamp,
-      ).toLocaleDateString("en-US", {
-        month: "long",
-        day: "numeric",
-        year: "numeric",
-      })
-    : undefined;
-
-  const title = dateTitle
-    ? dateTitle
+  const title = displayName
+    ? `${displayName} on Nounspace`
     : username
       ? `@${username} on Nounspace`
       : "Cast on Nounspace";

--- a/src/pages/api/metadata/cast.tsx
+++ b/src/pages/api/metadata/cast.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { NextApiRequest, NextApiResponse } from "next";
 import { ImageResponse } from "next/og";
+import { WEBSITE_URL } from "@/constants/app";
 
 export const config = {
   runtime: "edge",
@@ -8,9 +9,11 @@ export const config = {
 
 interface CastCardData {
   username: string;
+  displayName: string;
   pfpUrl: string;
   text: string;
   imageUrl?: string;
+  timestamp?: number | string;
 }
 
 export default async function GET(
@@ -24,9 +27,11 @@ export default async function GET(
   const params = new URLSearchParams(req.url.split("?")[1]);
   const data: CastCardData = {
     username: params.get("username") || "",
+    displayName: params.get("displayName") || "",
     pfpUrl: params.get("pfpUrl") || "",
     text: params.get("text") || "",
     imageUrl: params.get("imageUrl") || undefined,
+    timestamp: params.get("timestamp") || undefined,
   };
 
   return new ImageResponse(<CastCard data={data} />, {
@@ -36,20 +41,41 @@ export default async function GET(
 }
 
 const CastCard = ({ data }: { data: CastCardData }) => {
+  const dateString = data.timestamp
+    ? new Date(
+        typeof data.timestamp === "string"
+          ? data.timestamp
+          : data.timestamp.toString().length === 10
+            ? data.timestamp * 1000
+            : data.timestamp,
+      ).toLocaleDateString("en-US", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+      })
+    : "";
+
   return (
     <div
       style={{
         width: "100%",
         height: "100%",
-        padding: "40px",
+        padding: "60px",
         display: "flex",
         flexDirection: "column",
         background: "white",
         color: "black",
         fontFamily: "Arial, sans-serif",
         gap: "24px",
+        position: "relative",
       }}
     >
+      <img
+        src={`${WEBSITE_URL}/images/logo.png`}
+        width="80"
+        height="80"
+        style={{ position: "absolute", top: "40px", right: "40px" }}
+      />
       <div style={{ display: "flex", alignItems: "center", gap: "24px" }}>
         {data.pfpUrl && (
           <img
@@ -59,7 +85,27 @@ const CastCard = ({ data }: { data: CastCardData }) => {
             style={{ borderRadius: "60px" }}
           />
         )}
-        <span style={{ fontSize: "48px", fontWeight: "bold" }}>@{data.username}</span>
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          {data.displayName && (
+            <span style={{ fontSize: "48px", fontWeight: "bold" }}>
+              {data.displayName}
+            </span>
+          )}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+              fontSize: "32px",
+              color: "#666",
+            }}
+          >
+            <span>@{data.username}</span>
+            {dateString && (
+              <span>{`\u2022 ${dateString}`}</span>
+            )}
+          </div>
+        </div>
       </div>
       <span style={{ fontSize: "32px", whiteSpace: "pre-wrap" }}>{data.text}</span>
       {data.imageUrl && (

--- a/src/pages/api/metadata/cast.tsx
+++ b/src/pages/api/metadata/cast.tsx
@@ -72,9 +72,9 @@ const CastCard = ({ data }: { data: CastCardData }) => {
     >
       <img
         src={`${WEBSITE_URL}/images/logo.png`}
-        width="80"
-        height="80"
-        style={{ position: "absolute", top: "40px", right: "40px" }}
+        width="120"
+        height="120"
+        style={{ position: "absolute", top: "40px", right: "40px", objectFit: "contain" }}
       />
       <div style={{ display: "flex", alignItems: "center", gap: "24px" }}>
         {data.pfpUrl && (
@@ -107,17 +107,23 @@ const CastCard = ({ data }: { data: CastCardData }) => {
           </div>
         </div>
       </div>
-      <span style={{ fontSize: "32px", whiteSpace: "pre-wrap" }}>{data.text}</span>
-      {data.imageUrl && (
-        <img
-          src={data.imageUrl}
-          style={{
-            width: "100%",
-            maxHeight: "320px",
-            objectFit: "cover",
-            borderRadius: "12px",
-          }}
-        />
+      {data.imageUrl ? (
+        <div style={{ display: "flex", gap: "24px" }}>
+          <span style={{ fontSize: "32px", whiteSpace: "pre-wrap", flex: 1 }}>
+            {data.text}
+          </span>
+          <img
+            src={data.imageUrl}
+            style={{
+              width: "40%",
+              maxHeight: "320px",
+              objectFit: "cover",
+              borderRadius: "12px",
+            }}
+          />
+        </div>
+      ) : (
+        <span style={{ fontSize: "32px", whiteSpace: "pre-wrap" }}>{data.text}</span>
       )}
     </div>
   );

--- a/src/pages/api/metadata/cast.tsx
+++ b/src/pages/api/metadata/cast.tsx
@@ -108,20 +108,33 @@ const CastCard = ({ data }: { data: CastCardData }) => {
         </div>
       </div>
       {data.imageUrl ? (
-        <div style={{ display: "flex", gap: "24px" }}>
-          <span style={{ fontSize: "32px", whiteSpace: "pre-wrap", flex: 1 }}>
-            {data.text}
-          </span>
+        data.text ? (
+          <div style={{ display: "flex", gap: "24px" }}>
+            <span style={{ fontSize: "32px", whiteSpace: "pre-wrap", flex: 1 }}>
+              {data.text}
+            </span>
+            <img
+              src={data.imageUrl}
+              style={{
+                width: "40%",
+                maxHeight: "320px",
+                objectFit: "cover",
+                borderRadius: "12px",
+              }}
+            />
+          </div>
+        ) : (
           <img
             src={data.imageUrl}
             style={{
-              width: "40%",
+              width: "60%",
               maxHeight: "320px",
               objectFit: "cover",
               borderRadius: "12px",
+              alignSelf: "flex-start",
             }}
           />
-        </div>
+        )
       ) : (
         <span style={{ fontSize: "32px", whiteSpace: "pre-wrap" }}>{data.text}</span>
       )}

--- a/src/pages/api/metadata/cast.tsx
+++ b/src/pages/api/metadata/cast.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { NextApiRequest, NextApiResponse } from "next";
+import { ImageResponse } from "next/og";
+
+export const config = {
+  runtime: "edge",
+};
+
+interface CastCardData {
+  username: string;
+  pfpUrl: string;
+  text: string;
+  imageUrl?: string;
+}
+
+export default async function GET(
+  req: NextApiRequest,
+  res: NextApiResponse<ImageResponse | string>,
+) {
+  if (!req.url) {
+    return res.status(404).send("Url not found");
+  }
+
+  const params = new URLSearchParams(req.url.split("?")[1]);
+  const data: CastCardData = {
+    username: params.get("username") || "",
+    pfpUrl: params.get("pfpUrl") || "",
+    text: params.get("text") || "",
+    imageUrl: params.get("imageUrl") || undefined,
+  };
+
+  return new ImageResponse(<CastCard data={data} />, {
+    width: 1200,
+    height: 630,
+  });
+}
+
+const CastCard = ({ data }: { data: CastCardData }) => {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        padding: "40px",
+        display: "flex",
+        flexDirection: "column",
+        background: "white",
+        color: "black",
+        fontFamily: "Arial, sans-serif",
+        gap: "24px",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "24px" }}>
+        {data.pfpUrl && (
+          <img
+            src={data.pfpUrl}
+            width="120"
+            height="120"
+            style={{ borderRadius: "60px" }}
+          />
+        )}
+        <span style={{ fontSize: "48px", fontWeight: "bold" }}>@{data.username}</span>
+      </div>
+      <span style={{ fontSize: "32px", whiteSpace: "pre-wrap" }}>{data.text}</span>
+      {data.imageUrl && (
+        <img
+          src={data.imageUrl}
+          style={{
+            width: "100%",
+            maxHeight: "320px",
+            objectFit: "cover",
+            borderRadius: "12px",
+          }}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/pages/api/metadata/cast.tsx
+++ b/src/pages/api/metadata/cast.tsx
@@ -108,33 +108,20 @@ const CastCard = ({ data }: { data: CastCardData }) => {
         </div>
       </div>
       {data.imageUrl ? (
-        data.text ? (
-          <div style={{ display: "flex", gap: "24px" }}>
-            <span style={{ fontSize: "32px", whiteSpace: "pre-wrap", flex: 1 }}>
-              {data.text}
-            </span>
-            <img
-              src={data.imageUrl}
-              style={{
-                width: "40%",
-                maxHeight: "320px",
-                objectFit: "cover",
-                borderRadius: "12px",
-              }}
-            />
-          </div>
-        ) : (
+        <div style={{ display: "flex", gap: "24px" }}>
+          <span style={{ fontSize: "32px", whiteSpace: "pre-wrap", flex: 1 }}>
+            {data.text}
+          </span>
           <img
             src={data.imageUrl}
             style={{
-              width: "60%",
+              width: "40%",
               maxHeight: "320px",
               objectFit: "cover",
               borderRadius: "12px",
-              alignSelf: "flex-start",
             }}
           />
-        )
+        </div>
       ) : (
         <span style={{ fontSize: "32px", whiteSpace: "pre-wrap" }}>{data.text}</span>
       )}


### PR DESCRIPTION
## Summary
- generate open graph images for casts via new API endpoint
- build metadata for casts with `getCastMetadataStructure`
- provide metadata in cast routes

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684c13558058832586591f70f74836c4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added dynamic metadata and social media preview images for individual casts, enhancing SEO and sharing experience.
	- Introduced visually rich Open Graph and Twitter card images, including profile picture, username, cast text, and optional images.
- **Bug Fixes**
	- Improved handling of missing or invalid cast data to prevent errors and ensure graceful fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->