### PR TITLE
Fix disappearing fidgets on edit

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -624,7 +624,7 @@ export default function PublicSpace({
       };
       return saveLocalSpaceTab(currentSpaceId, currentTabName, saveableConfig);
     },
-    [getCurrentSpaceId, getCurrentTabName]
+    [getCurrentSpaceId, getCurrentTabName, config.fidgetInstanceDatums]
   );
 
   const commitConfig = useCallback(async () => {

--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -177,9 +177,11 @@ export default function Space({
       }
 
       if (!datum.fidgetType || !datum.id) {
+        // Safer approach: don't rely on splitting the id string
+        // Use existing fidgetType or fallback to "unknown"
         cleanedFidgetInstanceDatums[id] = {
           ...datum,
-          fidgetType: datum.fidgetType || id.split(":")[0],
+          fidgetType: datum.fidgetType || "unknown",
           id: datum.id || id,
         };
         datumFieldsUpdated = true;

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -213,9 +213,14 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
       async (newInstanceConfig: FidgetConfig<FidgetSettings>) => {
         const currentDatums = fidgetInstanceDatumsRef.current;
         const existing = currentDatums[id];
+        
+        // Safer approach: don't rely on splitting the id string
+        // Use existing fidgetType, provided fidgetType, or fallback to "unknown"
+        const determinedFidgetType = existing?.fidgetType ?? fidgetType ?? "unknown";
+        
         const updatedDatum: FidgetInstanceData = {
           id: existing?.id ?? id,
-          fidgetType: existing?.fidgetType ?? fidgetType ?? id.split(":")[0],
+          fidgetType: determinedFidgetType,
           config: newInstanceConfig,
         };
 

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -291,11 +291,6 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
       e.dataTransfer.getData("text/plain"),
     );
 
-    saveFidgetInstanceDatums({
-      ...fidgetInstanceDatums,
-      [fidgetData.id]: fidgetData,
-    });
-
     const newItem: PlacedGridItem = {
       i: fidgetData.id,
       x: item.x,
@@ -309,7 +304,11 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
       resizeHandles: resizeDirections,
     };
 
-    saveLayout([...layoutConfig.layout, newItem]);
+    // Save both layout and fidget data in a single operation to keep them in sync
+    debouncedSaveConfig({
+      layoutConfig: { layout: [...layoutConfig.layout, newItem] },
+      fidgetInstanceDatums: { ...fidgetInstanceDatums, [fidgetData.id]: fidgetData },
+    });
 
     removeFidgetFromTray(fidgetData.id);
     analytics.track(AnalyticsEvent.ADD_FIDGET, {

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -282,7 +282,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
       : gridDetails.rowHeight;
   }, [height, hasProfile, gridDetails.margin, gridDetails.containerPadding]);
 
-  function handleDrop(
+  async function handleDrop(
     _layout: PlacedGridItem[],
     item: PlacedGridItem,
     e: DragEvent<HTMLDivElement>,
@@ -304,8 +304,8 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
       resizeHandles: resizeDirections,
     };
 
-    // Save both layout and fidget data in a single operation to keep them in sync
-    debouncedSaveConfig({
+    // Save layout and fidget data immediately so editing has the latest state
+    await saveConfig({
       layoutConfig: { layout: [...layoutConfig.layout, newItem] },
       fidgetInstanceDatums: { ...fidgetInstanceDatums, [fidgetData.id]: fidgetData },
     });


### PR DESCRIPTION
## Summary
- ensure fidget configs stay in local state while editing
- keep layout and fidget data in sync when dropping a fidget

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_68513c8f158083259560302474e3a840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved state consistency when saving fidget configurations and layouts, ensuring that updates are saved atomically and reliably.
	- Fixed handling of missing fidget type information to avoid errors during data cleanup.
- **Refactor**
	- Enhanced internal handling of configuration data to prevent issues with outdated information during save operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->