### PR TITLE
Add token search via CoinGecko API

### DIFF
--- a/src/common/components/organisms/SearchAutocompleteInput.tsx
+++ b/src/common/components/organisms/SearchAutocompleteInput.tsx
@@ -60,11 +60,13 @@ const SearchAutocompleteInputContent: React.FC<SearchAutocompleteInputProps> = (
     onSelect && onSelect();
   }, []);
 
-  const onSelectToken = useCallback((token: TokenResult) => {
-    router.push(`/t/${token.network}/${token.contractAddress}`);
-    onSelect && onSelect();
-  }, []);
-
+  const onSelectToken = useCallback(
+    (token: TokenResult) => {
+      router.push(`/t/${token.network}/${token.contractAddress}`);
+      onSelect?.();
+    },
+    [router, onSelect],
+  );
   return (
     <Command className="rounded-md border" shouldFilter={false} loop={true}>
       <div className={loading ? "animated-loading-bar" : ""}>

--- a/src/common/lib/hooks/useSearchTokens.ts
+++ b/src/common/lib/hooks/useSearchTokens.ts
@@ -61,13 +61,17 @@ const useSearchTokens = (
     }, debounceMs),
     [],
   );
-
   useEffect(() => {
     setError(null);
     if (query) {
       setLoading(true);
       fetchResults(query);
     }
+
+    return () => {
+      cancelRequest.current?.cancel("component unmounted");
+      fetchResults.cancel(); // lodash debounce helper
+    };
   }, [query]);
 
   return {
@@ -76,5 +80,4 @@ const useSearchTokens = (
     error: error,
   };
 };
-
 export default useSearchTokens;

--- a/src/common/lib/hooks/useSearchTokens.ts
+++ b/src/common/lib/hooks/useSearchTokens.ts
@@ -1,0 +1,80 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { debounce } from "lodash";
+import axios, { CancelTokenSource, isAxiosError } from "axios";
+import axiosBackend from "@/common/data/api/backend";
+import { NounspaceResponse } from "@/common/data/api/requestHandler";
+
+export type TokenResult = {
+  id: string;
+  name: string;
+  symbol: string;
+  image: string | null;
+  contractAddress: string;
+  network: string;
+};
+
+export type TokenSearchReturnValue = {
+  tokens: TokenResult[];
+  loading: boolean;
+  error: string | null;
+};
+
+const useSearchTokens = (
+  query: string | null,
+  debounceMs: number = 300,
+): TokenSearchReturnValue => {
+  const [results, setResults] = useState<TokenResult[] | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const cancelRequest = useRef<CancelTokenSource | null>(null);
+
+  const fetchResults = useCallback(
+    debounce(async (q: string) => {
+      if (cancelRequest.current) {
+        cancelRequest.current.cancel("New search initiated");
+      }
+
+      cancelRequest.current = axios.CancelToken.source();
+
+      try {
+        const response = await axiosBackend.get<
+          NounspaceResponse<{ tokens: TokenResult[] }>
+        >("/api/search/tokens", {
+          params: {
+            q,
+            limit: 5,
+          },
+          cancelToken: cancelRequest.current.token,
+        });
+        setResults(response.data.value?.tokens || []);
+        setLoading(false);
+        setError(null);
+      } catch (err) {
+        if (!axios.isCancel(err)) {
+          const errMsg = isAxiosError(err)
+            ? err.response?.data?.error?.message
+            : null;
+          setError(errMsg || "An error occurred while searching");
+          setLoading(false);
+        }
+      }
+    }, debounceMs),
+    [],
+  );
+
+  useEffect(() => {
+    setError(null);
+    if (query) {
+      setLoading(true);
+      fetchResults(query);
+    }
+  }, [query]);
+
+  return {
+    tokens: (query && results) || [],
+    loading: loading,
+    error: error,
+  };
+};
+
+export default useSearchTokens;

--- a/src/pages/api/search/tokens.ts
+++ b/src/pages/api/search/tokens.ts
@@ -1,4 +1,4 @@
-import { NextApiRequest, NextApiResponse } from "next/types";
+import { NextApiRequest, NextApiResponse } from "next";
 import { z, ZodSchema } from "zod";
 import requestHandler, { NounspaceResponse } from "@/common/data/api/requestHandler";
 

