### PR TITLE
Hide empty fidget tray

### DIFF
--- a/src/common/components/organisms/EditorPanel.tsx
+++ b/src/common/components/organisms/EditorPanel.tsx
@@ -156,20 +156,23 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({
           )}
         </div>
       </div>
-      {fidgetTrayContents.length > 0 && (
-        <div className="w-24">
-          <FidgetTray
-            setCurrentlyDragging={setCurrentlyDragging}
-            setExternalDraggedItem={setExternalDraggedItem}
-            contents={fidgetTrayContents}
-            openFidgetPicker={openFidgetPicker}
-            saveTrayContents={saveTrayContents}
-            removeFidget={removeFidget}
-            selectedFidgetID={selectedFidgetID}
-            selectFidget={selectFidget}
-          />
-        </div>
-      )}
+      <div 
+        className={`
+          transition-all duration-300 ease-in-out overflow-hidden
+          ${fidgetTrayContents.length > 0 ? 'w-24 opacity-100' : 'w-0 opacity-0'}
+        `}
+      >
+        <FidgetTray
+          setCurrentlyDragging={setCurrentlyDragging}
+          setExternalDraggedItem={setExternalDraggedItem}
+          contents={fidgetTrayContents}
+          openFidgetPicker={openFidgetPicker}
+          saveTrayContents={saveTrayContents}
+          removeFidget={removeFidget}
+          selectedFidgetID={selectedFidgetID}
+          selectFidget={selectFidget}
+        />
+      </div>
     </aside>
   );
 };

--- a/src/common/components/organisms/EditorPanel.tsx
+++ b/src/common/components/organisms/EditorPanel.tsx
@@ -156,18 +156,20 @@ export const EditorPanel: React.FC<EditorPanelProps> = ({
           )}
         </div>
       </div>
-      <div className="w-24">
-        <FidgetTray
-          setCurrentlyDragging={setCurrentlyDragging}
-          setExternalDraggedItem={setExternalDraggedItem}
-          contents={fidgetTrayContents}
-          openFidgetPicker={openFidgetPicker}
-          saveTrayContents={saveTrayContents}
-          removeFidget={removeFidget}
-          selectedFidgetID={selectedFidgetID}
-          selectFidget={selectFidget}
-        />
-      </div>
+      {fidgetTrayContents.length > 0 && (
+        <div className="w-24">
+          <FidgetTray
+            setCurrentlyDragging={setCurrentlyDragging}
+            setExternalDraggedItem={setExternalDraggedItem}
+            contents={fidgetTrayContents}
+            openFidgetPicker={openFidgetPicker}
+            saveTrayContents={saveTrayContents}
+            removeFidget={removeFidget}
+            selectedFidgetID={selectedFidgetID}
+            selectFidget={selectFidget}
+          />
+        </div>
+      )}
     </aside>
   );
 };

