### PR TITLE
Improve space tab deletion

### DIFF
--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -343,8 +343,11 @@ export const createSpaceStoreFunc = (
       draft.space.localSpaces[spaceId].updatedAt = newSpaceTimestamp;
     }, "saveLocalSpaceTab");
   },
-  deleteSpaceTab: debounce(
-    async (spaceId, tabName, network?: EtherScanChainName) => {
+  deleteSpaceTab: async (
+    spaceId,
+    tabName,
+    network?: EtherScanChainName,
+  ) => {
       // This deletes locally and remotely at the same time
       // We can separate these out, but I think deleting feels better as a single decisive action
       const unsignedDeleteTabRequest: UnsignedDeleteSpaceTabRequest = {
@@ -388,8 +391,6 @@ export const createSpaceStoreFunc = (
         console.error(e);
       }
     },
-    1000,
-  ),
   createSpaceTab: async (
     spaceId: string,
     tabName: string,


### PR DESCRIPTION
## Summary
- fix deletion so it runs immediately instead of debounced

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_6862197267d883258be9d6457cd9dd23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the responsiveness of tab deletion actions; deleting a tab now happens immediately without delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->