### PR TITLE
Fix ChannelPicker avatar regression

### DIFF
--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -673,8 +673,8 @@ const CreateCast: React.FC<CreateCastProps> = ({
               ) : (
                 <ChannelPicker
                   getChannels={debouncedGetChannels}
-                  onSelect={(id, name) => {
-                    setChannel({ id, name } as Channel);
+                  onSelect={(selectedChannel) => {
+                    setChannel(selectedChannel);
                   }}
                   value={channel}
                   initialChannels={initialChannels}

--- a/src/fidgets/farcaster/components/channelPicker.tsx
+++ b/src/fidgets/farcaster/components/channelPicker.tsx
@@ -19,7 +19,7 @@ import { Channel } from "@mod-protocol/farcaster"; // Assuming this is your type
 
 type Props = {
   getChannels: (query: string) => Promise<Channel[]>;
-  onSelect: (hash: string, name: string) => void;
+  onSelect: (channel: Channel) => void;
   value: Channel;
   initialChannels?: Channel[];
 };
@@ -48,7 +48,7 @@ export function ChannelPicker(props: Props) {
   const handleSelect = React.useCallback(
     (channel: Channel) => {
       setOpen(false);
-      onSelect(channel.id, channel.name);
+      onSelect(channel);
     },
     [onSelect],
   );


### PR DESCRIPTION
## Summary
- revert ChannelPicker `onSelect` to return full channel object
- update CreateCast to store selected channel object

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684fe71a1e348325ba4062add40c7be1