### PR TITLE
Fix duplicate feed settings portal

### DIFF
--- a/src/app/(spaces)/homebase/PrivateSpace.tsx
+++ b/src/app/(spaces)/homebase/PrivateSpace.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useEffect, useMemo, lazy } from "react";
-import { createPortal } from "react-dom";
 import { useAppStore } from "@/common/data/stores/app";
 import SpacePage, { SpacePageArgs } from "@/app/(spaces)/SpacePage";
 import FeedModule, { FilterType } from "@/fidgets/farcaster/Feed";
@@ -306,8 +305,8 @@ function PrivateSpaceInner({ tabName, castHash }: { tabName: string; castHash?: 
   // Render the SpacePage component with the defined arguments
   return (
     <>
-      {editMode && portalRef.current &&
-        createPortal(currentFidgetSettings, portalRef.current)}
+      {/* The EditorPanel already handles rendering the current fidget settings */}
+      {/* Removing duplicate portal to avoid redundant settings section */}
       <SpacePage key={tabName} {...args} />
     </>
   );


### PR DESCRIPTION
## Summary
- remove unused `createPortal` import
- avoid rendering feed settings twice by deleting the extra portal

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68636ecd27148325a0d42a72c21dee6c