### PR TITLE
Fix z-index issues for popover and modal

### DIFF
--- a/src/common/components/atoms/popover.tsx
+++ b/src/common/components/atoms/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={mergeClasses(
-        "z-level-4 w-72 rounded-xl border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-infinity w-72 rounded-xl border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/src/common/components/molecules/Modal.tsx
+++ b/src/common/components/molecules/Modal.tsx
@@ -30,14 +30,14 @@ const Modal = ({
   <Dialog.Root open={open} onOpenChange={setOpen}>
     <Dialog.Portal>
       {overlay && open && (
-        <Dialog.Overlay className="bg-muted/95 data-[state=open]:animate-overlayShow fixed inset-0 z-level-4" />
+        <Dialog.Overlay className="bg-muted/95 data-[state=open]:animate-overlayShow fixed inset-0 z-infinity" />
       )}
       <Dialog.Content
         className={mergeClasses(
           "data-[state=open]:animate-contentShow fixed bg-background top-[40%]",
           "left-[50%] w-[100vw] max-w-[600px] translate-x-[-50%] translate-y-[-40%] rounded-[10px] p-[25px]",
           "shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none",
-          "z-level-5",
+          "z-infinity",
         )}
         onMouseDown={(e) => e.stopPropagation()} // Fixes issue causing grid items to remain draggable behind open modal
       >


### PR DESCRIPTION
## Summary
- ensure popover uses highest z-index so color picker overlays the editor panel
- raise modal z-index so it appears over fidgets

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_686523fdcba88325aaa65b123989b854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the stacking order of popovers and modals to ensure they appear above all other elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->