### PR TITLE
Add basic channel spaces

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -20,7 +20,7 @@ import { createEditabilityChecker } from "@/common/utils/spaceEditability";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialPersonSpace";
 const FARCASTER_NOUNSPACE_AUTHENTICATOR_NAME = "farcaster:nounspace";
 
-export type SpacePageType = "profile" | "token" | "proposal";
+export type SpacePageType = "profile" | "token" | "proposal" | "channel";
 
 interface PublicSpaceProps {
   spaceId: string | null;

--- a/src/app/(spaces)/channel/[channelName]/ChannelSpace.tsx
+++ b/src/app/(spaces)/channel/[channelName]/ChannelSpace.tsx
@@ -1,0 +1,25 @@
+"use client";
+import React from "react";
+import PublicSpace from "../../PublicSpace";
+import createInitialChannelSpaceConfig from "@/constants/initialChannelSpace";
+import { Channel } from "@neynar/nodejs-sdk/build/api";
+
+interface ChannelSpaceProps {
+  channel: Channel;
+}
+
+export default function ChannelSpace({ channel }: ChannelSpaceProps) {
+  const INITIAL_CONFIG = createInitialChannelSpaceConfig(channel.id);
+  const getSpacePageUrl = (tabName: string) => `/channel/${channel.id}/${tabName}`;
+
+  return (
+    <PublicSpace
+      spaceId={null}
+      tabName="Profile"
+      initialConfig={INITIAL_CONFIG}
+      getSpacePageUrl={getSpacePageUrl}
+      spaceOwnerFid={channel.lead?.fid}
+      pageType="channel"
+    />
+  );
+}

--- a/src/app/(spaces)/channel/[channelName]/[tabName]/page.tsx
+++ b/src/app/(spaces)/channel/[channelName]/[tabName]/page.tsx
@@ -1,0 +1,3 @@
+import ChannelSpacePage from "../page";
+
+export default ChannelSpacePage;

--- a/src/app/(spaces)/channel/[channelName]/layout.tsx
+++ b/src/app/(spaces)/channel/[channelName]/layout.tsx
@@ -1,0 +1,3 @@
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/(spaces)/channel/[channelName]/page.tsx
+++ b/src/app/(spaces)/channel/[channelName]/page.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import ChannelSpace from "./ChannelSpace";
+import { getChannelInfo } from "./utils";
+
+export default async function ChannelSpacePage({ params }) {
+  const channelName = params?.channelName as string;
+  const channel = await getChannelInfo(channelName);
+  if (!channel) {
+    return <div>Channel not found</div>;
+  }
+  return (
+    <ChannelSpace channel={channel} />
+  );
+}

--- a/src/app/(spaces)/channel/[channelName]/utils.ts
+++ b/src/app/(spaces)/channel/[channelName]/utils.ts
@@ -1,0 +1,15 @@
+import axiosBackend from "@/common/data/api/backend";
+import { ChannelResponse } from "@neynar/nodejs-sdk/build/api";
+
+export const getChannelInfo = async (name: string) => {
+  try {
+    const { data } = await axiosBackend.get<ChannelResponse>(
+      "/api/farcaster/neynar/channel",
+      { params: { channel_id: name } },
+    );
+    return data.channel;
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+};

--- a/src/common/components/organisms/SearchAutocompleteInput.tsx
+++ b/src/common/components/organisms/SearchAutocompleteInput.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, Suspense } from "react";
 import { useRouter } from "next/navigation";
 import useSearchUsers from "@/common/lib/hooks/useSearchUsers";
+import { useChannelsByName } from "@/common/lib/hooks/useChannels";
 import { User } from "@neynar/nodejs-sdk/build/api";
 import { Avatar, AvatarImage } from "@/common/components/atoms/avatar";
 import {
@@ -34,6 +35,7 @@ const SearchAutocompleteInputContent: React.FC<SearchAutocompleteInputProps> = (
   const [isFocused, setIsFocused] = useState(false);
   const [query, setQuery] = useState<string | null>(null);
   const { users, loading } = useSearchUsers(query);
+  const { data: channels } = useChannelsByName(query || "");
 
   const handleFocus = useCallback(() => {
     setIsFocused(true);
@@ -57,11 +59,16 @@ const SearchAutocompleteInputContent: React.FC<SearchAutocompleteInputProps> = (
     onSelect && onSelect();
   }, []);
 
+  const onSelectChannel = useCallback((name: string) => {
+    router.push(`/channel/${name}`);
+    onSelect && onSelect();
+  }, []);
+
   return (
     <Command className="rounded-md border" shouldFilter={false} loop={true}>
       <div className={loading ? "animated-loading-bar" : ""}>
         <CommandInput
-          placeholder="Search users"
+          placeholder="Search users or channels"
           onValueChange={setQuery}
           value={query || ""}
           onFocus={handleFocus}
@@ -101,6 +108,26 @@ const SearchAutocompleteInputContent: React.FC<SearchAutocompleteInputProps> = (
                   <div className="leading-[1.3]">
                     <p className="font-bold opacity-80">{user.display_name}</p>
                     <p className="font-normal opacity-80">@{user.username}</p>
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+          {channels && channels.length > 0 && (
+            <CommandGroup heading="Channels">
+              {channels.map((ch: any, i: number) => (
+                <CommandItem
+                  key={`ch-${i}`}
+                  onSelect={() => onSelectChannel(ch.id)}
+                  value={ch.id}
+                  className="gap-x-2 cursor-pointer"
+                >
+                  <Avatar className="h-12 w-12">
+                    <AvatarImage src={ch.image_url} alt={ch.name} />
+                  </Avatar>
+                  <div className="leading-[1.3]">
+                    <p className="font-bold opacity-80">{ch.name}</p>
+                    <p className="font-normal opacity-80">/{ch.id}</p>
                   </div>
                 </CommandItem>
               ))}

--- a/src/constants/initialChannelSpace.ts
+++ b/src/constants/initialChannelSpace.ts
@@ -1,0 +1,41 @@
+import { SpaceConfig } from "@/app/(spaces)/Space";
+import { cloneDeep } from "lodash";
+import { INITIAL_SPACE_CONFIG_EMPTY } from "./initialPersonSpace";
+import { FeedType } from "@neynar/nodejs-sdk/build/api";
+import { FilterType } from "@/fidgets/farcaster/Feed";
+
+export const createInitialChannelSpaceConfig = (channelName: string): Omit<SpaceConfig, "isEditable"> => {
+  const config = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
+  config.fidgetInstanceDatums = {
+    "feed:channel": {
+      config: {
+        editable: false,
+        settings: {
+          selectPlatform: { name: "Farcaster", icon: "/images/farcaster.jpeg" },
+          feedType: FeedType.Filter,
+          filterType: FilterType.Channel,
+          channel: channelName,
+        },
+        data: {},
+      },
+      fidgetType: "feed",
+      id: "feed:channel",
+    },
+  };
+  config.layoutDetails.layoutConfig.layout.push({
+    w: 6,
+    h: 8,
+    x: 0,
+    y: 0,
+    i: "feed:channel",
+    minW: 4,
+    maxW: 36,
+    minH: 6,
+    maxH: 36,
+    moved: false,
+    static: false,
+  });
+  return config;
+};
+
+export default createInitialChannelSpaceConfig;

--- a/src/fidgets/farcaster/ChannelInfo.tsx
+++ b/src/fidgets/farcaster/ChannelInfo.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { FidgetArgs, FidgetModule, FidgetProperties } from "@/common/fidgets";
+import { Channel } from "@neynar/nodejs-sdk/build/api";
+import { useQuery } from "@tanstack/react-query";
+import axiosBackend from "@/common/data/api/backend";
+import { Button } from "@/common/components/atoms/button";
+import TextInput from "@/common/components/molecules/TextInput";
+
+export type ChannelInfoSettings = { channel: string };
+
+const properties: FidgetProperties<ChannelInfoSettings> = {
+  fidgetName: "Channel",
+  fields: [
+    { fieldName: "channel", default: "", required: true, inputSelector: TextInput },
+  ],
+  icon: 0x1f4e2,
+  size: { minHeight: 3, maxHeight: 12, minWidth: 4, maxWidth: 12 },
+};
+
+function useChannel(name: string) {
+  return useQuery({
+    queryKey: ["channel-info", name],
+    queryFn: async () => {
+      const { data } = await axiosBackend.get(`/api/farcaster/neynar/channel`, { params: { channel_id: name } });
+      return (data as { channel: Channel }).channel as Channel;
+    },
+  });
+}
+
+const ChannelInfo: React.FC<FidgetArgs<ChannelInfoSettings>> = ({ settings }) => {
+  const { data: channel } = useChannel(settings.channel);
+
+  if (!channel) return <div className="p-4">Loading...</div>;
+  return (
+    <div className="p-4 space-y-1">
+      <div className="font-bold text-lg">{channel.name}</div>
+      <div className="text-sm text-gray-500">/{channel.id}</div>
+      <div className="text-sm">{channel.description}</div>
+      {channel.external_link?.url && (
+        <a href={channel.external_link.url} className="text-blue-500" target="_blank" rel="noreferrer">
+          {channel.external_link.url}
+        </a>
+      )}
+      <div className="text-sm">{channel.member_count} members · {channel.follower_count} followers</div>
+      <Button variant="secondary" size="sm">Follow</Button>
+    </div>
+  );
+};
+
+export default {
+  fidget: ChannelInfo,
+  properties,
+} as FidgetModule<FidgetArgs<ChannelInfoSettings>>;

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -476,12 +476,13 @@ const CastReactions = ({ cast }: { cast: CastWithInteractions }) => {
           getIconForCastReactionType(CastReactionType.quote),
         )}
         {cast.channel && cast.channel.name && (
-          <div
+          <PriorityLink
+            href={`/channel/${cast.channel.name}`}
             key={`cast-${cast.hash}-channel-name`}
             className="mt-1.5 flex align-center text-sm opacity-40 py-1 px-1.5 rounded-md"
           >
             /{cast.channel.name}
-          </div>
+          </PriorityLink>
         )}
       </div>
     </>

--- a/src/fidgets/index.ts
+++ b/src/fidgets/index.ts
@@ -9,6 +9,7 @@ import Grid from "./layout/Grid";
 import NounishGovernance from "./community/nouns-dao/NounishGovernance";
 import Cast from "./farcaster/Cast";
 import Feed from "./farcaster/Feed";
+import ChannelInfo from "./farcaster/ChannelInfo";
 // import CreateCast from "./farcaster/CreateCast";
 import Links from "./ui/Links";
 import snapShot from "./snapshot/SnapShot";
@@ -34,6 +35,7 @@ export const CompleteFidgets = {
   // iframely: iframely,
   feed: Feed,
   cast: Cast,
+  channel: ChannelInfo,
   // createCast: CreateCast,
   // Basic UI elements
   gallery: Gallery,


### PR DESCRIPTION
## Summary
- add ChannelInfo fidget to show channel details
- allow searching channels in SearchAutocompleteInput
- link cast channel names to channel spaces
- initialize channel spaces with Farcaster feed filtered to channel
- add /channel pages and PublicSpace support for channel type

## Testing
- `npm run lint`
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_684ce0d45bac8325866ae1c89836fe1d