### PR TITLE
Fix tab alignment in token space

### DIFF
--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -202,7 +202,7 @@ function TabBar({
     <TooltipProvider>
       <div className="flex flex-col md:flex-row justify-start md:h-16 z-30 bg-white w-full"> 
         {isTokenPage && contractAddress && (
-          <div className="flex flex-row justify-start h-16 overflow-y-scroll w-full z-20 bg-white"> 
+          <div className="flex flex-row justify-start h-16 overflow-y-scroll w-auto z-20 bg-white">
             <TokenDataHeader />
           </div>
         )}
@@ -236,7 +236,7 @@ function TabBar({
                 as="ol"
                 axis="x"
                 onReorder={updateTabOrder}
-                className="flex flex-row gap-5 md:gap-4 items-start m-4 tabs"
+                className="flex flex-row gap-5 md:gap-4 items-start ml-2 mr-4 my-4 tabs"
                 values={tabList}
                 style={{
                   maxWidth: isMobile ? 'calc(100% - 60px)' : '100%',


### PR DESCRIPTION
## Summary
- make token header container auto width so it doesn't push tabs
- give tab list a small left margin for spacing

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6866264d68c48325aeaea79491c99d1f