### PR TITLE
Fix video embeds

### DIFF
--- a/src/common/lib/utils/urls.ts
+++ b/src/common/lib/utils/urls.ts
@@ -17,17 +17,25 @@ export const isWebUrl = (url: string) => {
   return url.match(/^(http|https):\/\//) != null;
 };
 
-export const isVideoUrl = (url: string) => {
+const VIDEO_STREAM_DOMAINS = [
+  "https://stream.warpcast.com",
+  "https://stream.farcaster.xyz",
+];
+
+const VIDEO_PATH_REGEX = /\/~\/(video|shorts)\//i;
+
+const VIDEO_EXTENSION_REGEX = /\.(m3u8|mp4|webm|mov|ogg)(\?|$)/i;
+
+export const isVideoUrl = (url: string): boolean => {
   if (!url) {
     return false;
   }
 
+  const lowerUrl = url.toLowerCase();
+
   return (
-    url.startsWith("https://stream.warpcast.com") ||
-    url.startsWith("https://stream.farcaster.xyz") ||
-    url.includes("/~/video/") ||
-    url.includes("/~/shorts/") ||
-    /\.m3u8($|\?)/.test(url) ||
-    /\.mp4($|\?)/.test(url)
+    VIDEO_STREAM_DOMAINS.some((domain) => lowerUrl.startsWith(domain)) ||
+    VIDEO_PATH_REGEX.test(lowerUrl) ||
+    VIDEO_EXTENSION_REGEX.test(lowerUrl)
   );
 };

--- a/src/common/lib/utils/urls.ts
+++ b/src/common/lib/utils/urls.ts
@@ -16,3 +16,18 @@ export const isWebUrl = (url: string) => {
 
   return url.match(/^(http|https):\/\//) != null;
 };
+
+export const isVideoUrl = (url: string) => {
+  if (!url) {
+    return false;
+  }
+
+  return (
+    url.startsWith("https://stream.warpcast.com") ||
+    url.startsWith("https://stream.farcaster.xyz") ||
+    url.includes("/~/video/") ||
+    url.includes("/~/shorts/") ||
+    /\.m3u8($|\?)/.test(url) ||
+    /\.mp4($|\?)/.test(url)
+  );
+};

--- a/src/fidgets/farcaster/components/Embeds/index.tsx
+++ b/src/fidgets/farcaster/components/Embeds/index.tsx
@@ -7,7 +7,7 @@ import ParagraphXyzEmbed from "./ParagraphXyzEmbed";
 import VideoEmbed from "./VideoEmbed";
 import ImageEmbed from "./ImageEmbed";
 import FrameEmbed from "./FrameEmbed";
-import { isImageUrl } from "@/common/lib/utils/urls";
+import { isImageUrl, isVideoUrl } from "@/common/lib/utils/urls";
 import CreateCastImage from "./createCastImage";
 
 export type CastEmbed = {
@@ -38,7 +38,7 @@ export const renderEmbedForUrl = ({ url, castId, key }: CastEmbed, isCreateCast:
   }
   else if (url.startsWith('"chain:')) {
     return <OnchainEmbed url={url} key={key} />;
-  } else if (url.startsWith("https://stream.warpcast.com")) {
+  } else if (isVideoUrl(url)) {
     return <VideoEmbed url={url} key={key} />;
   } else if (url.startsWith("https://warpcast.com") && !url.includes("/~/")) {
     return <EmbededCast url={url} key={key} />;

--- a/tests/urls.test.ts
+++ b/tests/urls.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { isVideoUrl } from '../src/common/lib/utils/urls';
+
+describe('isVideoUrl', () => {
+  it('detects video URLs regardless of case', () => {
+    expect(isVideoUrl('https://stream.warpcast.com/clip.mp4')).toBe(true);
+    expect(isVideoUrl('https://STREAM.WARPCAST.COM/CLIP.MP4')).toBe(true);
+    expect(isVideoUrl('https://Stream.Warpcast.com/video.WEBM')).toBe(true);
+    expect(isVideoUrl('https://warpcast.com/~/video/123')).toBe(true);
+    expect(isVideoUrl('https://example.com/test.MOV')).toBe(true);
+  });
+
+  it('returns false for non-video URLs', () => {
+    expect(isVideoUrl('https://example.com/image.png')).toBe(false);
+  });
+});


### PR DESCRIPTION
Currently in-feed videos are broken in both staging and prod, and do not render in the feed. This fixes and also expands the list of detected video domains

## Summary
- detect new Farcaster video URLs in embeds
- support additional video domains

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_684cd98e2fb48325992d5a949cb20ed7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved detection of video links, enabling video embeds for a wider range of supported video URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->