### PR TITLE
Add Farcaster channel spaces

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -20,7 +20,7 @@ import { createEditabilityChecker } from "@/common/utils/spaceEditability";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialPersonSpace";
 const FARCASTER_NOUNSPACE_AUTHENTICATOR_NAME = "farcaster:nounspace";
 
-export type SpacePageType = "profile" | "token" | "proposal";
+export type SpacePageType = "profile" | "token" | "proposal" | "channel";
 
 interface PublicSpaceProps {
   spaceId: string | null;
@@ -37,6 +37,7 @@ interface PublicSpaceProps {
   tokenData?: MasterToken;
   // New prop to identify page type
   pageType?: SpacePageType;
+  channelName?: string;
 }
 
 export default function PublicSpace({
@@ -52,6 +53,7 @@ export default function PublicSpace({
   contractAddress,
   tokenData,
   pageType, // New prop
+  channelName,
 }: PublicSpaceProps) {
   console.log("PublicSpace mounted:", {
     spaceId: providedSpaceId,
@@ -419,6 +421,16 @@ export default function PublicSpace({
               newSpaceId,
               contractAddress,
             });
+          } else if (resolvedPageType === "channel" && channelName) {
+            console.log("Attempting to register channel space:", {
+              currentUserFid,
+              channelName,
+            });
+            newSpaceId = await registerSpaceFid(
+              currentUserFid,
+              channelName,
+              getSpacePageUrl("Profile"),
+            );
           } else if (!isTokenPage) {
             console.log("Attempting to register user space:", {
               currentUserFid,

--- a/src/app/(spaces)/channel/[channelName]/ChannelSpace.tsx
+++ b/src/app/(spaces)/channel/[channelName]/ChannelSpace.tsx
@@ -1,0 +1,41 @@
+"use client";
+import React from "react";
+import { isArray, isNil } from "lodash";
+import SpaceNotFound from "@/app/(spaces)/SpaceNotFound";
+import createInitialChannelSpaceConfig from "@/constants/initialChannelSpace";
+import PublicSpace from "../../PublicSpace";
+
+export interface ChannelSpaceProps {
+  spaceOwnerFid: number | null;
+  channelName: string;
+  spaceId: string | null;
+  tabName: string | string[] | null | undefined;
+}
+
+const ChannelSpace = ({
+  spaceOwnerFid,
+  channelName,
+  spaceId,
+  tabName,
+}: ChannelSpaceProps) => {
+  if (isNil(spaceOwnerFid)) {
+    return <SpaceNotFound />;
+  }
+
+  const INITIAL_SPACE_CONFIG = createInitialChannelSpaceConfig(channelName);
+  const getSpacePageUrl = (tab: string) => `/channel/${channelName}/${tab}`;
+
+  return (
+    <PublicSpace
+      spaceId={spaceId}
+      tabName={isArray(tabName) ? tabName[0] : tabName || "Profile"}
+      initialConfig={INITIAL_SPACE_CONFIG}
+      getSpacePageUrl={getSpacePageUrl}
+      spaceOwnerFid={spaceOwnerFid}
+      pageType="channel"
+      channelName={channelName}
+    />
+  );
+};
+
+export default ChannelSpace;

--- a/src/app/(spaces)/channel/[channelName]/layout.tsx
+++ b/src/app/(spaces)/channel/[channelName]/layout.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/(spaces)/channel/[channelName]/page.tsx
+++ b/src/app/(spaces)/channel/[channelName]/page.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { getChannelMetadata, getTabList, type Tab } from "./utils";
+import ChannelSpace from "./ChannelSpace";
+import SpaceNotFound from "@/app/(spaces)/SpaceNotFound";
+import { unstable_noStore as noStore } from "next/cache";
+
+const loadChannelSpaceData = async (
+  channelName: string,
+  tabNameParam?: string,
+) => {
+  noStore();
+  const channelMeta = await getChannelMetadata(channelName);
+  const fid = channelMeta.fid;
+  if (!fid) return { spaceOwnerFid: null, spaceId: null, tabName: null };
+  const tabs = await getTabList(fid, channelName);
+  if (!tabs || tabs.length === 0) {
+    return { spaceOwnerFid: fid, spaceId: null, tabName: null };
+  }
+  const defaultTab: Tab = tabs[0];
+  const spaceId = defaultTab.spaceId;
+  const tabName = tabNameParam || defaultTab.spaceName;
+  return { spaceOwnerFid: fid, spaceId, tabName };
+};
+
+const ChannelSpacePage = async ({ params }) => {
+  const { channelName, tabName: tabNameParam } = await params;
+  if (!channelName) return <SpaceNotFound />;
+  const { spaceOwnerFid, spaceId, tabName } = await loadChannelSpaceData(
+    channelName,
+    tabNameParam ? decodeURIComponent(tabNameParam) : undefined,
+  );
+  return (
+    <ChannelSpace
+      spaceOwnerFid={spaceOwnerFid}
+      channelName={channelName}
+      spaceId={spaceId}
+      tabName={tabName}
+    />
+  );
+};
+
+export default ChannelSpacePage;

--- a/src/app/(spaces)/channel/[channelName]/utils.ts
+++ b/src/app/(spaces)/channel/[channelName]/utils.ts
@@ -1,0 +1,39 @@
+import neynar from "@/common/data/api/neynar";
+import createSupabaseServerClient from "@/common/data/database/supabase/clients/server";
+import { unstable_noStore as noStore } from "next/cache";
+import { Channel } from "@neynar/nodejs-sdk/build/api";
+
+export type Tab = { spaceId: string; spaceName: string };
+
+export const getChannelMetadata = async (
+  channelName: string,
+): Promise<{ fid: number | null; name: string }> => {
+  try {
+    const { channel } = await neynar.lookupChannel({ id: channelName });
+    return { fid: channel.lead?.fid ?? null, name: channel.name || channel.id };
+  } catch {
+    return { fid: null, name: channelName };
+  }
+};
+
+export const getTabList = async (
+  fid: number,
+  channelName: string,
+): Promise<Tab[]> => {
+  noStore();
+  try {
+    const { data: registrations, error } = await createSupabaseServerClient()
+      .from("spaceRegistrations")
+      .select("spaceId, spaceName, fid")
+      .eq("fid", fid)
+      .eq("spaceName", channelName)
+      .limit(1);
+    if (error || !registrations || registrations.length === 0) {
+      return [];
+    }
+    const registration = registrations[0];
+    return [registration];
+  } catch {
+    return [];
+  }
+};

--- a/src/common/components/organisms/SearchAutocompleteInput.tsx
+++ b/src/common/components/organisms/SearchAutocompleteInput.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useCallback, Suspense } from "react";
 import { useRouter } from "next/navigation";
 import useSearchUsers from "@/common/lib/hooks/useSearchUsers";
+import { useChannelsByName } from "@/common/lib/hooks/useChannels";
 import { User } from "@neynar/nodejs-sdk/build/api";
+import type { Channel } from "@mod-protocol/farcaster";
 import { Avatar, AvatarImage } from "@/common/components/atoms/avatar";
 import {
   Command,
@@ -34,6 +36,7 @@ const SearchAutocompleteInputContent: React.FC<SearchAutocompleteInputProps> = (
   const [isFocused, setIsFocused] = useState(false);
   const [query, setQuery] = useState<string | null>(null);
   const { users, loading } = useSearchUsers(query);
+  const { data: channels } = useChannelsByName(query || "");
 
   const handleFocus = useCallback(() => {
     setIsFocused(true);
@@ -57,11 +60,16 @@ const SearchAutocompleteInputContent: React.FC<SearchAutocompleteInputProps> = (
     onSelect && onSelect();
   }, []);
 
+  const onSelectChannel = useCallback((channel: Channel) => {
+    router.push(`/channel/${channel.id}`);
+    onSelect && onSelect();
+  }, []);
+
   return (
     <Command className="rounded-md border" shouldFilter={false} loop={true}>
       <div className={loading ? "animated-loading-bar" : ""}>
         <CommandInput
-          placeholder="Search users"
+          placeholder="Search users or channels"
           onValueChange={setQuery}
           value={query || ""}
           onFocus={handleFocus}
@@ -101,6 +109,26 @@ const SearchAutocompleteInputContent: React.FC<SearchAutocompleteInputProps> = (
                   <div className="leading-[1.3]">
                     <p className="font-bold opacity-80">{user.display_name}</p>
                     <p className="font-normal opacity-80">@{user.username}</p>
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+          {channels && channels.length > 0 && (
+            <CommandGroup heading="Channels">
+              {channels.map((channel: Channel, i: number) => (
+                <CommandItem
+                  key={i}
+                  onSelect={() => onSelectChannel(channel)}
+                  value={channel.name || channel.id}
+                  className="gap-x-2 cursor-pointer"
+                >
+                  <Avatar className="h-12 w-12">
+                    <AvatarImage src={channel.image_url} alt={channel.name} />
+                  </Avatar>
+                  <div className="leading-[1.3]">
+                    <p className="font-bold opacity-80">{channel.name}</p>
+                    <p className="font-normal opacity-80">/{channel.id}</p>
                   </div>
                 </CommandItem>
               ))}

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -789,7 +789,9 @@ export const createSpaceStoreFunc = (
       );
       
       if (existingSpaces.value) {
-        const existingSpace = existingSpaces.value.spaces.find(space => space.fid === fid);
+        const existingSpace = existingSpaces.value.spaces.find(
+          space => space.fid === fid && space.spaceName === name,
+        );
         if (existingSpace) {
           return existingSpace.spaceId;
         }

--- a/src/constants/initialChannelSpace.ts
+++ b/src/constants/initialChannelSpace.ts
@@ -1,0 +1,43 @@
+import { SpaceConfig } from "@/app/(spaces)/Space";
+import { INITIAL_SPACE_CONFIG_EMPTY } from "./initialPersonSpace";
+import { FeedType } from "@neynar/nodejs-sdk/build/api";
+import { FilterType } from "@/fidgets/farcaster/Feed";
+import { cloneDeep } from "lodash";
+
+const createInitialChannelSpaceConfig = (
+  channel: string,
+): Omit<SpaceConfig, "isEditable"> => {
+  const config = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
+  config.fidgetInstanceDatums = {
+    "feed:channel": {
+      config: {
+        editable: false,
+        settings: {
+          feedType: FeedType.Filter,
+          filterType: FilterType.Channel,
+          channel,
+          selectPlatform: { name: "Farcaster", icon: "/images/farcaster.jpeg" },
+        },
+        data: {},
+      },
+      fidgetType: "feed",
+      id: "feed:channel",
+    },
+  };
+  config.layoutDetails.layoutConfig.layout.push({
+    w: 6,
+    h: 8,
+    x: 0,
+    y: 0,
+    i: "feed:channel",
+    minW: 4,
+    maxW: 36,
+    minH: 6,
+    maxH: 36,
+    moved: false,
+    static: false,
+  });
+  return config;
+};
+
+export default createInitialChannelSpaceConfig;

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -480,7 +480,7 @@ const CastReactions = ({ cast }: { cast: CastWithInteractions }) => {
             key={`cast-${cast.hash}-channel-name`}
             className="mt-1.5 flex align-center text-sm opacity-40 py-1 px-1.5 rounded-md"
           >
-            /{cast.channel.name}
+            <PriorityLink href={`/channel/${cast.channel.name}`}>/{cast.channel.name}</PriorityLink>
           </div>
         )}
       </div>

--- a/src/fidgets/index.ts
+++ b/src/fidgets/index.ts
@@ -5,6 +5,7 @@ import Gallery from "./ui/gallery";
 import TextFidget from "./ui/Text";
 import IFrame from "./ui/IFrame";
 import Profile from "./ui/profile";
+import Channel from "./ui/channel";
 import Grid from "./layout/Grid";
 import NounishGovernance from "./community/nouns-dao/NounishGovernance";
 import Cast from "./farcaster/Cast";
@@ -34,6 +35,7 @@ export const CompleteFidgets = {
   // iframely: iframely,
   feed: Feed,
   cast: Cast,
+  Channel: Channel,
   // createCast: CreateCast,
   // Basic UI elements
   gallery: Gallery,

--- a/src/fidgets/ui/channel.tsx
+++ b/src/fidgets/ui/channel.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { FidgetArgs, FidgetModule, FidgetProperties } from "@/common/fidgets";
+import TextInput from "@/common/components/molecules/TextInput";
+import { useQuery } from "@tanstack/react-query";
+import axiosBackend from "@/common/data/api/backend";
+import { ChannelResponse } from "@neynar/nodejs-sdk/build/api";
+import { BsChatLeft, BsChatLeftFill } from "react-icons/bs";
+
+export type ChannelFidgetSettings = { channel: string };
+
+const channelProperties: FidgetProperties<ChannelFidgetSettings> = {
+  fidgetName: "Channel",
+  icon: 0x1f4ac,
+  mobileIcon: <BsChatLeft size={24} />,
+  mobileIconSelected: <BsChatLeftFill size={24} />,
+  fields: [
+    { fieldName: "channel", default: "", required: true, inputSelector: TextInput },
+  ],
+  size: { minHeight: 3, maxHeight: 36, minWidth: 4, maxWidth: 36 },
+};
+
+const useChannelInfo = (name: string) =>
+  useQuery({
+    queryKey: ["channel-info", name],
+    enabled: !!name,
+    staleTime: 1000 * 60,
+    queryFn: async () => {
+      const { data } = await axiosBackend.get<ChannelResponse>(
+        "/api/farcaster/neynar/channel",
+        { params: { channel_id: name } },
+      );
+      return data.channel;
+    },
+  });
+
+const Channel: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({ settings: { channel } }) => {
+  const { data } = useChannelInfo(channel);
+  if (!data) return <div className="p-4">Loading...</div>;
+
+  return (
+    <div className="p-4 flex flex-col gap-1">
+      <div className="flex items-center gap-3">
+        {data.image_url && (
+          <img src={data.image_url} className="w-12 h-12 rounded" />
+        )}
+        <div className="flex flex-col">
+          <span className="text-xl font-bold">{data.name || channel}</span>
+          <small className="text-slate-500">/{data.id}</small>
+        </div>
+      </div>
+      {data.description && <p className="text-sm mt-2">{data.description}</p>}
+      <div className="text-sm flex gap-4 mt-2">
+        {data.member_count !== undefined && <span>{data.member_count} Members</span>}
+        {data.follower_count !== undefined && <span>{data.follower_count} Followers</span>}
+      </div>
+      {data.external_link?.url && (
+        <a
+          href={data.external_link.url}
+          target="_blank"
+          rel="noreferrer"
+          className="text-blue-600 hover:underline text-sm"
+        >
+          {data.external_link.url}
+        </a>
+      )}
+      <a
+        className="mt-2 inline-block bg-blue-600 text-white text-sm px-3 py-1 rounded self-start"
+        href={`https://warpcast.com/~/channel/${data.id}`}
+        target="_blank"
+        rel="noreferrer"
+      >
+        Follow
+      </a>
+    </div>
+  );
+};
+
+export default { fidget: Channel, properties: channelProperties } as FidgetModule<FidgetArgs<ChannelFidgetSettings>>;


### PR DESCRIPTION
## Summary
- implement channel space default config
- enable channel data fidget
- allow channel search in search modal
- hyperlink cast channel names to channel space
- register channel spaces uniquely by name
- support `/channel/[name]` routes

## Testing
- `npm run lint`
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_684ce0d45bac8325866ae1c89836fe1d