### PR TITLE
Add default prettier configuration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+dist
+build
+coverage

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 120
+}


### PR DESCRIPTION
## Summary
- add `.prettierrc` with common formatting rules
- ignore build output in `.prettierignore`

## Testing
- `npm run lint --silent` *(fails: next not found)*
- `npm run check-types --silent` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_686376decd908325a5e71699f6ddb118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configuration files to standardize code formatting and specify files and folders to be ignored by the formatter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->