### PR TITLE
fix: add 'media.tenor.com' to non-frame domains list

### DIFF
--- a/src/common/lib/utils/frameDetection.ts
+++ b/src/common/lib/utils/frameDetection.ts
@@ -26,6 +26,7 @@ const NON_FRAME_DOMAINS = [
   'imgur.com',
   'giphy.com',
   'tenor.com',
+  'media.tenor.com',
   'pinterest.com',
   'flickr.com',
   'unsplash.com',


### PR DESCRIPTION
This pull request adds a new domain to the `NON_FRAME_DOMAINS` list in the `src/common/lib/utils/frameDetection.ts` file. The domain `media.tenor.com` is now included to ensure proper handling of non-frame domains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated domain handling to ensure URLs from 'media.tenor.com' are correctly excluded from frame compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->