### PR TITLE
Fix Add Fidget button placement on public profiles

### DIFF
--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -593,7 +593,10 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
 
       <div className="flex flex-col z-10">
         {inEditMode && (
-          <div className="flex gap-2 absolute top-0 right-0 m-3">
+          <div
+            className="flex gap-2 absolute right-0 m-3"
+            style={{ top: hasProfile ? "160px" : 0 }}
+          >
             <button
               onClick={openFidgetPicker}
               className={


### PR DESCRIPTION
## Summary
- adjust Add Fidget button offset when profile fidget is present

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: missing `@types` packages)*

------
https://chatgpt.com/codex/tasks/task_e_68652888f2208325830f832f251b122e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the vertical positioning of the "Fidget" button in edit mode, so its placement now adapts dynamically based on profile presence for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->