### PR TITLE
Highlight channel name on hover

### DIFF
--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -501,7 +501,7 @@ const CastReactions = ({ cast }: { cast: CastWithInteractions }) => {
           <PriorityLink
             key={`cast-${cast.hash}-channel-name`}
             href={`/channel/${cast.channel.name}`}
-            className="mt-1.5 flex align-center text-sm opacity-40 py-1 px-1.5 rounded-md"
+            className="mt-1.5 flex align-center text-sm opacity-40 hover:text-blue-500 hover:opacity-100 hover:underline cursor-pointer py-1 px-1.5 rounded-md"
           >
             /{cast.channel.name}
           </PriorityLink>


### PR DESCRIPTION
## Summary
- highlight channel name blue on hover so the link stands out

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition file for 'node', 'react', 'react-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6859508276408325a7f911ce6358da79