### PR TITLE
Fix channel followers and link

### DIFF
--- a/src/fidgets/farcaster/utils.ts
+++ b/src/fidgets/farcaster/utils.ts
@@ -38,6 +38,10 @@ export interface Channel {
   member_count?: number;
   followers?: number;
   host?: { fid: number };
+  external_link?: {
+    title: string;
+    url: string;
+  };
 }
 
 type FarcasterUrlEmbed = {

--- a/src/fidgets/ui/channel.tsx
+++ b/src/fidgets/ui/channel.tsx
@@ -69,14 +69,14 @@ const Channel: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({ settings }) => {
         </div>
       </div>
       {data.description && <p className="text-sm">{data.description}</p>}
-      {data.parent_url && (
+      {data.external_link?.url && (
         <a
-          href={data.parent_url}
+          href={data.external_link.url}
           target="_blank"
           rel="noreferrer"
           className="text-blue-600 hover:underline text-sm"
         >
-          {data.parent_url}
+          {data.external_link.title}
         </a>
       )}
       <div className="flex gap-4 text-sm">

--- a/src/pages/api/farcaster/neynar/channel.ts
+++ b/src/pages/api/farcaster/neynar/channel.ts
@@ -20,6 +20,20 @@ async function loadChannel(req: NextApiRequest, res: NextApiResponse) {
       return res.status(data.status).json(data);
     }
 
+    try {
+      const fcRes = await axios.get("https://api.farcaster.xyz/v2/all-channels");
+      const fcChannel = fcRes.data.result.channels.find(
+        (c: any) => c.id === req.query.id,
+      );
+
+      if (fcChannel) {
+        data.channel.followers = fcChannel.followerCount;
+        data.channel.external_link = fcChannel.externalLink;
+      }
+    } catch {
+      // ignore errors from farcaster client API
+    }
+
     res.status(200).json(data);
   } catch (e) {
     if (isAxiosError(e)) {


### PR DESCRIPTION
## Summary
- fetch follower count and external link from the Farcaster client API
- expose the channel's `external_link` field in the interface
- display the channel external link title and follower count in Channel fidget

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6859560b37748325bef9e5ea37c612fe