### PR TITLE
Add basic PWA support

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Nounspace",
+  "short_name": "Nounspace",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/images/logo.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/images/nounspace_logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,38 @@
+const CACHE_NAME = 'nounspace-cache-v1';
+const STATIC_ASSETS = [
+  '/',
+  '/manifest.json',
+  '/images/favicon-32x32.png',
+  '/images/apple-touch-icon.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then(cached =>
+      cached || fetch(event.request).then(response => {
+        if (response.ok) {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+        }
+        return response;
+      })
+    )
+  );
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,6 +37,7 @@ export const metadata: Metadata = {
     ],
     apple: '/images/apple-touch-icon.png',
   },
+  manifest: '/manifest.json',
   other: {
     'fc:frame': JSON.stringify(defaultFrame),
   },

--- a/src/common/providers/PwaProvider.tsx
+++ b/src/common/providers/PwaProvider.tsx
@@ -1,0 +1,18 @@
+"use client";
+import React, { useEffect } from "react";
+
+export default function PwaProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production" && "serviceWorker" in navigator) {
+      navigator.serviceWorker
+        .register("/sw.js")
+        .catch((err) => console.error("Service worker registration failed", err));
+    }
+  }, []);
+
+  return <>{children}</>;
+}

--- a/src/common/providers/index.tsx
+++ b/src/common/providers/index.tsx
@@ -10,6 +10,7 @@ import UserThemeProvider from "@/common/lib/theme/UserThemeProvider";
 import LoggedInStateProvider from "./LoggedInStateProvider";
 import AnalyticsProvider from "./AnalyticsProvider";
 import VersionCheckProivder from "./VersionCheckProvider";
+import PwaProvider from "./PwaProvider";
 import { SidebarContextProvider } from "@/common/components/organisms/Sidebar";
 import { ToastProvider } from "../components/atoms/Toast";
 import MiniAppSdkProvider from "./MiniAppSdkProvider";
@@ -17,32 +18,34 @@ import { SharedDataProvider } from "./SharedDataProvider";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <VersionCheckProivder>
-      <Privy>
-        <Query>
-          <Wagmi>
-            <Theme>
-              <AppStoreProvider>
-                <UserThemeProvider>
-                  <AuthenticatorProvider>
-                    <LoggedInStateProvider>
-                      <SidebarContextProvider>
-                        <AnalyticsProvider>
-                          <MiniAppSdkProvider>
-                            <SharedDataProvider>
-                              <ToastProvider>{children}</ToastProvider>
-                            </SharedDataProvider>
-                          </MiniAppSdkProvider>
-                        </AnalyticsProvider>
-                      </SidebarContextProvider>
-                    </LoggedInStateProvider>
-                  </AuthenticatorProvider>
-                </UserThemeProvider>
-              </AppStoreProvider>
-            </Theme>
-          </Wagmi>
-        </Query>
-      </Privy>
-    </VersionCheckProivder>
+    <PwaProvider>
+      <VersionCheckProivder>
+        <Privy>
+          <Query>
+            <Wagmi>
+              <Theme>
+                <AppStoreProvider>
+                  <UserThemeProvider>
+                    <AuthenticatorProvider>
+                      <LoggedInStateProvider>
+                        <SidebarContextProvider>
+                          <AnalyticsProvider>
+                            <MiniAppSdkProvider>
+                              <SharedDataProvider>
+                                <ToastProvider>{children}</ToastProvider>
+                              </SharedDataProvider>
+                            </MiniAppSdkProvider>
+                          </AnalyticsProvider>
+                        </SidebarContextProvider>
+                      </LoggedInStateProvider>
+                    </AuthenticatorProvider>
+                  </UserThemeProvider>
+                </AppStoreProvider>
+              </Theme>
+            </Wagmi>
+          </Query>
+        </Privy>
+      </VersionCheckProivder>
+    </PwaProvider>
   );
 }


### PR DESCRIPTION
## Summary
- create a manifest file and service worker
- register the service worker via new provider
- link manifest from layout metadata

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685103db928c8325a5fbfe88c3ec9f0f