### PR TITLE
Improve push notification handling

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,12 @@ self.addEventListener('push', function (event) {
       vibrate: [100, 50, 100],
       data: {
         dateOfArrival: Date.now(),
-        primaryKey: '2',
+        primaryKey:
+          typeof data.id === 'string'
+            ? data.id
+            : self.crypto && 'randomUUID' in self.crypto
+              ? self.crypto.randomUUID()
+              : Date.now().toString(),
       },
     }
     event.waitUntil(self.registration.showNotification(data.title, options))

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -9,7 +9,7 @@ if (!NEXT_PUBLIC_VAPID_PUBLIC_KEY || !VAPID_PRIVATE_KEY) {
 }
 
 webpush.setVapidDetails(
-  'mailto:privacy@nounspace.com',
+  'mailto:willy@nounspace.com',
   NEXT_PUBLIC_VAPID_PUBLIC_KEY,
   VAPID_PRIVATE_KEY
 )

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -2,27 +2,71 @@
 
 import webpush from 'web-push'
 
+const { NEXT_PUBLIC_VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY } = process.env
+
+if (!NEXT_PUBLIC_VAPID_PUBLIC_KEY || !VAPID_PRIVATE_KEY) {
+  throw new Error('VAPID keys are missing')
+}
+
 webpush.setVapidDetails(
-  'mailto:your-email@example.com',
-  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!,
-  process.env.VAPID_PRIVATE_KEY!
+  'mailto:privacy@nounspace.com',
+  NEXT_PUBLIC_VAPID_PUBLIC_KEY,
+  VAPID_PRIVATE_KEY
 )
 
-let subscription: PushSubscription | null = null
+const subscriptions = new Map<string, PushSubscription>()
 
-export async function subscribeUser(sub: PushSubscription) {
-  subscription = sub
+async function saveSubscriptionToDB(
+  userId: string,
+  sub: PushSubscription
+): Promise<void> {
+  // TODO: Persist the subscription to a database
+  return Promise.resolve()
+}
+
+async function removeSubscriptionFromDB(userId: string): Promise<void> {
+  // TODO: Remove the subscription from the database
+  return Promise.resolve()
+}
+
+function isValidSubscription(sub: unknown): sub is PushSubscription {
+  return (
+    typeof sub === 'object' &&
+    sub !== null &&
+    typeof (sub as PushSubscription).endpoint === 'string'
+  )
+}
+
+export async function subscribeUser(userId: string, sub: unknown) {
+  if (!isValidSubscription(sub)) {
+    return { success: false, error: 'Invalid subscription' }
+  }
+
+  const url = new URL(sub.endpoint)
+  if (url.protocol !== 'https:') {
+    return { success: false, error: 'Invalid subscription endpoint' }
+  }
+
+  subscriptions.set(userId, sub)
+  await saveSubscriptionToDB(userId, sub)
   return { success: true }
 }
 
-export async function unsubscribeUser() {
-  subscription = null
+export async function unsubscribeUser(userId: string) {
+  subscriptions.delete(userId)
+  await removeSubscriptionFromDB(userId)
   return { success: true }
 }
 
-export async function sendNotification(message: string) {
+export async function sendNotification(userId: string, message: string) {
+  const subscription = subscriptions.get(userId)
   if (!subscription) {
     throw new Error('No subscription available')
+  }
+
+  const url = new URL(subscription.endpoint)
+  if (url.protocol !== 'https:') {
+    throw new Error('Invalid subscription endpoint')
   }
 
   try {


### PR DESCRIPTION
## Summary
- generate unique IDs in the service worker
- validate env vars and manage subscriptions per user
- sanitize subscription endpoints before using web-push
- handle errors during service worker registration and push subscription
- persist a userId in localStorage so multiple subscriptions can exist

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run check-types` *(fails: cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_686ebed567908325ba35ebd455e15748