### PR TITLE
Add basic channel features

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-
 import React from "react";
 import { useAuthenticatorManager } from "@/authenticators/AuthenticatorManager";
 import { useSidebarContext } from "@/common/components/organisms/Sidebar";
@@ -59,7 +58,6 @@ export default function PublicSpace({
   pageType, // New prop
   channelName,
 }: PublicSpaceProps) {
-
   const {
     clearLocalSpaces,
     getCurrentSpaceId,
@@ -106,17 +104,13 @@ export default function PublicSpace({
 
   const router = useRouter();
 
-  const initialLoading =
-    providedSpaceId !== null &&
-    providedSpaceId !== "" &&
-    !localSpaces[providedSpaceId];
+  const initialLoading = providedSpaceId !== null && providedSpaceId !== "" && !localSpaces[providedSpaceId];
 
   const [loading, setLoading] = useState<boolean>(initialLoading);
   const [currentUserFid, setCurrentUserFid] = useState<number | null>(null);
   const [isSignedIntoFarcaster, setIsSignedIntoFarcaster] = useState(false);
   const { wallets } = useWallets();
 
-  
   // Clear cache only when switching to a different space
   useEffect(() => {
     const currentSpaceId = getCurrentSpaceId();
@@ -145,21 +139,14 @@ export default function PublicSpace({
     });
 
     return checker;
-  }, [
-    currentUserFid,
-    spaceOwnerFid,
-    spaceOwnerAddress,
-    tokenData,
-    wallets,
-    isTokenPage,
-  ]);
+  }, [currentUserFid, spaceOwnerFid, spaceOwnerAddress, tokenData, wallets, isTokenPage]);
 
   // Internal isEditable function
   const isEditable = useCallback(
     (userFid: number) => {
       return editabilityCheck.isEditable;
     },
-    [editabilityCheck],
+    [editabilityCheck]
   );
 
   // Determine the page type if not explicitly provided
@@ -180,7 +167,7 @@ export default function PublicSpace({
     if (prevSpaceId.current !== providedSpaceId) {
       initialDataLoadRef.current = false;
     }
-    
+
     let nextSpaceId = providedSpaceId;
     let nextTabName = decodeURIComponent(providedTabName);
 
@@ -188,18 +175,14 @@ export default function PublicSpace({
 
     if (resolvedPageType === "token" && contractAddress && tokenData?.network) {
       const existingSpace = Object.values(localSpacesSnapshot).find(
-        (space) =>
-          space.contractAddress === contractAddress &&
-          space.network === tokenData.network,
+        (space) => space.contractAddress === contractAddress && space.network === tokenData.network
       );
       if (existingSpace) {
         nextSpaceId = existingSpace.id;
         nextTabName = decodeURIComponent(providedTabName);
       }
     } else if (resolvedPageType === "person" && spaceOwnerFid) {
-      const existingSpace = Object.values(localSpacesSnapshot).find(
-        (space) => space.fid === spaceOwnerFid,
-      );
+      const existingSpace = Object.values(localSpacesSnapshot).find((space) => space.fid === spaceOwnerFid);
       if (existingSpace) {
         nextSpaceId = existingSpace.id;
         nextTabName = decodeURIComponent(providedTabName);
@@ -229,20 +212,20 @@ export default function PublicSpace({
     async (spaceId: string) => {
       const currentTabName = getCurrentTabName() ?? "Profile";
       const tabOrder = localSpaces[spaceId]?.order || [];
-      
+
       // Initialize the set of loaded tabs for this space if it doesn't exist
       if (!loadedTabsRef.current[spaceId]) {
         loadedTabsRef.current[spaceId] = new Set();
       }
-      
+
       // Mark the current tab as loaded
       loadedTabsRef.current[spaceId].add(currentTabName);
-      
+
       // Load only tabs that haven't been loaded yet
       const tabsToLoad = tabOrder.filter(
         (tabName) => tabName !== currentTabName && !loadedTabsRef.current[spaceId].has(tabName)
       );
-      
+
       // Load the remaining tabs in parallel and mark them as loaded
       if (tabsToLoad.length > 0) {
         await Promise.all(
@@ -253,30 +236,28 @@ export default function PublicSpace({
         );
       }
     },
-    [localSpaces, getCurrentTabName, loadSpaceTab, currentUserFid],
+    [localSpaces, getCurrentTabName, loadSpaceTab, currentUserFid]
   );
 
   // Track if initial data load already happened
-  const initialDataLoadRef = useRef(
-    providedSpaceId !== null && !!localSpaces[providedSpaceId],
-  );
+  const initialDataLoadRef = useRef(providedSpaceId !== null && !!localSpaces[providedSpaceId]);
   const isLoadingRef = useRef(false);
   // Keeps track of which tabs have already been loaded for each space
   const loadedTabsRef = useRef<Record<string, Set<string>>>({});
-  
+
   // Loads and sets up the user's space tab when providedSpaceId or providedTabName changes
   useEffect(() => {
     const currentSpaceId = getCurrentSpaceId();
     const currentTabName = getCurrentTabName() ?? "Profile";
-    
-// Avoid repeated simultaneous loading or when reloading is not necessary
+
+    // Avoid repeated simultaneous loading or when reloading is not necessary
     if (isLoadingRef.current) {
       return;
     }
 
     if (!isNil(currentSpaceId)) {
       let loadPromise;
-      
+
       if (!initialDataLoadRef.current) {
         // First load - load everything from the database
         isLoadingRef.current = true;
@@ -299,7 +280,7 @@ export default function PublicSpace({
           setLoading(false);
           isLoadingRef.current = false;
           loadPromise = Promise.resolve();
-          
+
           // Ensure that the tab is registered as loaded
           if (!loadedTabsRef.current[currentSpaceId]) {
             loadedTabsRef.current[currentSpaceId] = new Set();
@@ -312,13 +293,13 @@ export default function PublicSpace({
           loadPromise = loadSpaceTab(currentSpaceId, currentTabName, currentUserFid || undefined);
         }
       }
-      
+
       loadPromise
         .then(() => {
           setLoading(false);
           isLoadingRef.current = false;
           initialDataLoadRef.current = true;
-          
+
           // Mark the current tab as loaded in our registry
           if (currentSpaceId) {
             if (!loadedTabsRef.current[currentSpaceId]) {
@@ -326,7 +307,7 @@ export default function PublicSpace({
             }
             loadedTabsRef.current[currentSpaceId].add(currentTabName);
           }
-          
+
           // Load remaining tabs in the background if necessary
           if (currentSpaceId && !initialDataLoadRef.current) {
             void loadRemainingTabs(currentSpaceId);
@@ -343,9 +324,7 @@ export default function PublicSpace({
   // Checks if the user is signed into Farcaster
   useEffect(() => {
     authManagerGetInitializedAuthenticators().then((authNames) => {
-      setIsSignedIntoFarcaster(
-        indexOf(authNames, FARCASTER_NOUNSPACE_AUTHENTICATOR_NAME) > -1,
-      );
+      setIsSignedIntoFarcaster(indexOf(authNames, FARCASTER_NOUNSPACE_AUTHENTICATOR_NAME) > -1);
     });
   }, [authManagerLastUpdatedAt]);
 
@@ -365,14 +344,14 @@ export default function PublicSpace({
   }, [isSignedIntoFarcaster, authManagerLastUpdatedAt]);
 
   const currentConfig = getCurrentSpaceConfig();
-  if (!currentConfig) {
-    console.error("Current space config is undefined");
-  }
 
+  // Fallback to initial config if no space configuration is available for the
+  // current tab. This avoids noisy console errors while still providing the
+  // default layout for tabs that haven't been configured yet (e.g. new channel
+  // spaces).
+  const baseConfig = currentConfig?.tabs[getCurrentTabName() ?? "Profile"];
   const config = {
-    ...(currentConfig?.tabs[getCurrentTabName() ?? "Profile"]
-      ? currentConfig.tabs[getCurrentTabName() ?? "Profile"]
-      : { ...initialConfig }),
+    ...(baseConfig ?? { ...initialConfig }),
     isEditable,
   };
 
@@ -383,7 +362,9 @@ export default function PublicSpace({
     }
     return config;
   }, [
-    Object.keys(config?.fidgetInstanceDatums || {}).sort().join(','),
+    Object.keys(config?.fidgetInstanceDatums || {})
+      .sort()
+      .join(","),
     config?.layoutID,
     config?.layoutDetails,
     config?.isEditable,
@@ -403,7 +384,6 @@ export default function PublicSpace({
       !loading &&
       !editabilityCheck.isLoading
     ) {
-
       const registerSpace = async () => {
         try {
           let newSpaceId: string | undefined;
@@ -411,9 +391,7 @@ export default function PublicSpace({
           // First check local spaces for existing space
           if (isTokenPage && contractAddress && tokenData?.network) {
             const existingSpace = Object.values(localSpaces).find(
-              (space) =>
-                space.contractAddress === contractAddress &&
-                space.network === tokenData.network,
+              (space) => space.contractAddress === contractAddress && space.network === tokenData.network
             );
 
             if (existingSpace) {
@@ -422,9 +400,7 @@ export default function PublicSpace({
               return;
             }
           } else if (!isTokenPage) {
-            const existingSpace = Object.values(localSpaces).find(
-              (space) => space.fid === currentUserFid,
-            );
+            const existingSpace = Object.values(localSpaces).find((space) => space.fid === currentUserFid);
 
             if (existingSpace) {
               setCurrentSpaceId(existingSpace.id);
@@ -439,14 +415,10 @@ export default function PublicSpace({
               "Profile",
               currentUserFid,
               initialConfig,
-              tokenData.network,
+              tokenData.network
             );
           } else if (!isTokenPage) {
-            newSpaceId = await registerSpaceFid(
-              currentUserFid,
-              "Profile",
-              getSpacePageUrl("Profile"),
-            );
+            newSpaceId = await registerSpaceFid(currentUserFid, "Profile", getSpacePageUrl("Profile"));
 
             const newUrl = getSpacePageUrl("Profile");
             router.replace(newUrl);
@@ -509,12 +481,12 @@ export default function PublicSpace({
         ...spaceConfig,
         fidgetInstanceDatums: spaceConfig.fidgetInstanceDatums
           ? mapValues(spaceConfig.fidgetInstanceDatums, (datum) => ({
-            ...datum,
-            config: {
-              settings: datum.config.settings,
-              editable: datum.config.editable,
-            },
-          }))
+              ...datum,
+              config: {
+                settings: datum.config.settings,
+                editable: datum.config.editable,
+              },
+            }))
           : undefined,
         isPrivate: false,
       };
@@ -536,7 +508,7 @@ export default function PublicSpace({
     const currentTabName = getCurrentTabName() ?? "Profile";
 
     if (isNil(currentSpaceId)) return;
-    
+
     let configToSave;
     if (isNil(remoteSpaces[currentSpaceId])) {
       configToSave = {
@@ -549,7 +521,7 @@ export default function PublicSpace({
         ...remoteConfig,
       };
     }
-    
+
     saveLocalSpaceTab(currentSpaceId, currentTabName, configToSave);
   }, [getCurrentSpaceId, initialConfig, remoteSpaces, getCurrentTabName]);
 
@@ -560,10 +532,10 @@ export default function PublicSpace({
 
     // Update the store immediately for better responsiveness
     setCurrentTabName(tabName);
-    
+
     // Check if we already have the tab in cache
     const tabExists = currentSpaceId && localSpaces[currentSpaceId]?.tabs?.[tabName];
-    
+
     if (currentSpaceId && !tabExists) {
       // Show skeleton when loading a tab from the database
       setLoading(true);
@@ -575,8 +547,9 @@ export default function PublicSpace({
       }
 
       // Load the tab showing the skeleton for better UX
-      loadSpaceTab(currentSpaceId, tabName, currentUserFid || undefined)
-        .catch(error => console.error(`Error loading tab ${tabName}:`, error));
+      loadSpaceTab(currentSpaceId, tabName, currentUserFid || undefined).catch((error) =>
+        console.error(`Error loading tab ${tabName}:`, error)
+      );
     } else if (currentSpaceId && tabExists) {
       // Tab already in cache - no need to show skeleton
       if (!loadedTabsRef.current[currentSpaceId]) {
@@ -603,67 +576,47 @@ export default function PublicSpace({
       pageType={pageType}
       inHomebase={false}
       currentTab={getCurrentTabName() ?? "Profile"}
-      tabList={
-        getCurrentSpaceId()
-          ? localSpaces[getCurrentSpaceId()!]?.order
-          : ["Profile"]
-      }
+      tabList={getCurrentSpaceId() ? localSpaces[getCurrentSpaceId()!]?.order : ["Profile"]}
       contractAddress={contractAddress as Address}
       switchTabTo={switchTabTo}
       updateTabOrder={async (newOrder) => {
         const currentSpaceId = getCurrentSpaceId();
-        return currentSpaceId
-          ? updateSpaceTabOrder(currentSpaceId, newOrder)
-          : undefined;
+        return currentSpaceId ? updateSpaceTabOrder(currentSpaceId, newOrder) : undefined;
       }}
       inEditMode={editMode}
       deleteTab={async (tabName) => {
         const currentSpaceId = getCurrentSpaceId();
         return currentSpaceId
-          ? deleteSpaceTab(
-            currentSpaceId,
-            tabName,
-            tokenData?.network as EtherScanChainName,
-          )
+          ? deleteSpaceTab(currentSpaceId, tabName, tokenData?.network as EtherScanChainName)
           : undefined;
       }}
       createTab={async (tabName) => {
         const currentSpaceId = getCurrentSpaceId();
         return currentSpaceId
           ? createSpaceTab(
-            currentSpaceId,
-            tabName,
-            INITIAL_SPACE_CONFIG_EMPTY,
-            tokenData?.network as EtherScanChainName,
-          )
+              currentSpaceId,
+              tabName,
+              INITIAL_SPACE_CONFIG_EMPTY,
+              tokenData?.network as EtherScanChainName
+            )
           : undefined;
       }}
       renameTab={async (oldName, newName) => {
         const currentSpaceId = getCurrentSpaceId();
         if (currentSpaceId) {
           const resolvedConfig = await config;
-          return saveLocalSpaceTab(
-            currentSpaceId,
-            oldName,
-            resolvedConfig,
-            newName,
-          );
+          return saveLocalSpaceTab(currentSpaceId, oldName, resolvedConfig, newName);
         }
         return undefined;
       }}
       commitTab={async (tabName) => {
         const currentSpaceId = getCurrentSpaceId();
-        return currentSpaceId
-          ? commitSpaceTab(currentSpaceId, tabName, tokenData?.network)
-          : undefined;
+        return currentSpaceId ? commitSpaceTab(currentSpaceId, tabName, tokenData?.network) : undefined;
       }}
       commitTabOrder={async () => {
         const currentSpaceId = getCurrentSpaceId();
         return currentSpaceId
-          ? commitSpaceTabOrder(
-            currentSpaceId,
-            tokenData?.network as EtherScanChainName,
-          )
+          ? commitSpaceTabOrder(currentSpaceId, tokenData?.network as EtherScanChainName)
           : undefined;
       }}
       getSpacePageUrl={getSpacePageUrl}
@@ -673,69 +626,54 @@ export default function PublicSpace({
 
   // @todo - Use correct page type for profile
   const profile =
-    pageType === "proposal" || isTokenPage
-      ? undefined
-      : channelName
-        ? (
-          <ChannelInfo.fidget
-            settings={{ channel: channelName }}
-            saveData={async () => noop()}
-            data={{}}
-          />
-        )
-        : spaceOwnerFid
-          ? (
-            <Profile.fidget
-              settings={{ fid: spaceOwnerFid }}
-              saveData={async () => noop()}
-              data={{}}
-            />
-          )
-          : undefined;
+    pageType === "proposal" || isTokenPage ? undefined : channelName ? (
+      <ChannelInfo.fidget settings={{ channel: channelName }} saveData={async () => noop()} data={{}} />
+    ) : spaceOwnerFid ? (
+      <Profile.fidget settings={{ fid: spaceOwnerFid }} saveData={async () => noop()} data={{}} />
+    ) : undefined;
 
   if (!profile) {
     console.warn("Profile component is undefined");
   }
 
-  const MemoizedSpacePage = useMemo(() => (
-    <SpacePage
-      config={memoizedConfig}
-      saveConfig={saveConfig}
-      commitConfig={commitConfig}
-      resetConfig={resetConfig}
-      tabBar={tabBar}
-      profile={profile ?? undefined}
-    />
-  ), [memoizedConfig, saveConfig, commitConfig, resetConfig, tabBar, profile]);
-  
+  const MemoizedSpacePage = useMemo(
+    () => (
+      <SpacePage
+        config={memoizedConfig}
+        saveConfig={saveConfig}
+        commitConfig={commitConfig}
+        resetConfig={resetConfig}
+        tabBar={tabBar}
+        profile={profile ?? undefined}
+      />
+    ),
+    [memoizedConfig, saveConfig, commitConfig, resetConfig, tabBar, profile]
+  );
+
   // Shows the skeleton only during initial space loading, not during tab switching
   const shouldShowSkeleton =
     loading &&
     // Show skeleton only when we haven't loaded initial data yet
     !initialDataLoadRef.current &&
     // Don't show skeleton for navigation between tabs
-    providedSpaceId !== null && providedSpaceId !== "" &&
+    providedSpaceId !== null &&
+    providedSpaceId !== "" &&
     // Avoid showing skeleton for tabs that have already been loaded
-    !(loadedTabsRef.current[getCurrentSpaceId() ?? ""] && 
-      loadedTabsRef.current[getCurrentSpaceId() ?? ""].has(getCurrentTabName() ?? "Profile"));
+    !(
+      loadedTabsRef.current[getCurrentSpaceId() ?? ""] &&
+      loadedTabsRef.current[getCurrentSpaceId() ?? ""].has(getCurrentTabName() ?? "Profile")
+    );
 
   if (shouldShowSkeleton) {
     return (
       <div className="user-theme-background w-full h-full relative flex-col">
         <div className="w-full transition-all duration-100 ease-out">
           <div className="flex flex-col h-full">
-            {profile ? (
-              <div className="z-50 bg-white md:h-40">{profile}</div>
-            ) : null}
+            {profile ? <div className="z-50 bg-white md:h-40">{profile}</div> : null}
             <TabBarSkeleton />
             <div className="flex h-full">
               <div className="grow">
-                <SpaceLoading
-                  hasProfile={
-                    !isTokenPage && !!spaceOwnerFid && pageType !== "proposal"
-                  }
-                  hasFeed={false}
-                />
+                <SpaceLoading hasProfile={!isTokenPage && !!spaceOwnerFid && pageType !== "proposal"} hasFeed={false} />
               </div>
             </div>
           </div>
@@ -743,6 +681,6 @@ export default function PublicSpace({
       </div>
     );
   }
-  
+
   return MemoizedSpacePage;
 }

--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -12,6 +12,7 @@ import { createEditabilityChecker } from "@/common/utils/spaceEditability";
 import { EtherScanChainName } from "@/constants/etherscanChainIds";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialPersonSpace";
 import Profile from "@/fidgets/ui/profile";
+import ChannelInfo from "@/fidgets/ui/Channel";
 import { useWallets } from "@privy-io/react-auth";
 import { indexOf, isNil, mapValues, noop } from "lodash";
 import { useRouter } from "next/navigation";
@@ -39,6 +40,8 @@ interface PublicSpaceProps {
   tokenData?: MasterToken;
   // New prop to identify page type
   pageType?: SpacePageType;
+  // Channel name for channel pages
+  channelName?: string;
 }
 
 export default function PublicSpace({
@@ -54,6 +57,7 @@ export default function PublicSpace({
   contractAddress,
   tokenData,
   pageType, // New prop
+  channelName,
 }: PublicSpaceProps) {
 
   const {
@@ -669,13 +673,25 @@ export default function PublicSpace({
 
   // @todo - Use correct page type for profile
   const profile =
-    isTokenPage || !spaceOwnerFid || pageType === "proposal" ? undefined : (
-      <Profile.fidget
-        settings={{ fid: spaceOwnerFid }}
-        saveData={async () => noop()}
-        data={{}}
-      />
-    );
+    pageType === "proposal" || isTokenPage
+      ? undefined
+      : channelName
+        ? (
+          <ChannelInfo.fidget
+            settings={{ channel: channelName }}
+            saveData={async () => noop()}
+            data={{}}
+          />
+        )
+        : spaceOwnerFid
+          ? (
+            <Profile.fidget
+              settings={{ fid: spaceOwnerFid }}
+              saveData={async () => noop()}
+              data={{}}
+            />
+          )
+          : undefined;
 
   if (!profile) {
     console.warn("Profile component is undefined");

--- a/src/app/(spaces)/channel/[channelName]/ChannelSpace.tsx
+++ b/src/app/(spaces)/channel/[channelName]/ChannelSpace.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import React from "react";
+import { isArray, isNil } from "lodash";
+import SpaceNotFound from "@/app/(spaces)/SpaceNotFound";
+import createInitialChannelSpaceConfigForName from "@/constants/initialChannelSpace";
+import PublicSpace from "../../PublicSpace";
+
+export interface ChannelSpaceProps {
+  spaceOwnerFid: number | null;
+  spaceId: string | null;
+  tabName: string | string[] | null | undefined;
+  channelName: string;
+}
+
+const ChannelSpace: React.FC<ChannelSpaceProps> = ({
+  spaceOwnerFid,
+  spaceId,
+  tabName,
+  channelName,
+}) => {
+  if (isNil(spaceOwnerFid)) {
+    return <SpaceNotFound />;
+  }
+
+  const INITIAL_CHANNEL_SPACE_CONFIG = createInitialChannelSpaceConfigForName(
+    channelName,
+  );
+
+  const getSpacePageUrl = (tab: string) => `/channel/${channelName}/${tab}`;
+
+  return (
+    <PublicSpace
+      spaceId={spaceId}
+      tabName={isArray(tabName) ? tabName[0] : tabName ?? "Profile"}
+      initialConfig={INITIAL_CHANNEL_SPACE_CONFIG}
+      getSpacePageUrl={getSpacePageUrl}
+      spaceOwnerFid={spaceOwnerFid}
+      pageType="profile"
+    />
+  );
+};
+
+export default ChannelSpace;

--- a/src/app/(spaces)/channel/[channelName]/ChannelSpace.tsx
+++ b/src/app/(spaces)/channel/[channelName]/ChannelSpace.tsx
@@ -32,6 +32,7 @@ const ChannelSpace: React.FC<ChannelSpaceProps> = ({
       initialConfig={INITIAL_CHANNEL_SPACE_CONFIG}
       getSpacePageUrl={getSpacePageUrl}
       spaceOwnerFid={spaceOwnerFid ?? undefined}
+      channelName={channelName}
       pageType="profile"
     />
   );

--- a/src/app/(spaces)/channel/[channelName]/ChannelSpace.tsx
+++ b/src/app/(spaces)/channel/[channelName]/ChannelSpace.tsx
@@ -31,7 +31,7 @@ const ChannelSpace: React.FC<ChannelSpaceProps> = ({
       tabName={isArray(tabName) ? tabName[0] : tabName ?? "Profile"}
       initialConfig={INITIAL_CHANNEL_SPACE_CONFIG}
       getSpacePageUrl={getSpacePageUrl}
-      spaceOwnerFid={spaceOwnerFid}
+      spaceOwnerFid={spaceOwnerFid ?? undefined}
       pageType="profile"
     />
   );

--- a/src/app/(spaces)/channel/[channelName]/ChannelSpace.tsx
+++ b/src/app/(spaces)/channel/[channelName]/ChannelSpace.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import React from "react";
-import { isArray, isNil } from "lodash";
-import SpaceNotFound from "@/app/(spaces)/SpaceNotFound";
+import { isArray } from "lodash";
 import createInitialChannelSpaceConfigForName from "@/constants/initialChannelSpace";
 import PublicSpace from "../../PublicSpace";
 
@@ -19,9 +18,6 @@ const ChannelSpace: React.FC<ChannelSpaceProps> = ({
   tabName,
   channelName,
 }) => {
-  if (isNil(spaceOwnerFid)) {
-    return <SpaceNotFound />;
-  }
 
   const INITIAL_CHANNEL_SPACE_CONFIG = createInitialChannelSpaceConfigForName(
     channelName,

--- a/src/app/(spaces)/channel/[channelName]/[tabName]/page.tsx
+++ b/src/app/(spaces)/channel/[channelName]/[tabName]/page.tsx
@@ -1,0 +1,2 @@
+import ChannelSpacePage from "../page";
+export default ChannelSpacePage;

--- a/src/app/(spaces)/channel/[channelName]/layout.tsx
+++ b/src/app/(spaces)/channel/[channelName]/layout.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata({ params }): Promise<Metadata> {
   if (!channelName) {
     return defaultMetadata;
   }
-  const channel = await getChannelMetadata(channelName);
+  const channel = await getChannelMetadata(channelName.toLowerCase());
   if (!channel) {
     return defaultMetadata;
   }

--- a/src/app/(spaces)/channel/[channelName]/layout.tsx
+++ b/src/app/(spaces)/channel/[channelName]/layout.tsx
@@ -2,7 +2,7 @@ import { WEBSITE_URL } from "@/constants/app";
 import React from "react";
 import { getChannelMetadata } from "./utils";
 import { Metadata } from "next/types";
-import { defaultFrame } from "@/common/lib/frames/metadata";
+import { defaultFrame } from "@/constants/metadata";
 
 const defaultMetadata = {
   other: {

--- a/src/app/(spaces)/channel/[channelName]/layout.tsx
+++ b/src/app/(spaces)/channel/[channelName]/layout.tsx
@@ -1,0 +1,49 @@
+import { WEBSITE_URL } from "@/constants/app";
+import React from "react";
+import { getChannelMetadata } from "./utils";
+import { Metadata } from "next/types";
+import { defaultFrame } from "@/common/lib/frames/metadata";
+
+const defaultMetadata = {
+  other: {
+    "fc:frame": JSON.stringify(defaultFrame),
+  },
+};
+
+export async function generateMetadata({ params }): Promise<Metadata> {
+  const { channelName, tabName: tabNameParam } = await params;
+  if (!channelName) {
+    return defaultMetadata;
+  }
+  const channel = await getChannelMetadata(channelName);
+  if (!channel) {
+    return defaultMetadata;
+  }
+  const tabName = tabNameParam ? decodeURIComponent(tabNameParam) : undefined;
+  const frameUrl = tabName
+    ? `${WEBSITE_URL}/channel/${channelName}/${encodeURIComponent(tabName)}`
+    : `${WEBSITE_URL}/channel/${channelName}`;
+  const displayName = channel.name || channel.id;
+  const metadata: Metadata = {
+    title: `${displayName} Channel | Nounspace`,
+    openGraph: {
+      title: `${displayName} Channel | Nounspace`,
+      url: frameUrl,
+    },
+    other: {
+      "fc:frame": JSON.stringify({
+        version: "next",
+        imageUrl: `${WEBSITE_URL}/images/nounspace_logo.png`,
+        button: {
+          title: `Visit ${displayName} on Nounspace`,
+          action: { type: "launch_frame", url: frameUrl, name: `${displayName} Channel`, splashImageUrl: `${WEBSITE_URL}/images/nounspace_logo.png`, splashBackgroundColor: "#FFFFFF" },
+        },
+      }),
+    },
+  };
+  return metadata;
+}
+
+export default function ChannelSpaceLayout({ children }) {
+  return <>{children}</>;
+}

--- a/src/app/(spaces)/channel/[channelName]/page.tsx
+++ b/src/app/(spaces)/channel/[channelName]/page.tsx
@@ -7,13 +7,10 @@ import { unstable_noStore as noStore } from "next/cache";
 const loadChannelSpaceData = async (
   channelName: string,
   tabNameParam?: string,
-): Promise<{ spaceOwnerFid: number | null; spaceId: string | null; tabName: string | null } | null> => {
+): Promise<{ spaceOwnerFid: number | null; spaceId: string | null; tabName: string | null }> => {
   noStore();
   const channelMetadata = await getChannelMetadata(channelName.toLowerCase());
-  if (!channelMetadata) {
-    return null;
-  }
-  const spaceOwnerFid = channelMetadata.leadFid ?? null;
+  const spaceOwnerFid = channelMetadata?.leadFid ?? null;
   const tabList: Tab[] = await getTabList(channelName.toLowerCase());
   if (!tabList || tabList.length === 0) {
     return { spaceOwnerFid, spaceId: null, tabName: tabNameParam || null };
@@ -30,11 +27,10 @@ const ChannelSpacePage = async ({ params }) => {
     return <SpaceNotFound />;
   }
   const decodedTabName = tabNameParam ? decodeURIComponent(tabNameParam) : undefined;
-  const data = await loadChannelSpaceData(channelName, decodedTabName);
-  if (!data) {
-    return <SpaceNotFound />;
-  }
-  const { spaceOwnerFid, spaceId, tabName } = data;
+  const { spaceOwnerFid, spaceId, tabName } = await loadChannelSpaceData(
+    channelName,
+    decodedTabName,
+  );
   return (
     <ChannelSpace
       channelName={channelName}

--- a/src/app/(spaces)/channel/[channelName]/page.tsx
+++ b/src/app/(spaces)/channel/[channelName]/page.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { getChannelMetadata, getTabList, type Tab } from "./utils";
+import ChannelSpace from "./ChannelSpace";
+import SpaceNotFound from "@/app/(spaces)/SpaceNotFound";
+import { unstable_noStore as noStore } from "next/cache";
+
+const loadChannelSpaceData = async (
+  channelName: string,
+  tabNameParam?: string,
+) => {
+  noStore();
+  const channelMetadata = await getChannelMetadata(channelName);
+  const spaceOwnerFid = channelMetadata?.leadFid || null;
+  if (!channelMetadata) {
+    return { spaceOwnerFid: null, spaceId: null, tabName: null };
+  }
+  const tabList: Tab[] = await getTabList(channelName);
+  if (!tabList || tabList.length === 0) {
+    return { spaceOwnerFid, spaceId: null, tabName: null };
+  }
+  const defaultTab: Tab = tabList[0];
+  const spaceId = defaultTab.spaceId;
+  const tabName = tabNameParam || defaultTab.spaceName;
+  return { spaceOwnerFid, spaceId, tabName };
+};
+
+const ChannelSpacePage = async ({ params }) => {
+  const { channelName, tabName: tabNameParam } = await params;
+  if (!channelName) {
+    return <SpaceNotFound />;
+  }
+  const decodedTabName = tabNameParam ? decodeURIComponent(tabNameParam) : undefined;
+  const { spaceOwnerFid, spaceId, tabName } = await loadChannelSpaceData(
+    channelName,
+    decodedTabName,
+  );
+  return (
+    <ChannelSpace
+      channelName={channelName}
+      spaceOwnerFid={spaceOwnerFid}
+      spaceId={spaceId}
+      tabName={tabName}
+    />
+  );
+};
+
+export default ChannelSpacePage;

--- a/src/app/(spaces)/channel/[channelName]/utils.ts
+++ b/src/app/(spaces)/channel/[channelName]/utils.ts
@@ -1,0 +1,72 @@
+import axiosBackend from "@/common/data/api/backend";
+import createSupabaseServerClient from "@/common/data/database/supabase/clients/server";
+import { unstable_noStore as noStore } from "next/cache";
+
+export type Tab = { spaceId: string; spaceName: string };
+
+export interface ChannelMetadata {
+  id: string;
+  name: string;
+  leadFid?: number | null;
+}
+
+export const getChannelMetadata = async (
+  channelName: string,
+): Promise<ChannelMetadata | null> => {
+  try {
+    const { data } = await axiosBackend.get("/api/farcaster/neynar/channel", {
+      params: { id: channelName },
+    });
+    const ch = data.channel;
+    return {
+      id: ch.id,
+      name: ch.name,
+      leadFid: ch.lead_fid ?? ch.owner_fid ?? ch.host_fid ?? null,
+    } as ChannelMetadata;
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+};
+
+export const getTabList = async (channelName: string): Promise<Tab[]> => {
+  noStore();
+  try {
+    const { data: registrations, error } = await createSupabaseServerClient()
+      .from("spaceRegistrations")
+      .select("spaceId, spaceName")
+      .eq("spaceName", channelName)
+      .limit(1);
+    if (error) {
+      console.error("Error fetching space registration:", error);
+      return [];
+    }
+    if (!registrations || registrations.length === 0) {
+      return [];
+    }
+    const registration = registrations[0];
+    try {
+      const { data: tabOrderData, error: storageError } =
+        await createSupabaseServerClient()
+          .storage
+          .from("spaces")
+          .download(`${registration.spaceId}/tabOrder`);
+      if (storageError || !tabOrderData) {
+        return [registration];
+      }
+      const tabOrderText = await tabOrderData.text();
+      const tabOrderJson = JSON.parse(tabOrderText);
+      const enhancedTab = {
+        ...registration,
+        order: tabOrderJson.tabOrder || [],
+        updatedAt: tabOrderJson.timestamp || new Date().toISOString(),
+      };
+      return [enhancedTab];
+    } catch (e) {
+      return [registration];
+    }
+  } catch (e) {
+    console.error("Exception in getTabList:", e);
+    return [];
+  }
+};

--- a/src/app/(spaces)/channel/[channelName]/utils.ts
+++ b/src/app/(spaces)/channel/[channelName]/utils.ts
@@ -15,7 +15,7 @@ export const getChannelMetadata = async (
 ): Promise<ChannelMetadata | null> => {
   try {
     const { data } = await axiosBackend.get("/api/farcaster/neynar/channel", {
-      params: { id: channelName },
+      params: { id: channelName.toLowerCase() },
     });
     const ch = data.channel;
     return {
@@ -35,7 +35,7 @@ export const getTabList = async (channelName: string): Promise<Tab[]> => {
     const { data: registrations, error } = await createSupabaseServerClient()
       .from("spaceRegistrations")
       .select("spaceId, spaceName")
-      .eq("spaceName", channelName)
+      .eq("spaceName", channelName.toLowerCase())
       .limit(1);
     if (error) {
       console.error("Error fetching space registration:", error);

--- a/src/common/lib/hooks/useSearchChannels.ts
+++ b/src/common/lib/hooks/useSearchChannels.ts
@@ -1,0 +1,82 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { debounce } from "lodash";
+import axios, { CancelTokenSource, isAxiosError } from "axios";
+import axiosBackend from "@/common/data/api/backend";
+import { NounspaceResponse } from "@/common/data/api/requestHandler";
+
+export type ChannelResult = {
+  id: string;
+  name: string;
+  image_url: string | null;
+  description?: string;
+};
+
+export type ChannelSearchReturnValue = {
+  channels: ChannelResult[];
+  loading: boolean;
+  error: string | null;
+};
+
+const useSearchChannels = (
+  query: string | null,
+  debounceMs: number = 300,
+): ChannelSearchReturnValue => {
+  const [results, setResults] = useState<ChannelResult[] | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const cancelRequest = useRef<CancelTokenSource | null>(null);
+
+  const fetchResults = useCallback(
+    debounce(async (q: string) => {
+      if (cancelRequest.current) {
+        cancelRequest.current.cancel("New search initiated");
+      }
+
+      cancelRequest.current = axios.CancelToken.source();
+
+      try {
+        const response = await axiosBackend.get<
+          NounspaceResponse<{ channels: ChannelResult[] }>
+        >("/api/farcaster/neynar/search-channels", {
+          params: {
+            q,
+            limit: 5,
+          },
+          cancelToken: cancelRequest.current.token,
+        });
+        setResults(response.data.value?.channels || []);
+        setLoading(false);
+        setError(null);
+      } catch (err) {
+        if (!axios.isCancel(err)) {
+          const errMsg = isAxiosError(err)
+            ? err.response?.data?.error?.message
+            : null;
+          setError(errMsg || "An error occurred while searching");
+          setLoading(false);
+        }
+      }
+    }, debounceMs),
+    [],
+  );
+  useEffect(() => {
+    setError(null);
+    if (query) {
+      setLoading(true);
+      fetchResults(query);
+    }
+
+    return () => {
+      cancelRequest.current?.cancel("component unmounted");
+      fetchResults.cancel();
+    };
+  }, [query]);
+
+  return {
+    channels: (query && results) || [],
+    loading: loading,
+    error: error,
+  };
+};
+
+export default useSearchChannels;

--- a/src/constants/initialChannelSpace.ts
+++ b/src/constants/initialChannelSpace.ts
@@ -1,0 +1,42 @@
+import { SpaceConfig } from "@/app/(spaces)/Space";
+import { FeedType, FilterType } from "@neynar/nodejs-sdk/build/api";
+import { cloneDeep } from "lodash";
+import { INITIAL_SPACE_CONFIG_EMPTY } from "./initialPersonSpace";
+
+export const createInitialChannelSpaceConfigForName = (
+  channelName: string,
+): Omit<SpaceConfig, "isEditable"> => {
+  const config = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
+  config.fidgetInstanceDatums = {
+    "feed:channel": {
+      config: {
+        editable: false,
+        settings: {
+          feedType: FeedType.Filter,
+          filterType: FilterType.Channel,
+          channel: channelName,
+          selectPlatform: { name: "Farcaster", icon: "/images/farcaster.jpeg" },
+        },
+        data: {},
+      },
+      fidgetType: "feed",
+      id: "feed:channel",
+    },
+  };
+  config.layoutDetails.layoutConfig.layout.push({
+    w: 6,
+    h: 8,
+    x: 0,
+    y: 0,
+    i: "feed:channel",
+    minW: 4,
+    maxW: 36,
+    minH: 6,
+    maxH: 36,
+    moved: false,
+    static: false,
+  });
+  return config;
+};
+
+export default createInitialChannelSpaceConfigForName;

--- a/src/constants/initialChannelSpace.ts
+++ b/src/constants/initialChannelSpace.ts
@@ -1,5 +1,6 @@
 import { SpaceConfig } from "@/app/(spaces)/Space";
-import { FeedType, FilterType } from "@neynar/nodejs-sdk/build/api";
+import { FeedType } from "@neynar/nodejs-sdk/build/api";
+import { FilterType } from "@/fidgets/farcaster/Feed";
 import { cloneDeep } from "lodash";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "./initialPersonSpace";
 

--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -557,12 +557,14 @@ const CastReactions = ({ cast }: { cast: CastWithInteractions }) => {
           getIconForCastReactionType(CastReactionType.quote),
         )}
         {cast.channel && cast.channel.name && (
-          <div
+          <PriorityLink
             key={`cast-${cast.hash}-channel-name`}
-            className="mt-1.5 flex align-center text-sm opacity-40 py-1 px-1.5 rounded-md"
+            href={`/channel/${cast.channel.name}`}
           >
-            /{cast.channel.name}
-          </div>
+            <div className="mt-1.5 flex align-center text-sm opacity-40 py-1 px-1.5 rounded-md hover:text-blue-500">
+              /{cast.channel.name}
+            </div>
+          </PriorityLink>
         )}
         <div
           className="ml-auto mt-1.5 flex cursor-pointer text-sm opacity-50 hover:text-foreground/85 hover:bg-background/85 py-1 px-1.5 rounded-md"

--- a/src/fidgets/index.ts
+++ b/src/fidgets/index.ts
@@ -15,6 +15,7 @@ import snapShot from "./snapshot/SnapShot";
 import Swap from "./swap/Swap";
 import rss from "./ui/rss";
 import VideoFidget from "./ui/Video";
+import ChannelInfo from "./ui/Channel";
 import marketData from "./token/marketData";
 import Portfolio from "./token/Portfolio";
 import chat from "./ui/chat";
@@ -49,6 +50,7 @@ export const CompleteFidgets = {
   Market: marketData,
   Portfolio: Portfolio,
   Chat: chat,
+  Channel: ChannelInfo,
   FramesV2: FramesFidget,
 };
 

--- a/src/fidgets/ui/Channel.tsx
+++ b/src/fidgets/ui/Channel.tsx
@@ -1,5 +1,4 @@
-import React, { useMemo, useState } from "react";
-import { Button } from "@/common/components/atoms/button";
+import React, { useMemo } from "react";
 import TextInput from "@/common/components/molecules/TextInput";
 import { FidgetArgs, FidgetModule, FidgetProperties } from "@/common/fidgets";
 import axiosBackend from "@/common/data/api/backend";
@@ -45,9 +44,6 @@ const Channel: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
   settings: { channel },
 }) => {
   const { data } = useChannelInfo(channel);
-  const [following, setFollowing] = useState(false);
-
-  const handleToggle = () => setFollowing((p) => !p);
 
   const displayName = useMemo(
     () => data?.name || channel,
@@ -68,13 +64,6 @@ const Channel: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
           <span className="text-xl">{displayName}</span>
           <small className="text-slate-500">/{data.id}</small>
         </div>
-        <Button
-          className="ml-auto px-3 py-1 text-sm"
-          variant={following ? "secondary" : "primary"}
-          onClick={handleToggle}
-        >
-          {following ? "Unfollow" : "Follow"}
-        </Button>
       </div>
       {data.description && (
         <p className="text-sm mb-3">{data.description}</p>

--- a/src/fidgets/ui/Channel.tsx
+++ b/src/fidgets/ui/Channel.tsx
@@ -1,0 +1,112 @@
+import React, { useMemo, useState } from "react";
+import { Button } from "@/common/components/atoms/button";
+import TextInput from "@/common/components/molecules/TextInput";
+import { FidgetArgs, FidgetModule, FidgetProperties } from "@/common/fidgets";
+import axiosBackend from "@/common/data/api/backend";
+import { useQuery } from "@tanstack/react-query";
+
+export type ChannelFidgetSettings = {
+  channel: string;
+};
+
+const channelProperties: FidgetProperties = {
+  fidgetName: "Channel",
+  fields: [
+    {
+      fieldName: "channel",
+      default: "",
+      required: true,
+      inputSelector: TextInput,
+    },
+  ],
+  size: {
+    minHeight: 3,
+    maxHeight: 36,
+    minWidth: 4,
+    maxWidth: 36,
+  },
+};
+
+const useChannelInfo = (channel: string) => {
+  return useQuery({
+    queryKey: ["channel-info", channel],
+    queryFn: async () => {
+      const { data } = await axiosBackend.get(
+        "/api/farcaster/neynar/channel",
+        { params: { id: channel } },
+      );
+      return data.channel as any;
+    },
+  });
+};
+
+const Channel: React.FC<FidgetArgs<ChannelFidgetSettings>> = ({
+  settings: { channel },
+}) => {
+  const { data } = useChannelInfo(channel);
+  const [following, setFollowing] = useState(false);
+
+  const handleToggle = () => setFollowing((p) => !p);
+
+  const displayName = useMemo(
+    () => data?.name || channel,
+    [data, channel],
+  );
+
+  if (!data) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  return (
+    <div className="flex flex-col h-full overflow-auto p-4">
+      <div className="flex items-center mb-4">
+        {data.image_url && (
+          <img src={data.image_url} className="h-14 w-14 rounded-full mr-4" />
+        )}
+        <div className="flex flex-col">
+          <span className="text-xl">{displayName}</span>
+          <small className="text-slate-500">/{data.id}</small>
+        </div>
+        <Button
+          className="ml-auto px-3 py-1 text-sm"
+          variant={following ? "secondary" : "primary"}
+          onClick={handleToggle}
+        >
+          {following ? "Unfollow" : "Follow"}
+        </Button>
+      </div>
+      {data.description && (
+        <p className="text-sm mb-3">{data.description}</p>
+      )}
+      <div className="flex gap-3 text-sm">
+        {typeof data.member_count === "number" && (
+          <p>
+            <span className="font-bold">{data.member_count}</span> Members
+          </p>
+        )}
+        {typeof data.follower_count === "number" && (
+          <p>
+            <span className="font-bold">{data.follower_count}</span> Followers
+          </p>
+        )}
+        {data.external_url && (
+          <p>
+            <a
+              href={data.external_url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-blue-500 hover:underline"
+            >
+              {data.external_url}
+            </a>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default {
+  fidget: Channel,
+  properties: channelProperties,
+} as FidgetModule<FidgetArgs<ChannelFidgetSettings>>;

--- a/src/fidgets/ui/Channel.tsx
+++ b/src/fidgets/ui/Channel.tsx
@@ -11,6 +11,7 @@ export type ChannelFidgetSettings = {
 
 const channelProperties: FidgetProperties = {
   fidgetName: "Channel",
+  icon: 0x1f4e2,
   fields: [
     {
       fieldName: "channel",


### PR DESCRIPTION
Adds basic support for Farcaster Channels, including default channel spaces with a channel fidget instead of profile fidget, and a feed fidget filtered to casts on those channels.

## Summary
- add initial config for channel spaces
- add Channel fidget
- expose Channel in fidget index
- link channel names in casts

## To-do
- Add channels to search
- Register a channel space when the channel owner visits it
- Enable channel owners to customize channel spaces

## Note
- It's not currently possible to enable users to follow and unfollow channels from Nounspace since we have a developer managed signer and channel follows/unfollows are currently managed by Farcaster's API, and not yet enshrined in the protocol.

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run check-types` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68753a3e02b88325a0b8e1032c0e1daf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced channel spaces with dedicated pages, dynamic metadata, and navigation.
  - Added a Channel Info widget to display channel details within spaces.
  - Search now includes channels alongside users and tokens, with direct navigation to channel pages.
  - Channel mentions in casts are now clickable links to their channel pages.

- UX Improvements
  - More reliable default layouts and tab handling for public spaces and channels.
  - Smoother loading states and skeletons when viewing channel and space content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->