### PR TITLE
Enable channel pages and link mentions

### DIFF
--- a/src/app/(spaces)/channel/[channelName]/page.tsx
+++ b/src/app/(spaces)/channel/[channelName]/page.tsx
@@ -29,6 +29,8 @@ async function getChannelSpace(channel: string) {
   return data[0].spaceId as string;
 }
 
+export const dynamic = "force-dynamic";
+
 export default async function ChannelSpacePage({ params }: any) {
   const { channelName, tabName } = params as {
     channelName?: string;
@@ -37,7 +39,6 @@ export default async function ChannelSpacePage({ params }: any) {
   if (!channelName) return <SpaceNotFound />;
 
   const info = await loadChannelInfo(channelName);
-  if (!info) return <SpaceNotFound />;
 
   const spaceId = await getChannelSpace(channelName);
 
@@ -46,7 +47,7 @@ export default async function ChannelSpacePage({ params }: any) {
       channelName={channelName}
       spaceId={spaceId}
       tabName={tabName ?? "Feed"}
-      spaceOwnerFid={info.host?.fid}
+      spaceOwnerFid={info?.host?.fid}
     />
   );
 }

--- a/src/fidgets/farcaster/components/linkify.tsx
+++ b/src/fidgets/farcaster/components/linkify.tsx
@@ -51,16 +51,17 @@ const renderLink = ({ attributes, content }: RenderFunctionArgs) => {
 };
 
 const renderChannel = ({ content }: RenderFunctionArgs) => {
+  const channelName = content.startsWith("/") ? content.slice(1) : content;
   return (
-    <span
+    <Link
+      href={`/channel/${channelName}`}
       className="cursor-pointer text-blue-500 text-font-medium hover:underline hover:text-blue-500/70"
       onClick={(event) => {
         event.stopPropagation();
       }}
-      rel="noopener noreferrer"
     >
       {content}
-    </span>
+    </Link>
   );
 };
 


### PR DESCRIPTION
## Summary
- allow channel pages to render even if channel info lookup fails
- link channel mentions in farcaster linkify component

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68594722111c832583dbad00e9051a08