### PR TITLE
[CLIENT] refactor cast metadata API

### DIFF
--- a/src/app/(spaces)/homebase/c/[caster]/[castHash]/layout.tsx
+++ b/src/app/(spaces)/homebase/c/[caster]/[castHash]/layout.tsx
@@ -1,6 +1,6 @@
 import { WEBSITE_URL } from "@/constants/app";
-import { Metadata } from "next/types";
-import axios from "axios";
+import type { Metadata } from "next";
+// axios adds ~30 kB; built-in fetch is sufficient here
 import { getCastMetadataStructure } from "@/common/lib/utils/castMetadata";
 import { isImageUrl } from "@/common/lib/utils/urls";
 
@@ -12,12 +12,8 @@ export async function generateMetadata({
   }
 
   try {
-    const { data } = await axios.get(
-      `${WEBSITE_URL}/api/farcaster/neynar/cast`,
-      {
-        params: { identifier: castHash, type: "hash" },
-      },
-    );
+    const url = `${WEBSITE_URL}/api/farcaster/neynar/cast?identifier=${castHash}&type=hash`;
+    const data = await fetch(url).then(r => r.json());
 
     const cast = data.cast || data;
     const username: string = cast?.author?.username || caster;

--- a/src/app/api/metadata/cast/route.tsx
+++ b/src/app/api/metadata/cast/route.tsx
@@ -1,11 +1,8 @@
 import React from "react";
-import { NextApiRequest, NextApiResponse } from "next";
-import { ImageResponse } from "next/og";
+import { ImageResponse } from "next/server";
 import { WEBSITE_URL } from "@/constants/app";
 
-export const config = {
-  runtime: "edge",
-};
+export const runtime = "edge";
 
 interface CastCardData {
   username: string;
@@ -16,24 +13,16 @@ interface CastCardData {
   timestamp?: number | string;
 }
 
-export default async function GET(
-  req: NextApiRequest,
-  res: NextApiResponse<ImageResponse | string>,
-) {
-  if (!req.url) {
-    return res.status(404).send("Url not found");
-  }
-
-  const params = new URLSearchParams(req.url.split("?")[1]);
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
   const data: CastCardData = {
-    username: params.get("username") || "",
-    displayName: params.get("displayName") || "",
-    pfpUrl: params.get("pfpUrl") || "",
-    text: params.get("text") || "",
-    imageUrl: params.get("imageUrl") || undefined,
-    timestamp: params.get("timestamp") || undefined,
+    username: searchParams.get("username") || "",
+    displayName: searchParams.get("displayName") || "",
+    pfpUrl: searchParams.get("pfpUrl") || "",
+    text: searchParams.get("text") || "",
+    imageUrl: searchParams.get("imageUrl") || undefined,
+    timestamp: searchParams.get("timestamp") || undefined,
   };
-
   return new ImageResponse(<CastCard data={data} />, {
     width: 1200,
     height: 630,

--- a/src/common/lib/utils/castMetadata.tsx
+++ b/src/common/lib/utils/castMetadata.tsx
@@ -1,5 +1,5 @@
 import { WEBSITE_URL } from "@/constants/app";
-import { merge } from "lodash";
+// Avoid pulling in the whole lodash/merge for three shallow merges
 import { Metadata } from "next";
 
 export type CastMetadata = {
@@ -51,11 +51,12 @@ export const getCastMetadataStructure = (
   };
 
   if (text) {
-    merge(metadata, {
+    return {
+      ...metadata,
       description: text,
-      openGraph: { description: text },
-      twitter: { description: text },
-    });
+      openGraph: { ...metadata.openGraph, description: text },
+      twitter: { ...metadata.twitter, description: text },
+    };
   }
 
   return metadata;


### PR DESCRIPTION
## Summary
- move cast image API to app router with edge runtime
- compose cast metadata immutably
- use native fetch instead of axios

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684cd917cf808325a940ec1c93b2dcf3