### PR TITLE
Fix scrolling in Text fidget

### DIFF
--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -184,8 +184,8 @@ export function FidgetWrapper({
       <Card
         className={
           selectedFidgetID === bundle.id
-            ? "size-full border-solid border-sky-600 border-4 overflow-hidden"
-            : "size-full overflow-hidden"
+            ? "size-full border-solid border-sky-600 border-4"
+            : "size-full"
         }
         style={{
           background: settingsWithDefaults.useDefaultColors 
@@ -201,7 +201,6 @@ export function FidgetWrapper({
             ? homebaseConfig?.theme?.properties.fidgetShadow
             : settingsWithDefaults.fidgetShadow,
           borderRadius: borderRadius ?? homebaseConfig?.theme?.properties.fidgetBorderRadius ?? "12px",
-          overflow: "hidden"
         }}
       >
         {bundle.config.editable && (

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -211,7 +211,7 @@ export function FidgetWrapper({
           ></button>
         )}
         <ScopedStyles cssStyles={userStyles} className="size-full">
-          <CardContent className="size-full p-0" style={{ overflow: "hidden" }}>
+          <CardContent className="size-full p-0">
             <Fidget
               {...{
                 settings: settingsWithDefaults,

--- a/src/common/fidgets/FidgetWrapper.tsx
+++ b/src/common/fidgets/FidgetWrapper.tsx
@@ -184,8 +184,8 @@ export function FidgetWrapper({
       <Card
         className={
           selectedFidgetID === bundle.id
-            ? "size-full border-solid border-sky-600 border-4"
-            : "size-full"
+            ? "size-full border-solid border-sky-600 border-4 overflow-hidden"
+            : "size-full overflow-hidden"
         }
         style={{
           background: settingsWithDefaults.useDefaultColors 

--- a/src/fidgets/ui/Text.tsx
+++ b/src/fidgets/ui/Text.tsx
@@ -171,8 +171,7 @@ export const Text: React.FC<FidgetArgs<TextFidgetSettings>> = ({
   const urlColor = settings.urlColor || "var(--user-theme-link-color)";
 
   return (
-    <div
-    >
+    <div className="flex flex-col h-full">
       {settings?.title && (
         <CardHeader className="p-4 pb-2">
           <CardTitle
@@ -187,7 +186,7 @@ export const Text: React.FC<FidgetArgs<TextFidgetSettings>> = ({
         </CardHeader>
       )}
       {settings?.text && (
-        <CardContent className="p-4 pt-2 overflow-y-auto">
+        <CardContent className="p-4 pt-2 overflow-y-auto flex-grow">
           <CardDescription
             className="text-base font-normal text-black dark:text-white"
             style={{

--- a/src/fidgets/ui/Text.tsx
+++ b/src/fidgets/ui/Text.tsx
@@ -187,7 +187,7 @@ export const Text: React.FC<FidgetArgs<TextFidgetSettings>> = ({
         </CardHeader>
       )}
       {settings?.text && (
-        <CardContent className="p-4 pt-2">
+        <CardContent className="p-4 pt-2 overflow-y-auto">
           <CardDescription
             className="text-base font-normal text-black dark:text-white"
             style={{


### PR DESCRIPTION
## Summary
- allow fidgets to manage overflow in FidgetWrapper
- enable vertical scroll in Text fidget

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68655f8b1bb88325b37ea23bdd2e3490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved layout and scrolling behavior for card and text components by adjusting overflow handling and flex properties.
  * Updated visual presentation to better support content that exceeds available space, enabling vertical scrolling where necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->