--- a/src/common/components/organisms/FidgetTray.tsx
+++ b/src/common/components/organisms/FidgetTray.tsx
@@ -32,84 +32,85 @@ export const FidgetTray: React.FC<FidgetTrayProps> = ({
   selectedFidgetID,
   selectFidget,
 }) => {
-  if (contents.length === 0) {
-    return null;
-  }
   return (
     <div className="w-full h-screen flex flex-col justify-start items-center gap-2 bg-sky-50 py-7 px-6 overflow-auto">
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <center>
-              <FaInfoCircle color="#D1D5DB" />
-            </center>
-          </TooltipTrigger>
-          <TooltipContent side="left">
-            <div className="flex flex-col gap-1">
-              <div>
-                Click the + to browse Fidgets.
-                <br />
-                Then, drag them to your Space
+      {contents.length > 0 && (
+        <>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <center>
+                  <FaInfoCircle color="#D1D5DB" />
+                </center>
+              </TooltipTrigger>
+              <TooltipContent side="left">
+                <div className="flex flex-col gap-1">
+                  <div>
+                    Click the + to browse Fidgets.
+                    <br />
+                    Then, drag them to your Space
+                  </div>
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <h5 className="text-xs font-medium text-center -mx-3 mb-3">
+            Fidget Tray
+          </h5>
+          {map(contents, (fidgetData: FidgetInstanceData) => {
+            const fidgetBundle = {
+              ...fidgetData,
+              properties: CompleteFidgets[fidgetData.fidgetType].properties,
+              config: { ...fidgetData.config, editable: true },
+            };
+
+            const onClick = () => {
+              // console.log("fidgetBundle", fidgetBundle);
+              selectFidget(fidgetBundle);
+            };
+
+            return (
+              <div key={fidgetData.id} className="w-full">
+                <div
+                  className={`z-20 droppable-element px-2 py-2 flex justify-center items-center border rounded-md hover:bg-sky-100 group cursor-pointer ${
+                    selectedFidgetID === fidgetData.id
+                      ? "outline outline-4 outline-offset-1 outline-sky-600"
+                      : ""
+                  }`}
+                  draggable={true}
+                  // unselectable helps with IE support
+                  // eslint-disable-next-line react/no-unknown-property
+                  unselectable="off"
+                  onClick={onClick}
+                  onDragStart={(e) => {
+                    setCurrentlyDragging(true);
+                    e.dataTransfer.setData(
+                      "text/plain",
+                      JSON.stringify(fidgetData),
+                    );
+                    setExternalDraggedItem({
+                      i: fidgetData.id,
+                      w: CompleteFidgets[fidgetData.fidgetType].properties.size
+                        .minWidth,
+                      h: CompleteFidgets[fidgetData.fidgetType].properties.size
+                        .minHeight,
+                    });
+                  }}
+                >
+                  {String.fromCodePoint(
+                    CompleteFidgets[fidgetData.fidgetType].properties.icon,
+                  )}
+                </div>
               </div>
-            </div>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-      <h5 className="text-xs font-medium text-center -mx-3 mb-3">
-        Fidget Tray
-      </h5>
-      {map(contents, (fidgetData: FidgetInstanceData) => {
-        const fidgetBundle = {
-          ...fidgetData,
-          properties: CompleteFidgets[fidgetData.fidgetType].properties,
-          config: { ...fidgetData.config, editable: true },
-        };
-
-        const onClick = () => {
-          // console.log("fidgetBundle", fidgetBundle);
-          selectFidget(fidgetBundle);
-        };
-
-        return (
-          <div key={fidgetData.id} className="w-full">
-            <div
-              className={`z-20 droppable-element px-2 py-2 flex justify-center items-center border rounded-md hover:bg-sky-100 group cursor-pointer ${
-                selectedFidgetID === fidgetData.id
-                  ? "outline outline-4 outline-offset-1 outline-sky-600"
-                  : ""
-              }`}
-              draggable={true}
-              // unselectable helps with IE support
-              // eslint-disable-next-line react/no-unknown-property
-              unselectable="off"
-              onClick={onClick}
-              onDragStart={(e) => {
-                setCurrentlyDragging(true);
-                e.dataTransfer.setData(
-                  "text/plain",
-                  JSON.stringify(fidgetData),
-                );
-                setExternalDraggedItem({
-                  i: fidgetData.id,
-                  w: CompleteFidgets[fidgetData.fidgetType].properties.size
-                    .minWidth,
-                  h: CompleteFidgets[fidgetData.fidgetType].properties.size
-                    .minHeight,
-                });
-              }}
-            >
-              {String.fromCodePoint(
-                CompleteFidgets[fidgetData.fidgetType].properties.icon,
-              )}
-            </div>
+            );
+          })}
+          <div className="flex justify-center items-center w-full">
+            <Button onClick={openFidgetPicker} withIcon variant="primary">
+              <FaPlus />
+            </Button>
           </div>
-        );
-      })}
-      <div className="flex justify-center items-center w-full">
-        <Button onClick={openFidgetPicker} withIcon variant="primary">
-          <FaPlus />
-        </Button>
-      </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/common/components/organisms/FidgetTray.tsx
+++ b/src/common/components/organisms/FidgetTray.tsx
@@ -32,85 +32,90 @@ export const FidgetTray: React.FC<FidgetTrayProps> = ({
   selectedFidgetID,
   selectFidget,
 }) => {
+  const hasContents = contents.length > 0;
+  
   return (
     <div className="w-full h-screen flex flex-col justify-start items-center gap-2 bg-sky-50 py-7 px-6 overflow-auto">
-      {contents.length > 0 && (
-        <>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <center>
-                  <FaInfoCircle color="#D1D5DB" />
-                </center>
-              </TooltipTrigger>
-              <TooltipContent side="left">
-                <div className="flex flex-col gap-1">
-                  <div>
-                    Click the + to browse Fidgets.
-                    <br />
-                    Then, drag them to your Space
-                  </div>
-                </div>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <h5 className="text-xs font-medium text-center -mx-3 mb-3">
-            Fidget Tray
-          </h5>
-          {map(contents, (fidgetData: FidgetInstanceData) => {
-            const fidgetBundle = {
-              ...fidgetData,
-              properties: CompleteFidgets[fidgetData.fidgetType].properties,
-              config: { ...fidgetData.config, editable: true },
-            };
-
-            const onClick = () => {
-              // console.log("fidgetBundle", fidgetBundle);
-              selectFidget(fidgetBundle);
-            };
-
-            return (
-              <div key={fidgetData.id} className="w-full">
-                <div
-                  className={`z-20 droppable-element px-2 py-2 flex justify-center items-center border rounded-md hover:bg-sky-100 group cursor-pointer ${
-                    selectedFidgetID === fidgetData.id
-                      ? "outline outline-4 outline-offset-1 outline-sky-600"
-                      : ""
-                  }`}
-                  draggable={true}
-                  // unselectable helps with IE support
-                  // eslint-disable-next-line react/no-unknown-property
-                  unselectable="off"
-                  onClick={onClick}
-                  onDragStart={(e) => {
-                    setCurrentlyDragging(true);
-                    e.dataTransfer.setData(
-                      "text/plain",
-                      JSON.stringify(fidgetData),
-                    );
-                    setExternalDraggedItem({
-                      i: fidgetData.id,
-                      w: CompleteFidgets[fidgetData.fidgetType].properties.size
-                        .minWidth,
-                      h: CompleteFidgets[fidgetData.fidgetType].properties.size
-                        .minHeight,
-                    });
-                  }}
-                >
-                  {String.fromCodePoint(
-                    CompleteFidgets[fidgetData.fidgetType].properties.icon,
-                  )}
+      <div 
+        className={`
+          transition-all duration-300 ease-in-out w-full flex flex-col justify-start items-center gap-2
+          ${hasContents ? 'opacity-100 delay-150' : 'opacity-0 delay-0'}
+        `}
+      >
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <center>
+                <FaInfoCircle color="#D1D5DB" />
+              </center>
+            </TooltipTrigger>
+            <TooltipContent side="left">
+              <div className="flex flex-col gap-1">
+                <div>
+                  Click the + to browse Fidgets.
+                  <br />
+                  Then, drag them to your Space
                 </div>
               </div>
-            );
-          })}
-          <div className="flex justify-center items-center w-full">
-            <Button onClick={openFidgetPicker} withIcon variant="primary">
-              <FaPlus />
-            </Button>
-          </div>
-        </>
-      )}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <h5 className="text-xs font-medium text-center -mx-3 mb-3">
+          Fidget Tray
+        </h5>
+        {map(contents, (fidgetData: FidgetInstanceData) => {
+          const fidgetBundle = {
+            ...fidgetData,
+            properties: CompleteFidgets[fidgetData.fidgetType].properties,
+            config: { ...fidgetData.config, editable: true },
+          };
+
+          const onClick = () => {
+            // console.log("fidgetBundle", fidgetBundle);
+            selectFidget(fidgetBundle);
+          };
+
+          return (
+            <div key={fidgetData.id} className="w-full">
+              <div
+                className={`z-20 droppable-element px-2 py-2 flex justify-center items-center border rounded-md hover:bg-sky-100 group cursor-pointer ${
+                  selectedFidgetID === fidgetData.id
+                    ? "outline outline-4 outline-offset-1 outline-sky-600"
+                    : ""
+                }`}
+                draggable={true}
+                // unselectable helps with IE support
+                // eslint-disable-next-line react/no-unknown-property
+                unselectable="off"
+                onClick={onClick}
+                onDragStart={(e) => {
+                  setCurrentlyDragging(true);
+                  e.dataTransfer.setData(
+                    "text/plain",
+                    JSON.stringify(fidgetData),
+                  );
+                  setExternalDraggedItem({
+                    i: fidgetData.id,
+                    w: CompleteFidgets[fidgetData.fidgetType].properties.size
+                      .minWidth,
+                    h: CompleteFidgets[fidgetData.fidgetType].properties.size
+                      .minHeight,
+                  });
+                }}
+              >
+                {String.fromCodePoint(
+                  CompleteFidgets[fidgetData.fidgetType].properties.icon,
+                )}
+              </div>
+            </div>
+          );
+        })}
+        <div className="flex justify-center items-center w-full">
+          <Button onClick={openFidgetPicker} withIcon variant="primary">
+            <FaPlus />
+          </Button>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/common/components/organisms/FidgetTray.tsx
+++ b/src/common/components/organisms/FidgetTray.tsx
@@ -32,6 +32,9 @@ export const FidgetTray: React.FC<FidgetTrayProps> = ({
   selectedFidgetID,
   selectFidget,
 }) => {
+  if (contents.length === 0) {
+    return null;
+  }
   return (
     <div className="w-full h-screen flex flex-col justify-start items-center gap-2 bg-sky-50 py-7 px-6 overflow-auto">
       <TooltipProvider>


### PR DESCRIPTION
## Summary
- hide FidgetTray component when the tray has no fidgets

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6859236fed148325992809934c8e1a7e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- The Fidget Tray and its container now smoothly appear and disappear based on content, enhancing visual transitions and preventing empty tray UI from showing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->