### PR TITLE
Add basic Farcaster channel space

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -20,7 +20,7 @@ import { createEditabilityChecker } from "@/common/utils/spaceEditability";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialPersonSpace";
 const FARCASTER_NOUNSPACE_AUTHENTICATOR_NAME = "farcaster:nounspace";
 
-export type SpacePageType = "profile" | "token" | "proposal";
+export type SpacePageType = "profile" | "token" | "proposal" | "channel";
 
 interface PublicSpaceProps {
   spaceId: string | null;
@@ -156,9 +156,9 @@ export default function PublicSpace({
   const resolvedPageType = useMemo(() => {
     if (pageType) return pageType;
     if (isTokenPage) return "token";
-    if (spaceOwnerFid) return "person";
     if (providedSpaceId?.startsWith("proposal:")) return "proposal";
-    return "person"; // Default to person page
+    if (spaceOwnerFid) return "profile";
+    return "profile";
   }, [pageType, isTokenPage, spaceOwnerFid, providedSpaceId]);
 
   console.log("Resolved page type:", resolvedPageType);
@@ -183,7 +183,7 @@ export default function PublicSpace({
         nextSpaceId = existingSpace.id;
         nextTabName = decodeURIComponent(providedTabName);
       }
-    } else if (resolvedPageType === "person" && spaceOwnerFid) {
+    } else if (resolvedPageType === "profile" && spaceOwnerFid) {
       const existingSpace = Object.values(localSpacesSnapshot).find(
         (space) => space.fid === spaceOwnerFid,
       );

--- a/src/app/(spaces)/channel/[channelName]/ChannelSpace.tsx
+++ b/src/app/(spaces)/channel/[channelName]/ChannelSpace.tsx
@@ -1,0 +1,41 @@
+"use client";
+import React from "react";
+import { isArray, isNil } from "lodash";
+import SpaceNotFound from "@/app/(spaces)/SpaceNotFound";
+import createInitialChannelSpaceConfig from "@/constants/initialChannelSpace";
+import PublicSpace from "../../PublicSpace";
+
+export interface ChannelSpaceProps {
+  channelName: string | null;
+  ownerFid: number | null;
+  spaceId: string | null;
+  tabName: string | string[] | null | undefined;
+}
+
+export const ChannelSpace = ({
+  channelName,
+  ownerFid,
+  spaceId,
+  tabName,
+}: ChannelSpaceProps) => {
+  if (isNil(channelName) || isNil(ownerFid)) {
+    return <SpaceNotFound />;
+  }
+
+  const initialConfig = createInitialChannelSpaceConfig(channelName);
+
+  const getSpacePageUrl = (tabName: string) => `/channel/${channelName}/${tabName}`;
+
+  return (
+    <PublicSpace
+      spaceId={spaceId}
+      tabName={isArray(tabName) ? tabName[0] : tabName ?? "Profile"}
+      initialConfig={initialConfig}
+      getSpacePageUrl={getSpacePageUrl}
+      spaceOwnerFid={ownerFid}
+      pageType="channel"
+    />
+  );
+};
+
+export default ChannelSpace;

--- a/src/app/(spaces)/channel/[channelName]/[tabName]/page.tsx
+++ b/src/app/(spaces)/channel/[channelName]/[tabName]/page.tsx
@@ -1,0 +1,2 @@
+import ChannelPage from "../page";
+export default ChannelPage;

--- a/src/app/(spaces)/channel/[channelName]/layout.tsx
+++ b/src/app/(spaces)/channel/[channelName]/layout.tsx
@@ -1,0 +1,4 @@
+import React from "react";
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/(spaces)/channel/[channelName]/page.tsx
+++ b/src/app/(spaces)/channel/[channelName]/page.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { unstable_noStore as noStore } from "next/cache";
+import ChannelSpace from "./ChannelSpace";
+import createSupabaseServerClient from "@/common/data/database/supabase/clients/server";
+import axiosBackend from "@/common/data/api/backend";
+
+interface ChannelPageProps {
+  params: { channelName?: string; tabName?: string };
+}
+
+const loadChannelSpaceData = async (channelName: string, tabNameParam?: string) => {
+  noStore();
+  const { data } = await axiosBackend.get<{ channel: any }>(
+    "/api/farcaster/neynar/channel",
+    { params: { id: channelName } },
+  );
+  const ownerFid = data.channel?.host || null;
+
+  const { data: registrations } = await createSupabaseServerClient()
+    .from("spaceRegistrations")
+    .select("spaceId, spaceName, channelName")
+    .eq("channelName", channelName)
+    .limit(1);
+
+  const spaceId = registrations?.[0]?.spaceId || null;
+  const tabName = tabNameParam || "Profile";
+
+  return { ownerFid, spaceId, tabName };
+};
+
+const ChannelPage = async ({ params }: ChannelPageProps) => {
+  const { channelName, tabName } = params;
+  if (!channelName) return null;
+  const { ownerFid, spaceId, tabName: defaultTab } = await loadChannelSpaceData(
+    channelName,
+    tabName,
+  );
+
+  return (
+    <ChannelSpace
+      channelName={channelName}
+      ownerFid={ownerFid}
+      spaceId={spaceId}
+      tabName={defaultTab}
+    />
+  );
+};
+
+export default ChannelPage;

--- a/src/common/components/organisms/SearchAutocompleteInput.tsx
+++ b/src/common/components/organisms/SearchAutocompleteInput.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, Suspense } from "react";
 import { useRouter } from "next/navigation";
 import useSearchUsers from "@/common/lib/hooks/useSearchUsers";
+import { useChannelsByName } from "@/common/lib/hooks/useChannels";
 import { User } from "@neynar/nodejs-sdk/build/api";
 import { Avatar, AvatarImage } from "@/common/components/atoms/avatar";
 import {
@@ -34,6 +35,7 @@ const SearchAutocompleteInputContent: React.FC<SearchAutocompleteInputProps> = (
   const [isFocused, setIsFocused] = useState(false);
   const [query, setQuery] = useState<string | null>(null);
   const { users, loading } = useSearchUsers(query);
+  const { data: channels } = useChannelsByName(query || "");
 
   const handleFocus = useCallback(() => {
     setIsFocused(true);
@@ -61,7 +63,7 @@ const SearchAutocompleteInputContent: React.FC<SearchAutocompleteInputProps> = (
     <Command className="rounded-md border" shouldFilter={false} loop={true}>
       <div className={loading ? "animated-loading-bar" : ""}>
         <CommandInput
-          placeholder="Search users"
+          placeholder="Search users or channels"
           onValueChange={setQuery}
           value={query || ""}
           onFocus={handleFocus}
@@ -101,6 +103,31 @@ const SearchAutocompleteInputContent: React.FC<SearchAutocompleteInputProps> = (
                   <div className="leading-[1.3]">
                     <p className="font-bold opacity-80">{user.display_name}</p>
                     <p className="font-normal opacity-80">@{user.username}</p>
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+          {channels && channels.length > 0 && (
+            <CommandGroup heading="Channels">
+              {channels.map((channel, idx) => (
+                <CommandItem
+                  key={idx}
+                  onSelect={() => {
+                    router.push(`/channel/${channel.name}`);
+                    onSelect && onSelect();
+                  }}
+                  value={channel.name}
+                  className="gap-x-2 cursor-pointer"
+                >
+                  {channel.image_url && (
+                    <Avatar className="h-12 w-12">
+                      <AvatarImage src={channel.image_url} alt={channel.name} />
+                    </Avatar>
+                  )}
+                  <div className="leading-[1.3]">
+                    <p className="font-bold opacity-80">{channel.display_name}</p>
+                    <p className="font-normal opacity-80">/{channel.name}</p>
                   </div>
                 </CommandItem>
               ))}

--- a/src/constants/initialChannelSpace.ts
+++ b/src/constants/initialChannelSpace.ts
@@ -1,0 +1,42 @@
+import { SpaceConfig } from "@/app/(spaces)/Space";
+import DEFAULT_THEME from "@/common/lib/theme/defaultTheme";
+import { FeedType, FilterType } from "@/fidgets/farcaster/Feed";
+import { cloneDeep } from "lodash";
+import { INITIAL_SPACE_CONFIG_EMPTY } from "./initialPersonSpace";
+
+export default function createInitialChannelSpaceConfig(
+  channelName: string,
+): Omit<SpaceConfig, "isEditable"> {
+  const config = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
+  config.fidgetInstanceDatums = {
+    "feed:channel": {
+      config: {
+        editable: false,
+        settings: {
+          feedType: FeedType.Filter,
+          filterType: FilterType.Channel,
+          channel: channelName,
+          selectPlatform: { name: "Farcaster", icon: "/images/farcaster.jpeg" },
+        },
+        data: {},
+      },
+      fidgetType: "feed",
+      id: "feed:channel",
+    },
+  };
+  config.layoutDetails.layoutConfig.layout.push({
+    w: 6,
+    h: 8,
+    x: 0,
+    y: 0,
+    i: "feed:channel",
+    minW: 4,
+    maxW: 36,
+    minH: 6,
+    maxH: 36,
+    moved: false,
+    static: false,
+  });
+  config.theme = DEFAULT_THEME;
+  return config;
+}

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -476,12 +476,13 @@ const CastReactions = ({ cast }: { cast: CastWithInteractions }) => {
           getIconForCastReactionType(CastReactionType.quote),
         )}
         {cast.channel && cast.channel.name && (
-          <div
+          <PriorityLink
             key={`cast-${cast.hash}-channel-name`}
+            href={`/channel/${cast.channel.name}`}
             className="mt-1.5 flex align-center text-sm opacity-40 py-1 px-1.5 rounded-md"
           >
             /{cast.channel.name}
-          </div>
+          </PriorityLink>
         )}
       </div>
     </>

--- a/src/fidgets/index.ts
+++ b/src/fidgets/index.ts
@@ -5,6 +5,7 @@ import Gallery from "./ui/gallery";
 import TextFidget from "./ui/Text";
 import IFrame from "./ui/IFrame";
 import Profile from "./ui/profile";
+import ChannelInfo from "./ui/channel";
 import Grid from "./layout/Grid";
 import NounishGovernance from "./community/nouns-dao/NounishGovernance";
 import Cast from "./farcaster/Cast";
@@ -29,6 +30,7 @@ export const CompleteFidgets = {
   FramesV2: FramesFidget,
   profile:
     process.env.NEXT_PUBLIC_VERCEL_ENV === "development" ? Profile : undefined,
+  channel: ChannelInfo,
   // Farcaster
   frame: Frame,
   // iframely: iframely,

--- a/src/fidgets/ui/channel.tsx
+++ b/src/fidgets/ui/channel.tsx
@@ -1,0 +1,90 @@
+import { Button } from "@/common/components/atoms/button";
+import TextInput from "@/common/components/molecules/TextInput";
+import axiosBackend from "@/common/data/api/backend";
+import { FidgetArgs, FidgetModule, FidgetProperties } from "@/common/fidgets";
+import { defaultStyleFields } from "@/fidgets/helpers";
+import { Channel } from "@mod-protocol/farcaster";
+import { useQuery } from "@tanstack/react-query";
+import { isUndefined } from "lodash";
+import React from "react";
+
+export type ChannelInfoFidgetSettings = { name: string };
+
+const properties: FidgetProperties = {
+  fidgetName: "Channel",
+  icon: 0x1f4e2,
+  fields: [
+    { fieldName: "name", default: "", required: true, inputSelector: TextInput },
+    ...defaultStyleFields,
+  ],
+  size: { minHeight: 3, maxHeight: 36, minWidth: 4, maxWidth: 36 },
+};
+
+const useChannelInfo = (name: string) => {
+  return useQuery({
+    queryKey: ["channel-info", name],
+    enabled: !!name,
+    queryFn: async () => {
+      const { data } = await axiosBackend.get<{ channel: Channel }>(
+        "/api/farcaster/neynar/channel",
+        { params: { id: name } },
+      );
+      return data.channel;
+    },
+  });
+};
+
+const ChannelInfo: React.FC<FidgetArgs<ChannelInfoFidgetSettings>> = ({
+  settings: { name },
+}) => {
+  const { data: channel } = useChannelInfo(name);
+
+  if (isUndefined(channel)) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  return (
+    <div className="p-4 flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        {channel.image_url && (
+          <img src={channel.image_url} alt={channel.name} className="h-10 w-10 rounded" />
+        )}
+        <div className="flex flex-col">
+          <span className="font-bold">{channel.display_name}</span>
+          <span className="text-sm opacity-70">/{channel.name}</span>
+        </div>
+      </div>
+      {channel.description && <p className="text-sm">{channel.description}</p>}
+      <div className="text-sm opacity-70 flex gap-4">
+        <span>{channel.following_count} members</span>
+        <span>{channel.follower_count} followers</span>
+      </div>
+      {channel.parent_url && (
+        <a
+          href={channel.parent_url}
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-500 hover:underline text-sm"
+        >
+          {channel.parent_url}
+        </a>
+      )}
+      <div>
+        <Button asChild size="sm">
+          <a
+            href={`https://warpcast.com/~/channel/${channel.name}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Follow
+          </a>
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default {
+  fidget: ChannelInfo,
+  properties,
+} as FidgetModule<FidgetArgs<ChannelInfoFidgetSettings>>;


### PR DESCRIPTION
## Summary
- add initial channel space config
- create Channel info fidget
- allow search for channels
- link casts to channel spaces
- add new Channel space route and support new page type

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684ce0d45bac8325866ae1c89836fe1d