### PR TITLE
Adjust nav logo spacing

### DIFF
--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -243,7 +243,7 @@ const Navigation: React.FC<NavProps> = ({
             </button>
           )}
 
-          <div className="-mt-5 pb-5">
+          <div className="-mt-[22px] pb-[22px]">
             <BrandHeader />
           </div>
           <div

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -243,7 +243,7 @@ const Navigation: React.FC<NavProps> = ({
             </button>
           )}
 
-          <div className="-mt-[25px] pb-[25px]">
+          <div className="-mt-6 pb-6">
             <BrandHeader />
           </div>
           <div

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -243,7 +243,9 @@ const Navigation: React.FC<NavProps> = ({
             </button>
           )}
 
-          <BrandHeader />
+          <div className="-mt-5 pb-5">
+            <BrandHeader />
+          </div>
           <div
             className={mergeClasses(
               "flex flex-col text-lg font-medium pb-3 px-4 overflow-auto transition-all duration-300",

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -243,7 +243,7 @@ const Navigation: React.FC<NavProps> = ({
             </button>
           )}
 
-          <div className="-mt-[22px] pb-[22px]">
+          <div className="-mt-[25px] pb-[25px]">
             <BrandHeader />
           </div>
           <div


### PR DESCRIPTION
Fix logo placement:
<img width="536" alt="image" src="https://github.com/user-attachments/assets/c7218110-fb4c-4782-a243-c0a719f4447a" />


## Summary
- shift BrandHeader up 20px and add padding below it so icons stay put

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850e11e971c8325a26562df90b1c976

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated spacing around the header for improved layout by adjusting margin and padding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->