### PR TITLE
Supabase fix pgsodium and gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ dist/
 
 # Visual Studio settings
 .vscode
+.env
+.env.development
+.env.development.local

--- a/src/common/data/database/supabase/clients/server.ts
+++ b/src/common/data/database/supabase/clients/server.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { Database } from '@/supabase/database';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL! || 'http://127.0.0.1:54321';
 const supabaseKey = process.env.SUPABASE_SERVICE_KEY!;
 
 export const createSupabaseServerClient = () => createClient<Database>(supabaseUrl, supabaseKey);

--- a/supabase/migrations/20240614000356_setup_db.sql
+++ b/supabase/migrations/20240614000356_setup_db.sql
@@ -12,7 +12,6 @@ SET row_security = off;
 
 CREATE EXTENSION IF NOT EXISTS "pg_net" WITH SCHEMA "extensions";
 
-CREATE EXTENSION IF NOT EXISTS "pgsodium" WITH SCHEMA "pgsodium";
 
 COMMENT ON SCHEMA "public" IS 'standard public schema';
 


### PR DESCRIPTION

### Configuration improvements:

* [`src/common/data/database/supabase/clients/server.ts`](diffhunk://#diff-2b84cc331706371ab106e5101a3c09931b246e0980ed65884e0e0193500ae56dL4-R4): Updated the `supabaseUrl` to fall back to `http://127.0.0.1:54321` if `NEXT_PUBLIC_SUPABASE_URL` is not defined, ensuring a default local development URL is available.

### Database migration adjustments:

* [`supabase/migrations/20240614000356_setup_db.sql`](diffhunk://#diff-5f082b4949cdb71956939e6918d5aa4835f3c88d6d2b582015ef72f9ff4eb6c1L15): Removed the creation of the `pgsodium` extension, which is no longer required in the database setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configuration to ignore additional `.env` files.
  * Improved server connection handling by providing a fallback for missing Supabase URLs.
  * Updated database setup by removing the creation of a specific extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->