--- a/src/pages/api/search/tokens.ts
+++ b/src/pages/api/search/tokens.ts
@@ -55,7 +55,7 @@ async function fetchTokenByAddress(address: string): Promise<TokenResult | null>
     id: json.id,
     name: json.name,
     symbol: json.symbol,
-    image: json.image?.thumb || null,
+    image: json.image?.small || json.image?.large || json.image?.thumb || null,
     contractAddress,
     network: platformId === "ethereum" ? "mainnet" : platformId.replace("polygon-pos", "polygon"),
   };
@@ -89,7 +89,7 @@ async function fetchTokensByQuery(query: string, limit: number): Promise<TokenRe
       id: json.id,
       name: json.name,
       symbol: json.symbol,
-      image: json.image?.thumb || null,
+      image: json.image?.small || json.image?.large || json.image?.thumb || null,
       contractAddress,
       network: platformId === "ethereum" ? "mainnet" : platformId.replace("polygon-pos", "polygon"),
     });

--- a/src/pages/api/search/tokens.ts
+++ b/src/pages/api/search/tokens.ts
@@ -49,7 +49,7 @@ async function fetchTokenByAddress(address: string): Promise<TokenResult | null>
   const platformId: string = json.asset_platform_id || "ethereum";
   const platforms: Record<string, string> = json.platforms || {};
   const contractAddress =
-    platforms[platformId] || platforms.ethereum || Object.values(platforms)[0];
+    (platforms[platformId] || platforms.ethereum || Object.values(platforms)[0] || "").toLowerCase();
   if (!contractAddress) return null;
   return {
     id: json.id,
@@ -57,7 +57,12 @@ async function fetchTokenByAddress(address: string): Promise<TokenResult | null>
     symbol: json.symbol,
     image: json.image?.small || json.image?.large || json.image?.thumb || null,
     contractAddress,
-    network: platformId === "ethereum" ? "mainnet" : platformId.replace("polygon-pos", "polygon"),
+    network: ({
+      ethereum: "mainnet",
+      "polygon-pos": "polygon",
+      optimism: "optimism",
+      "arbitrum-one": "arbitrum",
+    } as Record<string, string>)[platformId] ?? platformId,
   };
 }
 

