### PR TITLE
Load saved token space configs

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -109,16 +109,15 @@ export default function PublicSpace({
   });
 
   useEffect(() => {
-    const spaceId = getCurrentSpaceId();
-    const tabName = getCurrentTabName() ?? "Profile";
-    if (!spaceId || !initialConfig) return;
-    if (!localSpaces[spaceId]?.tabs?.[tabName]) {
-      void saveLocalSpaceTab(spaceId, tabName, {
+    if (!providedSpaceId || !initialConfig) return;
+    const tabName = providedTabName ?? "Profile";
+    if (!localSpaces[providedSpaceId]?.tabs?.[tabName]) {
+      void saveLocalSpaceTab(providedSpaceId, tabName, {
         ...initialConfig,
         isPrivate: false,
       });
     }
-  }, [initialConfig, getCurrentSpaceId, getCurrentTabName, localSpaces, saveLocalSpaceTab]);
+  }, [providedSpaceId, providedTabName, initialConfig, localSpaces, saveLocalSpaceTab]);
 
   const router = useRouter();
 

--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -108,6 +108,18 @@ export default function PublicSpace({
     pageType, // Log the page type
   });
 
+  useEffect(() => {
+    const spaceId = getCurrentSpaceId();
+    const tabName = getCurrentTabName() ?? "Profile";
+    if (!spaceId || !initialConfig) return;
+    if (!localSpaces[spaceId]?.tabs?.[tabName]) {
+      void saveLocalSpaceTab(spaceId, tabName, {
+        ...initialConfig,
+        isPrivate: false,
+      });
+    }
+  }, [initialConfig, getCurrentSpaceId, getCurrentTabName, localSpaces, saveLocalSpaceTab]);
+
   const router = useRouter();
 
   const initialLoading =

--- a/src/app/(spaces)/t/[network]/ContractDefinedSpace.tsx
+++ b/src/app/(spaces)/t/[network]/ContractDefinedSpace.tsx
@@ -5,6 +5,7 @@ import { OwnerType } from "@/common/data/api/etherscan"
 import dynamic from "next/dynamic"
 import { useEffect, useState } from "react"
 import { MobileContractDefinedSpace } from "./MobileSpace"
+import { SpaceConfig } from "@/app/(spaces)/Space"
 
 export interface ContractDefinedSpaceProps {
   spaceId: string | null
@@ -13,6 +14,7 @@ export interface ContractDefinedSpaceProps {
   pinnedCastId?: string
   ownerId: string | number | null
   ownerIdType: OwnerType
+  initialConfig?: Omit<SpaceConfig, "isEditable">
 }
 
 const ContractDefinedSpace = (props: ContractDefinedSpaceProps) => {

--- a/src/app/(spaces)/t/[network]/ContractPrimarySpaceContent.tsx
+++ b/src/app/(spaces)/t/[network]/ContractPrimarySpaceContent.tsx
@@ -7,6 +7,7 @@ import { useAppStore } from "@/common/data/stores/app";
 import { isArray, isNil } from "lodash";
 import { useEffect } from "react";
 import { ContractSpacePageProps } from "./[contractAddress]/page";
+import { SpaceConfig } from "@/app/(spaces)/Space";
 
 const ContractPrimarySpaceContent: React.FC<ContractSpacePageProps> = ({
   spaceId,
@@ -17,6 +18,7 @@ const ContractPrimarySpaceContent: React.FC<ContractSpacePageProps> = ({
   owningIdentities,
   network,
   tokenData,
+  initialConfig,
 }) => {
   console.log("ContractPrimarySpaceContent received props:", {
     spaceId,
@@ -91,6 +93,7 @@ const ContractPrimarySpaceContent: React.FC<ContractSpacePageProps> = ({
         spaceId={spaceId}
         tabName={isArray(tabName) ? tabName[0] : tabName ?? "Profile"}
         contractAddress={contractAddress}
+        initialConfig={initialConfig}
       />
     </>
   );

--- a/src/app/(spaces)/t/[network]/DesktopContractDefinedSpace.tsx
+++ b/src/app/(spaces)/t/[network]/DesktopContractDefinedSpace.tsx
@@ -17,6 +17,7 @@ export default function DesktopContractDefinedSpace({
   contractAddress,
   ownerId,
   ownerIdType,
+  initialConfig,
 }: ContractDefinedSpaceProps) {
   const { tokenData } = useToken();
   const { wallets } = useWallets();
@@ -31,6 +32,7 @@ export default function DesktopContractDefinedSpace({
 
   const INITIAL_SPACE_CONFIG = useMemo(
     () =>
+      initialConfig ??
       createInitialContractSpaceConfigForAddress(
         contractAddress,
         tokenData?.clankerData?.cast_hash || "",
@@ -39,7 +41,7 @@ export default function DesktopContractDefinedSpace({
         !!tokenData?.clankerData,
         tokenData?.network,
       ),
-    [contractAddress, tokenData, tokenData?.network],
+    [initialConfig, contractAddress, tokenData, tokenData?.network],
   );
 
   const getSpacePageUrl = (tabName: string) => 

--- a/src/app/(spaces)/t/[network]/MobileSpace.tsx
+++ b/src/app/(spaces)/t/[network]/MobileSpace.tsx
@@ -22,15 +22,18 @@ import { Address } from "viem";
 import { EtherScanChainName } from "@/constants/etherscanChainIds";
 import { useAppStore } from "@/common/data/stores/app";
 import createInitialContractSpaceConfigForAddress from "@/constants/initialContractSpace";
+import { SpaceConfig } from "@/app/(spaces)/Space";
 
 type Pages = "Price" | "Swaps" | "Chat" | "Links" | "Feed";
 
 export const MobileContractDefinedSpace = ({
   contractAddress,
   tabName: providedTabName,
+  initialConfig,
 }: {
   contractAddress: string;
   tabName: string;
+  initialConfig?: Omit<SpaceConfig, "isEditable">;
 }) => {
   const [tab, setTab] = useState<Pages>("Price");
   const [ref, inView] = useInView();
@@ -46,6 +49,7 @@ export const MobileContractDefinedSpace = ({
 
   const INITIAL_SPACE_CONFIG = useMemo(
     () =>
+      initialConfig ??
       createInitialContractSpaceConfigForAddress(
         contractAddress,
         tokenData?.clankerData?.cast_hash || "",
@@ -56,7 +60,7 @@ export const MobileContractDefinedSpace = ({
         !!tokenData?.clankerData,
         tokenData?.network,
       ),
-    [contractAddress, tokenData, tokenData?.network],
+    [initialConfig, contractAddress, tokenData, tokenData?.network],
   );
 
   const { getCurrentSpaceConfig } = useAppStore((state) => ({

--- a/src/app/(spaces)/t/[network]/[contractAddress]/[tabName]/page.tsx
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/[tabName]/page.tsx
@@ -9,6 +9,8 @@ import { fetchTokenData } from "@/common/lib/utils/fetchTokenData";
 import { fetchClankerByAddress } from "@/common/data/queries/clanker";
 import { EtherScanChainName } from "@/constants/etherscanChainIds";
 import ContractPrimarySpaceContent from "../../ContractPrimarySpaceContent";
+import { getSpaceTabConfig } from "../utils";
+import { SpaceConfig } from "@/app/(spaces)/Space";
 
 async function loadTokenData(
   contractAddress: Address,
@@ -41,6 +43,16 @@ export default async function WrappedContractPrimarySpace({ params }) {
   const network = params?.network as EtherScanChainName;
   const tokenData = await loadTokenData(contractAddress as Address, network);
 
+  let initialConfig: Omit<SpaceConfig, "isEditable"> | undefined = undefined;
+  const spaceId = contractData.props.spaceId;
+  const tabName = contractData.props.tabName ?? "Profile";
+  if (spaceId) {
+    const config = await getSpaceTabConfig(spaceId, tabName);
+    if (config) {
+      initialConfig = config;
+    }
+  }
+
   const props = {
     ...contractData.props,
     contractAddress,
@@ -54,7 +66,7 @@ export default async function WrappedContractPrimarySpace({ params }) {
       defaultTokenData={tokenData}
       network={network}
     >
-      <ContractPrimarySpaceContent {...props} />
+      <ContractPrimarySpaceContent {...props} initialConfig={initialConfig} />
     </TokenProvider>
   );
 }

--- a/src/app/(spaces)/t/[network]/[contractAddress]/page.tsx
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/page.tsx
@@ -5,6 +5,8 @@ import { MasterToken, TokenProvider } from "@/common/providers/TokenProvider";
 import { Address } from "viem";
 import { EtherScanChainName } from "@/constants/etherscanChainIds";
 import ContractPrimarySpaceContent from "../ContractPrimarySpaceContent";
+import { getSpaceTabConfig } from "./utils";
+import { SpaceConfig } from "@/app/(spaces)/Space";
 
 export interface ContractSpacePageProps {
   spaceId: string | null;
@@ -16,6 +18,7 @@ export interface ContractSpacePageProps {
   ownerId: string | null;
   tokenData?: MasterToken;
   network: EtherScanChainName;
+  initialConfig?: Omit<SpaceConfig, "isEditable">;
 }
 
 export default async function ContractPrimarySpace({ params }) {
@@ -30,6 +33,13 @@ export default async function ContractPrimarySpace({ params }) {
     },
   } = await loadContractData(params || {});
   const network = params?.network as EtherScanChainName;
+  let initialConfig: Omit<SpaceConfig, "isEditable"> | undefined = undefined;
+  if (spaceId) {
+    const config = await getSpaceTabConfig(spaceId, tabName ?? "Profile");
+    if (config) {
+      initialConfig = config;
+    }
+  }
 
   return (
     <TokenProvider
@@ -44,6 +54,7 @@ export default async function ContractPrimarySpace({ params }) {
         contractAddress={contractAddress}
         owningIdentities={owningIdentities}
         network={network}
+        initialConfig={initialConfig}
       />
     </TokenProvider>
   );

--- a/src/app/(spaces)/t/[network]/[contractAddress]/utils.ts
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/utils.ts
@@ -1,0 +1,30 @@
+import createSupabaseServerClient from "@/common/data/database/supabase/clients/server";
+import { SignedFile } from "@/common/lib/signedFiles";
+import { SpaceConfig } from "@/app/(spaces)/Space";
+import { unstable_noStore as noStore } from 'next/cache';
+
+export async function getSpaceTabConfig(
+  spaceId: string,
+  tabName: string,
+): Promise<Omit<SpaceConfig, "isEditable"> | null> {
+  noStore();
+  try {
+    const { data, error } = await createSupabaseServerClient()
+      .storage
+      .from("spaces")
+      .download(`${spaceId}/tabs/${tabName}`);
+    if (error || !data) {
+      console.warn(`No space config found for ${spaceId}/${tabName}:`, error);
+      return null;
+    }
+    const fileText = await data.text();
+    const fileData = JSON.parse(fileText) as SignedFile;
+    const config = JSON.parse(
+      fileData.fileData,
+    ) as Omit<SpaceConfig, "isEditable">;
+    return config;
+  } catch (e) {
+    console.error("Error loading space tab config", e);
+    return null;
+  }
+}

--- a/src/app/(spaces)/t/[network]/[contractAddress]/utils.ts
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/utils.ts
@@ -2,6 +2,7 @@ import createSupabaseServerClient from "@/common/data/database/supabase/clients/
 import { SignedFile, isSignedFile } from "@/common/lib/signedFiles";
 import { SpaceConfig } from "@/app/(spaces)/Space";
 import { unstable_noStore as noStore } from "next/cache";
+import axios from "axios";
 
 export async function getSpaceTabConfig(
   spaceId: string,
@@ -9,15 +10,22 @@ export async function getSpaceTabConfig(
 ): Promise<Omit<SpaceConfig, "isEditable"> | null> {
   noStore();
   try {
-    const { data, error } = await createSupabaseServerClient()
-      .storage
+    const supabase = createSupabaseServerClient();
+    const {
+      data: { publicUrl },
+    } = await supabase.storage
       .from("spaces")
-      .download(`${spaceId}/tabs/${tabName}`);
+      .getPublicUrl(`${spaceId}/tabs/${tabName}`);
 
-    if (error || !data) {
-      console.warn(`No space config found for ${spaceId}/${tabName}:`, error);
+    if (!publicUrl) {
+      console.warn(`No space config found for ${spaceId}/${tabName}`);
       return null;
     }
+
+    const t = Math.random().toString(36).substring(2);
+    const urlWithParam = `${publicUrl}?t=${t}`;
+
+    const { data } = await axios.get<Blob>(urlWithParam, { responseType: "blob" });
 
     const fileText = await data.text();
     let parsed: unknown;

--- a/src/app/(spaces)/t/[network]/[contractAddress]/utils.ts
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/utils.ts
@@ -1,8 +1,7 @@
-import createSupabaseServerClient from "@/common/data/database/supabase/clients/server";
+import { createSupabaseServerClient } from "@/common/data/database/supabase/clients/server";
 import { SignedFile, isSignedFile } from "@/common/lib/signedFiles";
 import { SpaceConfig } from "@/app/(spaces)/Space";
 import { unstable_noStore as noStore } from "next/cache";
-import axios from "axios";
 
 export async function getSpaceTabConfig(
   spaceId: string,
@@ -11,45 +10,34 @@ export async function getSpaceTabConfig(
   noStore();
   try {
     const supabase = createSupabaseServerClient();
-    const {
-      data: { publicUrl },
-    } = await supabase.storage
+    const { data, error } = await supabase.storage
       .from("spaces")
-      .getPublicUrl(`${spaceId}/tabs/${tabName}`);
+      .download(`${spaceId}/tabs/${tabName}`);
 
-    if (!publicUrl) {
-      console.warn(`No space config found for ${spaceId}/${tabName}`);
+    if (error || !data) {
+      console.warn(
+        `Failed to download config for ${spaceId}/${tabName}: ${error?.message}`,
+      );
       return null;
     }
-
-    const t = Math.random().toString(36).substring(2);
-    const urlWithParam = `${publicUrl}?t=${t}`;
-
-    const { data } = await axios.get<Blob>(urlWithParam, { responseType: "blob" });
 
     const fileText = await data.text();
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(fileText);
-    } catch (e) {
-      console.error("Error parsing signed file text", e);
-      return null;
-    }
+    const parsed = JSON.parse(fileText);
 
     if (!isSignedFile(parsed)) {
       console.warn(`Invalid signed file format for ${spaceId}/${tabName}`);
       return null;
     }
 
-    let config: unknown;
     try {
-      config = JSON.parse((parsed as SignedFile).fileData);
+      return JSON.parse((parsed as SignedFile).fileData) as Omit<
+        SpaceConfig,
+        "isEditable"
+      >;
     } catch (e) {
       console.error("Error parsing space config", e);
       return null;
     }
-
-    return config as Omit<SpaceConfig, "isEditable">;
   } catch (e) {
     console.error("Error loading space tab config", e);
     return null;


### PR DESCRIPTION
## Summary
- support server-side fetching of token space configs
- add prop plumbing for initial configs on token pages
- handle mobile/desktop token pages with custom config

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run check-types` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6864ae13c32883258ff63d38289062a3