### PR TITLE
Optimize fidget re-render behavior

### DIFF
--- a/src/fidgets/community/nouns-dao/NounishGovernance.tsx
+++ b/src/fidgets/community/nouns-dao/NounishGovernance.tsx
@@ -99,11 +99,7 @@ export const NounishGovernance: React.FC<
   FidgetArgs<NounishGovernanceSettings>
 > = ({ settings }) => {
   const [proposalId, setProposalId] = useState<string | null>(null);
-  const [selectedDao, setSelectedDao] = useState(settings.selectedDao);
-
-  useEffect(() => {
-    setSelectedDao(settings.selectedDao);
-  }, [settings.selectedDao]);
+  const selectedDao = settings.selectedDao;
 
   const isBuilderSubgraph = useMemo(
     () => selectedDao?.graphUrl.includes("nouns-builder-base-mainnet") || false,

--- a/src/fidgets/farcaster/components/channelPicker.tsx
+++ b/src/fidgets/farcaster/components/channelPicker.tsx
@@ -26,6 +26,12 @@ type Props = {
 
 export function ChannelPicker(props: Props) {
   const { getChannels, onSelect, value } = props;
+  // Store the latest getChannels callback in a ref so the effect
+  // doesn't re-run when the function identity changes
+  const getChannelsRef = React.useRef(props.getChannels);
+  React.useEffect(() => {
+    getChannelsRef.current = props.getChannels;
+  }, [props.getChannels]);
   const [open, setOpen] = React.useState(false);
   const [channelResults, setChannelResults] = React.useState<Channel[]>(
     props.initialChannels ?? [],
@@ -34,7 +40,7 @@ export function ChannelPicker(props: Props) {
 
   React.useEffect(() => {
     async function fetchChannels() {
-      const channels = await getChannels(query);
+      const channels = await getChannelsRef.current(query);
       setChannelResults(channels);
     }
 
@@ -43,7 +49,7 @@ export function ChannelPicker(props: Props) {
     } else {
       setChannelResults(props.initialChannels ?? []);
     }
-  }, [getChannels, query, props.initialChannels]);
+  }, [query, props.initialChannels]);
 
   const handleSelect = React.useCallback(
     (channel: Channel) => {

--- a/src/fidgets/layout/tabFullScreen/index.tsx
+++ b/src/fidgets/layout/tabFullScreen/index.tsx
@@ -95,12 +95,14 @@ const MobileStack: LayoutFidget<TabFullScreenProps> = ({
   useEffect(() => {
     // If there are no fidget IDs, do nothing
     if (orderedFidgetIds.length === 0) return;
-    
+
     // If current selection is invalid, select the first one
     if (!orderedFidgetIds.includes(selectedTab)) {
       setSelectedTab(orderedFidgetIds[0]);
     }
-  }, [orderedFidgetIds, selectedTab]);
+    // We only care about changes to the ordered list of IDs.
+    // selectedTab is intentionally omitted to avoid an extra render.
+  }, [orderedFidgetIds]);
   
   // Configuration saving function
   const saveFidgetConfig = (id: string) => (newConfig: FidgetConfig): Promise<void> => {

--- a/src/fidgets/ui/gallery.tsx
+++ b/src/fidgets/ui/gallery.tsx
@@ -255,6 +255,8 @@ const Gallery: React.FC<FidgetArgs<GalleryFidgetSettings>> = ({ settings }) => {
     }
   }, [settings.selectMediaSource?.name]);
 
+  const mediaSourceName = settings.selectMediaSource?.name;
+
   useEffect(() => {
     if (settings.selectMediaSource?.name === MediaSourceTypes.EXTERNAL) {
       const fetchNFTData = async () => {
@@ -305,7 +307,7 @@ const Gallery: React.FC<FidgetArgs<GalleryFidgetSettings>> = ({ settings }) => {
       setError("Please select a media source.");
     }
   }, [
-    settings.selectMediaSource,
+    mediaSourceName,
     settings.nftAddress,
     settings.nftTokenId,
     settings.network,

--- a/src/fidgets/ui/gallery.tsx
+++ b/src/fidgets/ui/gallery.tsx
@@ -308,6 +308,8 @@ const Gallery: React.FC<FidgetArgs<GalleryFidgetSettings>> = ({ settings }) => {
     }
   }, [
     mediaSourceName,
+    settings.imageUrl,
+    settings.nftSelector?.imageUrl,
     settings.nftAddress,
     settings.nftTokenId,
     settings.network,


### PR DESCRIPTION
## Summary
- avoid extra tab syncing rerenders in TabFullScreen
- narrow Gallery effect dependencies to media source name
- keep ChannelPicker effect stable with a ref
- remove redundant state in NounishGovernance

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: missing type definition files)*

------
https://chatgpt.com/codex/tasks/task_e_686757dec70c8325af55262368362dbb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance and simplified internal logic in several components by refining state and effect dependencies. This reduces unnecessary re-renders and streamlines component updates.

* **Style**
  * Added clarifying comments to improve code readability for future maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->