### PR TITLE
Enable customization of homebase feed

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -85,6 +85,10 @@ const nextConfig = {
       ...config.resolve.fallback,
       os: false,
     };
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      os: false,
+    };
     return config;
   },
 

--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -9,6 +9,7 @@ import {
   LayoutFidgetSavableConfig as LayoutFidgetSaveableConfig,
 } from "@/common/fidgets";
 import { UserTheme } from "@/common/lib/theme";
+import type { FeedFidgetSettings, FeedFidgetData } from "@/fidgets/farcaster/Feed";
 import CustomHTMLBackground from "@/common/components/molecules/CustomHTMLBackground";
 import { isNil, isUndefined } from "lodash";
 import InfoToast from "@/common/components/organisms/InfoBanner";
@@ -30,6 +31,7 @@ export type SpaceConfig = {
   fidgetInstanceDatums: {
     [key: string]: FidgetInstanceData;
   };
+  feedInstanceDatum?: FidgetInstanceData<FeedFidgetSettings, FeedFidgetData>;
   layoutID: string;
   layoutDetails: LayoutFidgetDetails<LayoutFidgetConfig<any>>;
   isEditable: boolean;

--- a/src/app/(spaces)/homebase/PrivateSpace.tsx
+++ b/src/app/(spaces)/homebase/PrivateSpace.tsx
@@ -13,6 +13,7 @@ import { useSidebarContext } from "@/common/components/organisms/Sidebar";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialPersonSpace";
 import { HOMEBASE_ID } from "@/common/data/stores/app/currentSpace";
 import INITIAL_HOMEBASE_CONFIG, { HOMEBASE_FEED_FIDGET_ID } from "@/constants/intialHomebase";
+import DEFAULT_THEME from "@/common/lib/theme/defaultTheme";
 import { LoginModal } from "@privy-io/react-auth";
 import { FeedType } from "@neynar/nodejs-sdk/build/api";
 
@@ -247,7 +248,7 @@ function PrivateSpace({ tabName, castHash }: { tabName: string; castHash?: strin
     feed: tabName === "Feed" ? (
       <FidgetWrapper
         fidget={FeedModule.fidget}
-        context={{ theme: sanitizedHomebaseConfig?.theme }}
+        context={{ theme: sanitizedHomebaseConfig?.theme ?? DEFAULT_THEME }}
         bundle={{
           ...feedBundle,
           config: {

--- a/src/common/data/stores/app/homebase/homebaseStore.ts
+++ b/src/common/data/stores/app/homebase/homebaseStore.ts
@@ -11,7 +11,7 @@ import {
   SpaceConfig,
   SpaceConfigSaveDetails,
 } from "@/app/(spaces)/Space";
-import INITIAL_HOMEBASE_CONFIG from "@/constants/intialHomebase";
+import INITIAL_HOMEBASE_CONFIG, { HOMEBASE_FEED_FIDGET_ID } from "@/constants/intialHomebase";
 import {
   HomeBaseTabStore,
   createHomeBaseTabStoreFunc,
@@ -83,6 +83,12 @@ export const createHomeBaseStoreFunc = (
       ) {
         return cloneDeep(currentHomebase);
       }
+      if (!spaceConfig.feedInstanceDatum) {
+        spaceConfig.feedInstanceDatum = {
+          ...INITIAL_HOMEBASE_CONFIG.feedInstanceDatum!,
+          id: HOMEBASE_FEED_FIDGET_ID,
+        };
+      }
       set((draft) => {
         draft.homebase.homebaseConfig = cloneDeep(spaceConfig);
         draft.homebase.remoteHomebaseConfig = cloneDeep(spaceConfig);
@@ -97,6 +103,7 @@ export const createHomeBaseStoreFunc = (
             id: `Homebase-Feed-Theme`,
             name: `Homebase-Feed-Theme`,
           },
+          feedInstanceDatum: INITIAL_HOMEBASE_CONFIG.feedInstanceDatum,
         };
         draft.homebase.remoteHomebaseConfig = {
           ...cloneDeep(INITIAL_HOMEBASE_CONFIG),
@@ -105,6 +112,7 @@ export const createHomeBaseStoreFunc = (
             id: `Homebase-Feed-Theme`,
             name: `Homebase-Feed-Theme`,
           },
+          feedInstanceDatum: INITIAL_HOMEBASE_CONFIG.feedInstanceDatum,
         };
       }, "loadHomebase-default");
       return cloneDeep(INITIAL_HOMEBASE_CONFIG);

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -109,18 +109,16 @@ export function FidgetWrapper<
     bundle.properties,
   );
 
-  const onSave = async (
+  const onSave = (
     newSettings: S,
     shouldUnselect?: boolean,
-  ) => {
-    try {
-      await saveConfig({
-        ...bundle.config,
-        settings: newSettings,
-      });
-    } catch (e) {
+  ): void => {
+    saveConfig({
+      ...bundle.config,
+      settings: newSettings,
+    }).catch(() => {
       toast.error("Failed to save fidget settings", { duration: 1000 });
-    }
+    });
 
     if (shouldUnselect) {
       unselect();

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -47,18 +47,18 @@ export const getSettingsWithDefaults = <
   settings: S | undefined,
   config: FidgetProperties<S>,
 ): S => {
-  const safeSettings = settings ?? {};
+  const safeSettings = settings ?? ({} as Partial<S>);
   return reduce(
     config.fields,
     (acc, f) => ({
       ...acc,
       [f.fieldName]:
         f.fieldName in safeSettings
-          ? safeSettings[f.fieldName]
-          : (f.default ?? undefined),
+          ? (safeSettings as Record<string, unknown>)[f.fieldName]
+          : f.default ?? undefined,
     }),
-    {},
-  );
+    {} as Partial<S>,
+  ) as S;
 };
 
 export function FidgetWrapper<

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -26,11 +26,14 @@ import {
 } from "../components/atoms/tooltip";
 import FidgetSettingsEditor from "../components/organisms/FidgetSettingsEditor";
 
-export type FidgetWrapperProps = {
-  fidget: React.FC<FidgetArgs>;
-  bundle: FidgetBundle;
+export type FidgetWrapperProps<
+  S extends FidgetSettings = FidgetSettings,
+  D extends FidgetData = FidgetData,
+> = {
+  fidget: React.FC<FidgetArgs<S, D>>;
+  bundle: FidgetBundle<S, D>;
   context?: FidgetRenderContext;
-  saveConfig: (conf: FidgetConfig) => Promise<void>;
+  saveConfig: (conf: FidgetConfig<S, D>) => Promise<void>;
   setCurrentFidgetSettings: (currentFidgetSettings: React.ReactNode) => void;
   setSelectedFidgetID: (selectedFidgetID: string) => void;
   selectedFidgetID: string;
@@ -38,10 +41,12 @@ export type FidgetWrapperProps = {
   minimizeFidget: (fidgetId: string) => void;
 };
 
-export const getSettingsWithDefaults = (
-  settings: FidgetSettings | undefined,
-  config: FidgetProperties,
-): FidgetSettings => {
+export const getSettingsWithDefaults = <
+  S extends FidgetSettings = FidgetSettings,
+>(
+  settings: S | undefined,
+  config: FidgetProperties<S>,
+): S => {
   const safeSettings = settings ?? {};
   return reduce(
     config.fields,
@@ -56,7 +61,10 @@ export const getSettingsWithDefaults = (
   );
 };
 
-export function FidgetWrapper({
+export function FidgetWrapper<
+  S extends FidgetSettings = FidgetSettings,
+  D extends FidgetData = FidgetData,
+>({
   fidget,
   bundle,
   context,
@@ -66,7 +74,7 @@ export function FidgetWrapper({
   selectedFidgetID,
   removeFidget,
   minimizeFidget,
-}: FidgetWrapperProps) {
+}: FidgetWrapperProps<S, D>) {
   const { homebaseConfig } = useAppStore((state) => ({
     homebaseConfig: state.homebase.homebaseConfig,
   }));
@@ -89,7 +97,7 @@ export function FidgetWrapper({
 
   const Fidget = fidget;
 
-  const saveData = (data: FidgetData) => {
+  const saveData = (data: D) => {
     return saveConfig({
       ...bundle.config,
       data,
@@ -102,7 +110,7 @@ export function FidgetWrapper({
   );
 
   const onSave = async (
-    newSettings: FidgetSettings,
+    newSettings: S,
     shouldUnselect?: boolean,
   ) => {
     try {

--- a/src/constants/intialHomebase.ts
+++ b/src/constants/intialHomebase.ts
@@ -1,5 +1,7 @@
 import { SpaceConfig } from "@/app/(spaces)/Space";
 import DEFAULT_THEME from "@/common/lib/theme/defaultTheme";
+import { FeedType, FilterType } from "@neynar/nodejs-sdk/build/api";
+import type { FeedFidgetSettings, FeedFidgetData } from "@/fidgets/farcaster/Feed";
 const tutorialText = `
 ### 🖌️ Click the paintbrush in the bottom-left corner to open Customization Mode
 
@@ -74,6 +76,30 @@ const onboardingFidgetConfig = {
   id: onboardingFidgetID,
 };
 
+export const HOMEBASE_FEED_FIDGET_ID = "feed:homebase";
+
+const homebaseFeedFidget: {
+  config: { editable: boolean; settings: FeedFidgetSettings; data: FeedFidgetData };
+  fidgetType: string;
+  id: string;
+} = {
+  config: {
+    editable: true,
+    settings: {
+      feedType: FeedType.Following,
+      filterType: FilterType.Users,
+      selectPlatform: { name: "Farcaster", icon: "/images/farcaster.jpeg" },
+      Xhandle: "",
+      style: "",
+      fontFamily: "var(--user-theme-font)",
+      fontColor: "var(--user-theme-font-color)" as any,
+    } as FeedFidgetSettings,
+    data: {},
+  },
+  fidgetType: "feed",
+  id: HOMEBASE_FEED_FIDGET_ID,
+};
+
 const layoutID = "";
 const INITIAL_HOMEBASE_CONFIG: SpaceConfig = {
   layoutID,
@@ -98,6 +124,7 @@ const INITIAL_HOMEBASE_CONFIG: SpaceConfig = {
   fidgetInstanceDatums: {
     [onboardingFidgetID]: onboardingFidgetConfig,
   },
+  feedInstanceDatum: homebaseFeedFidget,
   isEditable: true,
   fidgetTrayContents: [],
 };


### PR DESCRIPTION
## Summary
- add optional `feedInstanceDatum` to `SpaceConfig`
- define default feed fidget in `INITIAL_HOMEBASE_CONFIG`
- persist homebase feed settings in `homebaseStore`
- wrap homebase feed with `FidgetWrapper` for editing

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685e483940648325bf394fd5ed097906