### PR TITLE
Remove move/stash options for homebase feed

### DIFF
--- a/src/app/(spaces)/homebase/PrivateSpace.tsx
+++ b/src/app/(spaces)/homebase/PrivateSpace.tsx
@@ -287,7 +287,8 @@ function PrivateSpaceInner({ tabName, castHash }: { tabName: string; castHash?: 
         removeFidget={() => {}}
         minimizeFidget={() => {}}
         allowDelete={false}
-        allowMoveAndStash={false}
+        allowMove={false}
+        allowStash={false}
       />
     ) : undefined,
   }), [

--- a/src/app/(spaces)/homebase/PrivateSpace.tsx
+++ b/src/app/(spaces)/homebase/PrivateSpace.tsx
@@ -287,6 +287,7 @@ function PrivateSpaceInner({ tabName, castHash }: { tabName: string; castHash?: 
         removeFidget={() => {}}
         minimizeFidget={() => {}}
         allowDelete={false}
+        allowMoveAndStash={false}
       />
     ) : undefined,
   }), [

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -40,7 +40,8 @@ export type FidgetWrapperProps<
   removeFidget: (fidgetId: string) => void;
   minimizeFidget: (fidgetId: string) => void;
   allowDelete?: boolean;
-  allowMoveAndStash?: boolean;
+  allowMove?: boolean;
+  allowStash?: boolean;
 };
 
 export const getSettingsWithDefaults = <
@@ -77,7 +78,8 @@ export function FidgetWrapper<
   removeFidget,
   minimizeFidget,
   allowDelete = true,
-  allowMoveAndStash = true,
+  allowMove = true,
+  allowStash = true,
 }: FidgetWrapperProps<S, D>) {
   const { homebaseConfig } = useAppStore((state) => ({
     homebaseConfig: state.homebase.homebaseConfig,
@@ -190,39 +192,41 @@ export function FidgetWrapper<
           zIndex: 999999,
         }}
       >
-        {allowMoveAndStash && (
-          <>
-            <Card className="h-full grabbable rounded-lg w-6 flex items-center justify-center bg-[#F3F4F6] hover:bg-sky-100 text-[#1C64F2]">
+        {allowMove && (
+          <Card className="h-full grabbable rounded-lg w-6 flex items-center justify-center bg-[#F3F4F6] hover:bg-sky-100 text-[#1C64F2]">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="flex items-center gap-1">
+                    <GrabHandleIcon />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>Drag to Move</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </Card>
+        )}
+        {allowStash && (
+          <button
+            onClick={() => {
+              minimizeFidget(bundle.id);
+            }}
+          >
+            <Card
+              className={`h-full rounded-lg ${allowMove ? "ml-1" : ""} w-6 flex items-center justify-center bg-[#F3F4F6] hover:bg-sky-100 text-[#1C64F2]`}
+            >
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <div className="flex items-center gap-1">
-                      <GrabHandleIcon />
+                      <StashIcon />
                     </div>
                   </TooltipTrigger>
-                  <TooltipContent>Drag to Move</TooltipContent>
+                  <TooltipContent>Stash in Fidget Tray</TooltipContent>
                 </Tooltip>
               </TooltipProvider>
             </Card>
-            <button
-              onClick={() => {
-                minimizeFidget(bundle.id);
-              }}
-            >
-              <Card className="h-full rounded-lg ml-1 w-6 flex items-center justify-center bg-[#F3F4F6] hover:bg-sky-100 text-[#1C64F2]">
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div className="flex items-center gap-1">
-                        <StashIcon />
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent>Stash in Fidget Tray</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              </Card>
-            </button>
-          </>
+          </button>
         )}
         {allowDelete && (
           <button

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -40,6 +40,7 @@ export type FidgetWrapperProps<
   removeFidget: (fidgetId: string) => void;
   minimizeFidget: (fidgetId: string) => void;
   allowDelete?: boolean;
+  allowMoveAndStash?: boolean;
 };
 
 export const getSettingsWithDefaults = <
@@ -76,6 +77,7 @@ export function FidgetWrapper<
   removeFidget,
   minimizeFidget,
   allowDelete = true,
+  allowMoveAndStash = true,
 }: FidgetWrapperProps<S, D>) {
   const { homebaseConfig } = useAppStore((state) => ({
     homebaseConfig: state.homebase.homebaseConfig,
@@ -188,36 +190,40 @@ export function FidgetWrapper<
           zIndex: 999999,
         }}
       >
-        <Card className="h-full grabbable rounded-lg w-6 flex items-center justify-center bg-[#F3F4F6] hover:bg-sky-100 text-[#1C64F2]">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div className="flex items-center gap-1">
-                  <GrabHandleIcon />
-                </div>
-              </TooltipTrigger>
-              <TooltipContent>Drag to Move</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </Card>
-        <button
-          onClick={() => {
-            minimizeFidget(bundle.id);
-          }}
-        >
-          <Card className="h-full rounded-lg ml-1 w-6 flex items-center justify-center bg-[#F3F4F6] hover:bg-sky-100 text-[#1C64F2]">
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex items-center gap-1">
-                    <StashIcon />
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>Stash in Fidget Tray</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </Card>
-        </button>
+        {allowMoveAndStash && (
+          <>
+            <Card className="h-full grabbable rounded-lg w-6 flex items-center justify-center bg-[#F3F4F6] hover:bg-sky-100 text-[#1C64F2]">
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="flex items-center gap-1">
+                      <GrabHandleIcon />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>Drag to Move</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </Card>
+            <button
+              onClick={() => {
+                minimizeFidget(bundle.id);
+              }}
+            >
+              <Card className="h-full rounded-lg ml-1 w-6 flex items-center justify-center bg-[#F3F4F6] hover:bg-sky-100 text-[#1C64F2]">
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="flex items-center gap-1">
+                        <StashIcon />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>Stash in Fidget Tray</TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </Card>
+            </button>
+          </>
+        )}
         {allowDelete && (
           <button
             onClick={() => {


### PR DESCRIPTION
## Summary
- update `FidgetWrapper` to optionally disable move/stash buttons
- hide move/stash icons for the immutable homebase feed

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6863756f317c832592c7d4550d9b1e70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to optionally hide the "Move" and "Stash" controls for certain items in private spaces.
* **User Interface**
  * "Move" and "Stash" actions are now hidden in specific contexts to streamline the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->