### PR TITLE
Fix token metadata price and image source

### DIFF
--- a/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
@@ -57,7 +57,7 @@ export async function generateMetadata({
       });
       price = `$${formatted}`;
     } else if (tokenData?.price_usd === "0" || Number(tokenData?.price_usd) === 0) {
-      price = "TBD";
+      price = "TBD ";
     } else {
       price = "";
     }

--- a/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
@@ -34,10 +34,14 @@ export async function generateMetadata({
   let priceChange = "";
   
   try {
-    const [tokenData, clankerData] = await Promise.all([
+    // Replace Promise.all with Promise.allSettled for more resilient error handling
+    const [tokenResult, clankerResult] = await Promise.allSettled([
       fetchTokenData(contractAddress, null, network as string),
       fetchClankerByAddress(contractAddress as Address),
     ]);
+    
+    const tokenData = tokenResult.status === 'fulfilled' ? tokenResult.value : null;
+    const clankerData = clankerResult.status === 'fulfilled' ? clankerResult.value : null;
 
     console.log("Token data fetched:", tokenData);
 

--- a/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/layout.tsx
@@ -4,6 +4,8 @@ import React from "react";
 import { fetchTokenData } from "@/common/lib/utils/fetchTokenData";
 import { getTokenMetadataStructure } from "@/common/lib/utils/tokenMetadata";
 import { defaultFrame } from "@/common/lib/frames/metadata";
+import { fetchClankerByAddress } from "@/common/data/queries/clanker";
+import { Address } from "viem";
 
 // Default metadata (used as fallback)
 const defaultMetadata = {
@@ -32,29 +34,30 @@ export async function generateMetadata({
   let priceChange = "";
   
   try {
-    const tokenData = await fetchTokenData(
-      contractAddress,
-      null,
-      network as string
-    );
+    const [tokenData, clankerData] = await Promise.all([
+      fetchTokenData(contractAddress, null, network as string),
+      fetchClankerByAddress(contractAddress as Address),
+    ]);
 
     console.log("Token data fetched:", tokenData);
-    
-    // Get symbol and price from tokenData
-    symbol = tokenData?.symbol || "";
-    name = tokenData?.name || "";
-    imageUrl = tokenData?.image_url || "";
+
+    symbol = clankerData?.symbol || tokenData?.symbol || "";
+    name = clankerData?.name || tokenData?.name || "";
+    imageUrl =
+      clankerData?.img_url ||
+      (tokenData?.image_url !== "missing.png" ? tokenData?.image_url || "" : "");
     marketCap = tokenData?.market_cap_usd || "";
     priceChange = tokenData?.priceChange || "";
-    
-    // Format price with extra precision for small values
-    if (tokenData?.price_usd) {
+
+    if (tokenData?.price_usd && Number(tokenData.price_usd) !== 0) {
       const priceNumber = Number(tokenData.price_usd);
       const formatted = priceNumber.toLocaleString(undefined, {
         minimumFractionDigits: priceNumber < 0.01 ? 4 : 2,
         maximumFractionDigits: priceNumber < 0.01 ? 6 : 2,
       });
       price = `$${formatted}`;
+    } else if (tokenData?.price_usd === "0" || Number(tokenData?.price_usd) === 0) {
+      price = "TBD";
     } else {
       price = "";
     }


### PR DESCRIPTION
## Summary
- display `TBD` when the token price is zero
- use Clanker images first for token OG thumbnails

Before: 
<img width="462" alt="image" src="https://github.com/user-attachments/assets/93e62385-b234-4e6c-b346-6e56062a7be2" />

After:
<img width="419" alt="image" src="https://github.com/user-attachments/assets/1376a54e-3545-4e3d-ae2f-a891488e98aa" />


## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6857b6e6e6288325b536a545c93540e4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
  - Metadata now incorporates additional information from clanker data, including symbol, name, and image, with fallback to token data.
- **Improvements**
  - Enhanced image selection logic to avoid displaying placeholder images when better options are available.
  - Refined price formatting for clearer display, showing "TBD" when price is zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->