--- a/src/pages/api/search/tokens.ts
+++ b/src/pages/api/search/tokens.ts
@@ -1,0 +1,131 @@
+import { NextApiRequest, NextApiResponse } from "next/types";
+import { z, ZodSchema } from "zod";
+import requestHandler, { NounspaceResponse } from "@/common/data/api/requestHandler";
+
+interface TokenResult {
+  id: string;
+  name: string;
+  symbol: string;
+  image: string | null;
+  contractAddress: string;
+  network: string;
+}
+
+const QuerySchema = z.object({
+  q: z.string().min(1),
+  limit: z.coerce.number().int().positive().max(10).default(5),
+});
+
+type TokenSearchResult = {
+  tokens: TokenResult[];
+};
+
+const _validateQueryParams = <T extends ZodSchema>(
+  req: NextApiRequest,
+  schema: T,
+): [z.infer<T> | null, string | null] => {
+  const parseResult = schema.safeParse(req.query);
+
+  if (parseResult.success) {
+    return [parseResult.data, null];
+  }
+
+  const error = parseResult.error.errors[0];
+  const errorMessage = `${error.message} (${error.path.join(".")})`;
+  return [null, errorMessage];
+};
+
+const COINGECKO_BASE_URL = "https://api.coingecko.com/api/v3";
+
+async function fetchTokenByAddress(address: string): Promise<TokenResult | null> {
+  const url = `${COINGECKO_BASE_URL}/coins/ethereum/contract/${address}`;
+  const res = await fetch(url, {
+    headers: {
+      "x-cg-demo-api-key": process.env.COINGECKO_API_KEY ?? "",
+    },
+  });
+  if (!res.ok) return null;
+  const json = await res.json();
+  const platformId: string = json.asset_platform_id || "ethereum";
+  const platforms: Record<string, string> = json.platforms || {};
+  const contractAddress =
+    platforms[platformId] || platforms.ethereum || Object.values(platforms)[0];
+  if (!contractAddress) return null;
+  return {
+    id: json.id,
+    name: json.name,
+    symbol: json.symbol,
+    image: json.image?.thumb || null,
+    contractAddress,
+    network: platformId === "ethereum" ? "mainnet" : platformId.replace("polygon-pos", "polygon"),
+  };
+}
+
+async function fetchTokensByQuery(query: string, limit: number): Promise<TokenResult[]> {
+  const params = new URLSearchParams({ query });
+  const searchRes = await fetch(`${COINGECKO_BASE_URL}/search?${params.toString()}`, {
+    headers: {
+      "x-cg-demo-api-key": process.env.COINGECKO_API_KEY ?? "",
+    },
+  });
+  if (!searchRes.ok) return [];
+  const searchJson = await searchRes.json();
+  const coins = Array.isArray(searchJson.coins) ? searchJson.coins.slice(0, limit) : [];
+  const results: TokenResult[] = [];
+  for (const coin of coins) {
+    const detailRes = await fetch(`${COINGECKO_BASE_URL}/coins/${coin.id}`, {
+      headers: {
+        "x-cg-demo-api-key": process.env.COINGECKO_API_KEY ?? "",
+      },
+    });
+    if (!detailRes.ok) continue;
+    const json = await detailRes.json();
+    const platformId: string = json.asset_platform_id || "ethereum";
+    const platforms: Record<string, string> = json.platforms || {};
+    const contractAddress =
+      platforms[platformId] || platforms.ethereum || Object.values(platforms)[0];
+    if (!contractAddress) continue;
+    results.push({
+      id: json.id,
+      name: json.name,
+      symbol: json.symbol,
+      image: json.image?.thumb || null,
+      contractAddress,
+      network: platformId === "ethereum" ? "mainnet" : platformId.replace("polygon-pos", "polygon"),
+    });
+    if (results.length >= limit) break;
+  }
+  return results;
+}
+
+const get = async (
+  req: NextApiRequest,
+  res: NextApiResponse<NounspaceResponse<TokenSearchResult>>,
+) => {
+  const [params, errorMessage] = _validateQueryParams(req, QuerySchema);
+
+  if (errorMessage) {
+    return res.status(400).json({ result: "error", error: { message: errorMessage } });
+  }
+
+  try {
+    const { q, limit } = params!;
+    let tokens: TokenResult[] = [];
+    if (/^0x[a-fA-F0-9]{40}$/.test(q)) {
+      const token = await fetchTokenByAddress(q);
+      if (token) tokens = [token];
+    } else {
+      tokens = await fetchTokensByQuery(q, limit);
+    }
+    return res.status(200).json({ result: "success", value: { tokens } });
+  } catch (err) {
+    return res.status(500).json({
+      result: "error",
+      error: { message: err instanceof Error ? err.message : "Unknown error" },
+    });
+  }
+};
+
+export default requestHandler({ get });
+
+export { TokenResult };

--- a/src/pages/api/search/tokens.ts
+++ b/src/pages/api/search/tokens.ts
@@ -128,4 +128,4 @@ const get = async (
 
 export default requestHandler({ get });
 
-export { TokenResult };
+export type { TokenResult };


### PR DESCRIPTION
## Summary
- add API endpoint to search ERC20 tokens via CoinGecko
- create `useSearchTokens` hook
- extend `SearchAutocompleteInput` to show token results alongside users

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_684ce6c8b48c8325baa68cd298ed0dbf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced search functionality to support searching for both users and tokens.
  - Introduced token search results with detailed information, including name, symbol, contract address, and network.
  - Added the ability to navigate directly to a token’s page from the search interface.

- **Bug Fixes**
  - Improved loading indicators to reflect the status of both user and token searches.

- **API**
  - Added a new API endpoint for searching tokens by name, symbol, or contract address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->