### PR TITLE
Fix iframe overflow within fidget containers

### DIFF
--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -72,6 +72,10 @@ export function FidgetWrapper({
   }));
 
   const themeProps = (context?.theme ?? homebaseConfig?.theme)?.properties;
+  const hasRoundedCorners = Boolean(
+    themeProps?.fidgetBorderRadius &&
+      !/^0(px)?$/i.test(themeProps.fidgetBorderRadius.trim()),
+  );
 
   function onClickEdit() {
     setSelectedFidgetID(bundle.id);
@@ -262,11 +266,10 @@ export function FidgetWrapper({
             ? homebaseConfig?.theme?.properties.fidgetShadow
             : settingsWithDefaults.fidgetShadow,
           borderRadius: themeProps?.fidgetBorderRadius,
-          overflow:
-            themeProps?.fidgetBorderRadius &&
-            themeProps?.fidgetBorderRadius !== "0px"
-              ? "hidden"
-              : "visible",
+          overflow: hasRoundedCorners ? "hidden" : "visible",
+          clipPath: hasRoundedCorners
+            ? `inset(0 round ${themeProps?.fidgetBorderRadius})`
+            : undefined,
         }}
       >
         {bundle.config.editable && (
@@ -280,11 +283,10 @@ export function FidgetWrapper({
           <CardContent
             className="size-full"
             style={{
-              overflow:
-                themeProps?.fidgetBorderRadius &&
-                themeProps?.fidgetBorderRadius !== "0px"
-                  ? "hidden"
-                  : "visible",
+              overflow: hasRoundedCorners ? "hidden" : "visible",
+              clipPath: hasRoundedCorners
+                ? `inset(0 round ${themeProps?.fidgetBorderRadius})`
+                : undefined,
             }}
           >
             <Fidget

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -237,58 +237,53 @@ export function FidgetWrapper({
   return (
     <>
       {renderActionIcons()}
-      <Card
-        ref={fidgetRef}
-        className={
-          selectedFidgetID === bundle.id
-            ? "size-full border-solid border-sky-600 border-4 rounded-2xl"
-            : "size-full"
-        }
+      <div
         style={{
-          outline:
-            selectedFidgetID === bundle.id
-              ? "4px solid rgb(2 132 199)" /* sky-600 */
-              : undefined,
-          outlineOffset:
-            selectedFidgetID === bundle.id
-              ? -parseInt(themeProps?.fidgetBorderWidth ?? "0")
-              : undefined,
-          background: settingsWithDefaults.useDefaultColors
-            ? homebaseConfig?.theme?.properties.fidgetBackground
-            : settingsWithDefaults.background,
-          borderColor: settingsWithDefaults.useDefaultColors
-            ? homebaseConfig?.theme?.properties.fidgetBorderColor
-            : settingsWithDefaults.fidgetBorderColor,
-          borderWidth: settingsWithDefaults.useDefaultColors
-            ? homebaseConfig?.theme?.properties.fidgetBorderWidth
-            : settingsWithDefaults.fidgetBorderWidth,
-          boxShadow: settingsWithDefaults.useDefaultColors
-            ? homebaseConfig?.theme?.properties.fidgetShadow
-            : settingsWithDefaults.fidgetShadow,
           borderRadius: themeProps?.fidgetBorderRadius,
           overflow: hasRoundedCorners ? "hidden" : "visible",
-          clipPath: hasRoundedCorners
-            ? `inset(0 round ${themeProps?.fidgetBorderRadius})`
-            : undefined,
         }}
+        className="size-full"
       >
-        {bundle.config.editable && (
-          <button
-            onMouseDown={onClickEdit}
-            className="items-center justify-center opacity-0 hover:opacity-50 duration-500 absolute inset-0 z-10 flex bg-slate-400 bg-opacity-50"
-            style={{ borderRadius: themeProps?.fidgetBorderRadius }}
-          ></button>
-        )}
-        <ScopedStyles cssStyles={userStyles} className="size-full">
-          <CardContent
-            className="size-full"
-            style={{
-              overflow: hasRoundedCorners ? "hidden" : "visible",
-              clipPath: hasRoundedCorners
-                ? `inset(0 round ${themeProps?.fidgetBorderRadius})`
+        <Card
+          ref={fidgetRef}
+          className={
+            selectedFidgetID === bundle.id
+              ? "size-full border-solid border-sky-600 border-4 rounded-2xl"
+              : "size-full"
+          }
+          style={{
+            outline:
+              selectedFidgetID === bundle.id
+                ? "4px solid rgb(2 132 199)" /* sky-600 */
                 : undefined,
-            }}
-          >
+            outlineOffset:
+              selectedFidgetID === bundle.id
+                ? -parseInt(themeProps?.fidgetBorderWidth ?? "0")
+                : undefined,
+            background: settingsWithDefaults.useDefaultColors
+              ? homebaseConfig?.theme?.properties.fidgetBackground
+              : settingsWithDefaults.background,
+            borderColor: settingsWithDefaults.useDefaultColors
+              ? homebaseConfig?.theme?.properties.fidgetBorderColor
+              : settingsWithDefaults.fidgetBorderColor,
+            borderWidth: settingsWithDefaults.useDefaultColors
+              ? homebaseConfig?.theme?.properties.fidgetBorderWidth
+              : settingsWithDefaults.fidgetBorderWidth,
+            boxShadow: settingsWithDefaults.useDefaultColors
+              ? homebaseConfig?.theme?.properties.fidgetShadow
+              : settingsWithDefaults.fidgetShadow,
+            borderRadius: themeProps?.fidgetBorderRadius,
+          }}
+        >
+          {bundle.config.editable && (
+            <button
+              onMouseDown={onClickEdit}
+              className="items-center justify-center opacity-0 hover:opacity-50 duration-500 absolute inset-0 z-10 flex bg-slate-400 bg-opacity-50"
+              style={{ borderRadius: themeProps?.fidgetBorderRadius }}
+            ></button>
+          )}
+          <ScopedStyles cssStyles={userStyles} className="size-full">
+          <CardContent className="size-full">
             <Fidget
               {...{
                 settings: settingsWithDefaults,
@@ -298,7 +293,8 @@ export function FidgetWrapper({
             />
           </CardContent>
         </ScopedStyles>
-      </Card>
+        </Card>
+      </div>
     </>
   );
 }

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -76,6 +76,9 @@ export function FidgetWrapper({
     themeProps?.fidgetBorderRadius &&
       !/^0(px)?$/i.test(themeProps.fidgetBorderRadius.trim()),
   );
+  const clipPathStyle = hasRoundedCorners
+    ? `inset(0 round ${themeProps?.fidgetBorderRadius})`
+    : undefined;
 
   function onClickEdit() {
     setSelectedFidgetID(bundle.id);
@@ -241,6 +244,8 @@ export function FidgetWrapper({
         style={{
           borderRadius: themeProps?.fidgetBorderRadius,
           overflow: hasRoundedCorners ? "hidden" : "visible",
+          clipPath: clipPathStyle,
+          WebkitClipPath: clipPathStyle,
         }}
         className="size-full"
       >

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -277,7 +277,6 @@ export function FidgetWrapper({
             boxShadow: settingsWithDefaults.useDefaultColors
               ? homebaseConfig?.theme?.properties.fidgetShadow
               : settingsWithDefaults.fidgetShadow,
-            borderRadius: themeProps?.fidgetBorderRadius,
           }}
         >
           {bundle.config.editable && (

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -262,7 +262,11 @@ export function FidgetWrapper({
             ? homebaseConfig?.theme?.properties.fidgetShadow
             : settingsWithDefaults.fidgetShadow,
           borderRadius: themeProps?.fidgetBorderRadius,
-          overflow: "visible"
+          overflow:
+            themeProps?.fidgetBorderRadius &&
+            themeProps?.fidgetBorderRadius !== "0px"
+              ? "hidden"
+              : "visible",
         }}
       >
         {bundle.config.editable && (
@@ -273,7 +277,16 @@ export function FidgetWrapper({
           ></button>
         )}
         <ScopedStyles cssStyles={userStyles} className="size-full">
-          <CardContent className="size-full" style={{ overflow: "visible" }}>
+          <CardContent
+            className="size-full"
+            style={{
+              overflow:
+                themeProps?.fidgetBorderRadius &&
+                themeProps?.fidgetBorderRadius !== "0px"
+                  ? "hidden"
+                  : "visible",
+            }}
+          >
             <Fidget
               {...{
                 settings: settingsWithDefaults,

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -644,6 +644,16 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
                       !/^0(px)?$/i.test(gridDetails.borderRadius.trim())
                         ? "hidden"
                         : undefined,
+                    clipPath:
+                      gridDetails.borderRadius &&
+                      !/^0(px)?$/i.test(gridDetails.borderRadius.trim())
+                        ? `inset(0 round ${gridDetails.borderRadius})`
+                        : undefined,
+                    WebkitClipPath:
+                      gridDetails.borderRadius &&
+                      !/^0(px)?$/i.test(gridDetails.borderRadius.trim())
+                        ? `inset(0 round ${gridDetails.borderRadius})`
+                        : undefined,
                     outline:
                       selectedFidgetID === gridItem.i
                         ? "4px solid rgb(2 132 199)" /* sky-600 */

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -639,6 +639,11 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
                   className="grid-item"
                   style={{
                     borderRadius: gridDetails.borderRadius,
+                    overflow:
+                      gridDetails.borderRadius &&
+                      !/^0(px)?$/i.test(gridDetails.borderRadius.trim())
+                        ? "hidden"
+                        : undefined,
                     outline:
                       selectedFidgetID === gridItem.i
                         ? "4px solid rgb(2 132 199)" /* sky-600 */

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -633,27 +633,23 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
                 : null;
               if (!fidgetModule) return null;
 
+              const shouldClipCorners =
+                gridDetails.borderRadius &&
+                !/^0(px)?$/i.test(gridDetails.borderRadius.trim());
+
               return (
                 <div
                   key={gridItem.i}
                   className="grid-item"
                   style={{
                     borderRadius: gridDetails.borderRadius,
-                    overflow:
-                      gridDetails.borderRadius &&
-                      !/^0(px)?$/i.test(gridDetails.borderRadius.trim())
-                        ? "hidden"
-                        : undefined,
-                    clipPath:
-                      gridDetails.borderRadius &&
-                      !/^0(px)?$/i.test(gridDetails.borderRadius.trim())
-                        ? `inset(0 round ${gridDetails.borderRadius})`
-                        : undefined,
-                    WebkitClipPath:
-                      gridDetails.borderRadius &&
-                      !/^0(px)?$/i.test(gridDetails.borderRadius.trim())
-                        ? `inset(0 round ${gridDetails.borderRadius})`
-                        : undefined,
+                    overflow: shouldClipCorners ? "hidden" : undefined,
+                    clipPath: shouldClipCorners
+                      ? `inset(0 round ${gridDetails.borderRadius})`
+                      : undefined,
+                    WebkitClipPath: shouldClipCorners
+                      ? `inset(0 round ${gridDetails.borderRadius})`
+                      : undefined,
                     outline:
                       selectedFidgetID === gridItem.i
                         ? "4px solid rgb(2 132 199)" /* sky-600 */


### PR DESCRIPTION
## Summary
- hide overflow for fidget containers when rounded

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6859139d10908325be22b5b04994710e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved visual rendering of components with rounded corners by adding clipping and overflow styles, ensuring content respects border radius settings.
  - Enhanced grid items to properly display rounded corners when a border radius is set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->