### PR TITLE
Add basic Farcaster channel spaces

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -20,7 +20,7 @@ import { createEditabilityChecker } from "@/common/utils/spaceEditability";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialPersonSpace";
 const FARCASTER_NOUNSPACE_AUTHENTICATOR_NAME = "farcaster:nounspace";
 
-export type SpacePageType = "profile" | "token" | "proposal";
+export type SpacePageType = "profile" | "token" | "proposal" | "channel";
 
 interface PublicSpaceProps {
   spaceId: string | null;
@@ -160,6 +160,8 @@ export default function PublicSpace({
     if (providedSpaceId?.startsWith("proposal:")) return "proposal";
     return "person"; // Default to person page
   }, [pageType, isTokenPage, spaceOwnerFid, providedSpaceId]);
+
+  const isChannelPage = resolvedPageType === "channel";
 
   console.log("Resolved page type:", resolvedPageType);
 
@@ -419,6 +421,14 @@ export default function PublicSpace({
               newSpaceId,
               contractAddress,
             });
+          } else if (isChannelPage) {
+            newSpaceId = await registerSpaceFid(
+              currentUserFid,
+              "Feed",
+              getSpacePageUrl("Feed"),
+            );
+            const newUrl = getSpacePageUrl("Feed");
+            router.replace(newUrl, { scroll: false });
           } else if (!isTokenPage) {
             console.log("Attempting to register user space:", {
               currentUserFid,
@@ -478,6 +488,7 @@ export default function PublicSpace({
     isTokenPage,
     contractAddress,
     tokenData?.network,
+    isChannelPage,
     getCurrentSpaceId,
     getCurrentTabName,
     localSpaces,

--- a/src/app/(spaces)/channel/[channelName]/layout.tsx
+++ b/src/app/(spaces)/channel/[channelName]/layout.tsx
@@ -1,0 +1,6 @@
+export const dynamic = "force-static";
+export const revalidate = 60;
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/(spaces)/channel/[channelName]/page.tsx
+++ b/src/app/(spaces)/channel/[channelName]/page.tsx
@@ -1,0 +1,54 @@
+import createInitialChannelSpaceConfig from "@/constants/initialChannelSpace";
+import PublicSpace from "@/app/(spaces)/PublicSpace";
+import SpaceNotFound from "@/app/(spaces)/SpaceNotFound";
+import axiosBackend from "@/common/data/api/backend";
+import createSupabaseServerClient from "@/common/data/database/supabase/clients/server";
+import { Channel } from "@mod-protocol/farcaster";
+import { unstable_noStore as noStore } from 'next/cache';
+
+async function loadChannelInfo(channel: string): Promise<Channel | null> {
+  try {
+    const { data } = await axiosBackend.get<{ channel: Channel }>(
+      "/api/farcaster/neynar/channel",
+      { params: { id: channel } },
+    );
+    return data.channel;
+  } catch {
+    return null;
+  }
+}
+
+async function getChannelSpace(channel: string) {
+  noStore();
+  const { data, error } = await createSupabaseServerClient()
+    .from("spaceRegistrations")
+    .select("spaceId")
+    .eq("spaceName", channel)
+    .limit(1);
+  if (error || !data || data.length === 0) return null;
+  return data[0].spaceId as string;
+}
+
+export default async function ChannelSpace({ params }) {
+  const channelName = params?.channelName as string;
+  if (!channelName) return <SpaceNotFound />;
+
+  const info = await loadChannelInfo(channelName);
+  if (!info) return <SpaceNotFound />;
+
+  const spaceId = await getChannelSpace(channelName);
+  const INITIAL_CONFIG = createInitialChannelSpaceConfig(channelName);
+
+  const getSpacePageUrl = (_: string) => `/channel/${channelName}`;
+
+  return (
+    <PublicSpace
+      spaceId={spaceId}
+      tabName="Feed"
+      initialConfig={INITIAL_CONFIG}
+      getSpacePageUrl={getSpacePageUrl}
+      spaceOwnerFid={info.host?.fid ?? null}
+      pageType="channel"
+    />
+  );
+}

--- a/src/common/components/organisms/SearchAutocompleteInput.tsx
+++ b/src/common/components/organisms/SearchAutocompleteInput.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, Suspense } from "react";
 import { useRouter } from "next/navigation";
 import useSearchUsers from "@/common/lib/hooks/useSearchUsers";
+import { useChannelsByName } from "@/common/lib/hooks/useChannels";
 import { User } from "@neynar/nodejs-sdk/build/api";
 import { Avatar, AvatarImage } from "@/common/components/atoms/avatar";
 import {
@@ -34,6 +35,7 @@ const SearchAutocompleteInputContent: React.FC<SearchAutocompleteInputProps> = (
   const [isFocused, setIsFocused] = useState(false);
   const [query, setQuery] = useState<string | null>(null);
   const { users, loading } = useSearchUsers(query);
+  const { data: channels } = useChannelsByName(query || "");
 
   const handleFocus = useCallback(() => {
     setIsFocused(true);
@@ -57,11 +59,16 @@ const SearchAutocompleteInputContent: React.FC<SearchAutocompleteInputProps> = (
     onSelect && onSelect();
   }, []);
 
+  const onSelectChannel = useCallback((name: string) => {
+    router.push(`/channel/${name}`);
+    onSelect && onSelect();
+  }, []);
+
   return (
     <Command className="rounded-md border" shouldFilter={false} loop={true}>
       <div className={loading ? "animated-loading-bar" : ""}>
         <CommandInput
-          placeholder="Search users"
+          placeholder="Search users or channels"
           onValueChange={setQuery}
           value={query || ""}
           onFocus={handleFocus}
@@ -101,6 +108,28 @@ const SearchAutocompleteInputContent: React.FC<SearchAutocompleteInputProps> = (
                   <div className="leading-[1.3]">
                     <p className="font-bold opacity-80">{user.display_name}</p>
                     <p className="font-normal opacity-80">@{user.username}</p>
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+          {channels && channels.length > 0 && (
+            <CommandGroup heading="Channels">
+              {channels.map((ch) => (
+                <CommandItem
+                  key={ch.id}
+                  onSelect={() => onSelectChannel(ch.id)}
+                  value={ch.id}
+                  className="gap-x-2 cursor-pointer"
+                >
+                  {ch.image_url && (
+                    <Avatar className="h-12 w-12">
+                      <AvatarImage src={ch.image_url} alt={ch.name} />
+                    </Avatar>
+                  )}
+                  <div className="leading-[1.3]">
+                    <p className="font-bold opacity-80">{ch.name}</p>
+                    <p className="font-normal opacity-80">/{ch.id}</p>
                   </div>
                 </CommandItem>
               ))}

--- a/src/constants/initialChannelSpace.ts
+++ b/src/constants/initialChannelSpace.ts
@@ -1,0 +1,43 @@
+import { SpaceConfig } from "@/app/(spaces)/Space";
+import { cloneDeep } from "lodash";
+import { FeedType } from "@neynar/nodejs-sdk/build/api";
+import { INITIAL_SPACE_CONFIG_EMPTY } from "./initialPersonSpace";
+import { FilterType } from "@/fidgets/farcaster/Feed";
+
+export const createInitialChannelSpaceConfig = (
+  channel: string,
+): Omit<SpaceConfig, "isEditable"> => {
+  const config = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
+  config.fidgetInstanceDatums = {
+    "feed:channel": {
+      config: {
+        editable: false,
+        settings: {
+          selectPlatform: { name: "Farcaster", icon: "/images/farcaster.jpeg" },
+          feedType: FeedType.Filter,
+          filterType: FilterType.Channel,
+          channel,
+        },
+        data: {},
+      },
+      fidgetType: "feed",
+      id: "feed:channel",
+    },
+  };
+  config.layoutDetails.layoutConfig.layout.push({
+    w: 6,
+    h: 8,
+    x: 0,
+    y: 0,
+    i: "feed:channel",
+    minW: 4,
+    maxW: 36,
+    minH: 6,
+    maxH: 36,
+    moved: false,
+    static: false,
+  });
+  return config;
+};
+
+export default createInitialChannelSpaceConfig;

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -476,12 +476,13 @@ const CastReactions = ({ cast }: { cast: CastWithInteractions }) => {
           getIconForCastReactionType(CastReactionType.quote),
         )}
         {cast.channel && cast.channel.name && (
-          <div
+          <PriorityLink
             key={`cast-${cast.hash}-channel-name`}
+            href={`/channel/${cast.channel.name}`}
             className="mt-1.5 flex align-center text-sm opacity-40 py-1 px-1.5 rounded-md"
           >
             /{cast.channel.name}
-          </div>
+          </PriorityLink>
         )}
       </div>
     </>
@@ -625,7 +626,20 @@ const CastRowComponent = ({
 
   const getChannelForParentUrl = (
     _parentUrl: string | null,
-  ): { name: string } | null => null;
+  ): { name: string } | null => {
+    if (!_parentUrl) return null;
+    try {
+      const url = new URL(_parentUrl);
+      const parts = url.pathname.split("/");
+      const idx = parts.indexOf("channel");
+      if (idx >= 0 && idx + 1 < parts.length) {
+        return { name: parts[idx + 1] };
+      }
+    } catch (e) {
+      return null;
+    }
+    return null;
+  };
 
   const renderRecastBadge = () => {
     const shouldShowBadge =

--- a/src/fidgets/index.ts
+++ b/src/fidgets/index.ts
@@ -5,6 +5,7 @@ import Gallery from "./ui/gallery";
 import TextFidget from "./ui/Text";
 import IFrame from "./ui/IFrame";
 import Profile from "./ui/profile";
+import Channel from "./ui/channel";
 import Grid from "./layout/Grid";
 import NounishGovernance from "./community/nouns-dao/NounishGovernance";
 import Cast from "./farcaster/Cast";
@@ -34,6 +35,7 @@ export const CompleteFidgets = {
   // iframely: iframely,
   feed: Feed,
   cast: Cast,
+  channel: Channel,
   // createCast: CreateCast,
   // Basic UI elements
   gallery: Gallery,

--- a/src/fidgets/ui/channel.tsx
+++ b/src/fidgets/ui/channel.tsx
@@ -1,0 +1,95 @@
+import { Button } from "@/common/components/atoms/button";
+import TextInput from "@/common/components/molecules/TextInput";
+import { useQuery } from "@tanstack/react-query";
+import { FidgetArgs, FidgetModule, FidgetProperties } from "@/common/fidgets";
+import axiosBackend from "@/common/data/api/backend";
+import { Channel } from "@mod-protocol/farcaster";
+import { useFarcasterSigner } from "../farcaster";
+import { followUser } from "../farcaster/utils";
+
+export type ChannelFidgetSettings = {
+  channel: string;
+};
+
+const channelProperties: FidgetProperties = {
+  fidgetName: "Channel",
+  icon: 0x1f4e2,
+  fields: [
+    { fieldName: "channel", default: "", required: true, inputSelector: TextInput },
+  ],
+  size: {
+    minHeight: 3,
+    maxHeight: 36,
+    minWidth: 4,
+    maxWidth: 36,
+  },
+};
+
+const useChannelInfo = (name: string) => {
+  return useQuery({
+    queryKey: ["channel-info", name],
+    enabled: !!name,
+    queryFn: async () => {
+      const { data } = await axiosBackend.get<{ channel: Channel }>(
+        "/api/farcaster/neynar/channel",
+        { params: { id: name } },
+      );
+      return data.channel;
+    },
+  });
+};
+
+const Channel: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({ settings }) => {
+  const { channel } = settings;
+  const { data } = useChannelInfo(channel);
+  const { signer, fid } = useFarcasterSigner("channel-info");
+
+  if (!data) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  const handleFollow = async () => {
+    if (data?.host && signer && fid) {
+      await followUser(Number(data.host.fid), fid, signer);
+    }
+  };
+
+  return (
+    <div className="p-4 flex flex-col gap-2">
+      <div className="flex items-center gap-3">
+        {data.image_url && (
+          <img src={data.image_url} className="h-16 w-16 rounded" />
+        )}
+        <div className="flex flex-col">
+          <span className="text-xl font-bold">{data.name}</span>
+          <span className="text-sm text-muted-foreground">/{data.id}</span>
+        </div>
+      </div>
+      {data.description && <p className="text-sm">{data.description}</p>}
+      {data.parent_url && (
+        <a
+          href={data.parent_url}
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-600 hover:underline text-sm"
+        >
+          {data.parent_url}
+        </a>
+      )}
+      <div className="flex gap-4 text-sm">
+        <span>{data.member_count} Members</span>
+        <span>{data.followers} Followers</span>
+      </div>
+      {data.host && (
+        <Button className="w-fit" onClick={handleFollow} variant="secondary">
+          Follow
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default {
+  fidget: Channel,
+  properties: channelProperties,
+} as FidgetModule<FidgetArgs<ChannelFidgetSettings>>;


### PR DESCRIPTION
## Summary
- support channel spaces with new route
- add default channel space config
- show channels in search
- add Channel fidget
- link casts to channel spaces

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684ce0d45bac8325866ae1c89836fe1d