### PR TITLE
Adjust primary feed width

### DIFF
--- a/src/app/(spaces)/Space.tsx
+++ b/src/app/(spaces)/Space.tsx
@@ -283,8 +283,8 @@ export default function Space({
               <div
                 className={
                   !isUndefined(profile)
-                    ? "w-6/12 h-[calc(100vh-224px)]"
-                    : "w-6/12 h-[calc(100vh-64px)]"
+                    ? "w-5/12 h-[calc(100vh-224px)]"
+                    : "w-5/12 h-[calc(100vh-64px)]"
                 }
                 style={{
                   padding: `${parseInt(config.theme?.properties?.gridSpacing ?? "16")}px`,

--- a/src/app/(spaces)/SpaceLoading.tsx
+++ b/src/app/(spaces)/SpaceLoading.tsx
@@ -6,7 +6,7 @@ import useWindowSize from "@/common/lib/hooks/useWindowSize";
 export default function SpaceLoading({ hasProfile, hasFeed }) {
   const { height } = useWindowSize();
   const maxRows = hasProfile ? 8 : 12;
-  const cols = hasFeed ? 6 : 12;
+  const cols = hasFeed ? 7 : 12;
   const margin = [16, 16];
   const containerPadding = [16, 16];
   const magicBase = hasProfile ? 64 + 160 : 64;

--- a/src/common/lib/utils/gridCleanup.ts
+++ b/src/common/lib/utils/gridCleanup.ts
@@ -7,7 +7,7 @@ export function cleanupLayout(
   hasProfile: boolean,
   hasFeed: boolean
 ): { cleanedLayout: PlacedGridItem[]; removedFidgetIds: string[] } {
-  const cols = hasFeed ? 6 : 12;
+  const cols = hasFeed ? 7 : 12;
   const maxRows = hasProfile ? 8 : 10;
   const cleanedLayout: typeof layout = [];
   const removedFidgetIds: string[] = [];

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -80,7 +80,7 @@ const makeGridDetails = (
   compactType: null,
   // This turns off rearrangement so items will not be pushed arround.
   preventCollision: true,
-  cols: hasFeed ? 6 : 12,
+  cols: hasFeed ? 7 : 12,
   maxRows: hasProfile ? 8 : 10,
   rowHeight: 70,
   layout: [],


### PR DESCRIPTION
## Summary
- update homebase feed width to use 5 grid columns
- expand grid layout to 7 columns when feed is present

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_685fc64813448325b1df6c4661a7e698