### PR TITLE
Remove tab token gate

### DIFF
--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -4,7 +4,6 @@ import { FaPlus, FaPaintbrush } from "react-icons/fa6";
 import { map } from "lodash";
 import { Reorder, AnimatePresence } from "framer-motion";
 import { Tab } from "../atoms/reorderable-tab";
-import NogsGateButton from "./NogsGateButton";
 import { Address } from "viem";
 import { useAppStore } from "@/common/data/stores/app";
 import { useSidebarContext } from "./Sidebar";
@@ -271,7 +270,7 @@ function TabBar({
         )}
         {inEditMode ? (
           <div className="mr-36 flex flex-row z-infinity">
-            <NogsGateButton
+            <Button
               onClick={() => handleCreateTab(generateNewTabName())}
               className="items-center flex rounded-xl p-2 m-3 px-auto bg-[#F3F4F6] hover:bg-sky-100 text-[#1C64F2] font-semibold"
             >
@@ -279,7 +278,7 @@ function TabBar({
                 <FaPlus />
               </div>
               <span className="ml-4 mr-2">Tab</span>
-            </NogsGateButton>
+            </Button>
           </div>
         ) : null}
       </div>


### PR DESCRIPTION
## Summary
- replace token-gated button with a regular button so everyone can add tabs

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6853dc21a1a88325a90040306264c298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Replaced the specialized wrapper for the "Add Tab" button with a standard button component. No changes to button behavior or appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->