### PR TITLE
Fix shifting in web embed fidget

### DIFF
--- a/src/fidgets/ui/IFrame.tsx
+++ b/src/fidgets/ui/IFrame.tsx
@@ -169,6 +169,9 @@ const IFrame: React.FC<FidgetArgs<IFrameFidgetSettings>> = ({
           title="IFrame Fidget"
           sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
           style={{
+            // Use CSS zoom to avoid shifting when modals within the iframe open
+            // `transform` acts as a fallback for browsers without zoom support
+            zoom: scaleValue,
             transform: `scale(${scaleValue})`,
             transformOrigin: "0 0",
             width: `${100 / scaleValue}%`,


### PR DESCRIPTION
## Summary
- avoid page shift when modals open in the web embed fidget by using CSS `zoom`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6853eff1478083258b26bfe220c86c71