### PR TITLE
Extend dynamic open graph data to user profile spaces and cast URLs

### DIFF
--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -1,7 +1,5 @@
 import React from "react";
-import type { Metadata } from "next";
-
-export const dynamic = "force-dynamic";
+import type { Metadata } from "next/types";
 
 import { WEBSITE_URL } from "@/constants/app";
 import { CastParamType } from "@neynar/nodejs-sdk/build/api";

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { Metadata, LayoutProps } from "next";
+import type { Metadata } from "next";
 
 import { WEBSITE_URL } from "@/constants/app";
 import { CastParamType } from "@neynar/nodejs-sdk/build/api";
@@ -15,8 +15,10 @@ const defaultMetadata = {
 
 export async function generateMetadata({
   params,
-}: LayoutProps<{ slug?: string[] }>): Promise<Metadata> {
-  const { slug } = await params;
+}: {
+  params: { slug?: string[] };
+}): Promise<Metadata> {
+  const { slug } = params;
   const segments: string[] = Array.isArray(slug) ? slug : [];
   let castHash: string | undefined;
   let username: string | undefined;

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import { WEBSITE_URL } from "@/constants/app";
-import neynar from "@/common/data/api/neynar";
 import { CastParamType } from "@neynar/nodejs-sdk/build/api";
 import { getCastMetadataStructure } from "@/common/lib/utils/castMetadata";
 import { defaultFrame } from "@/common/lib/frames/metadata";
@@ -28,10 +27,13 @@ export async function generateMetadata({ params }): Promise<Metadata> {
   }
 
   try {
-    const { cast } = await neynar.lookupCastByHashOrWarpcastUrl({
-      identifier: castHash,
-      type: CastParamType.Hash,
-    });
+    const res = await fetch(
+      `${WEBSITE_URL}/api/farcaster/neynar/cast?identifier=${castHash}&type=${CastParamType.Hash}`,
+    );
+    if (!res.ok) {
+      throw new Error(`Failed to load cast: ${res.status}`);
+    }
+    const { cast } = await res.json();
 
     const baseMetadata = getCastMetadataStructure({
       hash: cast.hash,

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from "next/types";
+import { WEBSITE_URL } from "@/constants/app";
 
 export const dynamic = "force-dynamic";
+export const metadataBase = new URL(WEBSITE_URL);
 import neynar from "@/common/data/api/neynar";
 import { CastParamType } from "@neynar/nodejs-sdk/build/api";
 import { getCastMetadataStructure } from "@/common/lib/utils/castMetadata";
@@ -8,8 +10,10 @@ import { getCastMetadataStructure } from "@/common/lib/utils/castMetadata";
 export async function generateMetadata({ params }): Promise<Metadata> {
   const segments: string[] = Array.isArray(params.slug) ? params.slug : [];
   let castHash: string | undefined;
+  let username: string | undefined;
 
   if (segments.length >= 3 && segments[0] === "c") {
+    username = decodeURIComponent(segments[1]);
     castHash = decodeURIComponent(segments[2]);
   } else if (segments.length >= 2) {
     castHash = decodeURIComponent(segments[1]);
@@ -34,7 +38,7 @@ export async function generateMetadata({ params }): Promise<Metadata> {
     });
   } catch (error) {
     console.error("Error generating cast metadata:", error);
-    return getCastMetadataStructure({ hash: castHash });
+    return getCastMetadataStructure({ hash: castHash, username });
   }
 }
 

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import type { Metadata } from "next";
 
+export const dynamic = "force-dynamic";
+
 import { WEBSITE_URL } from "@/constants/app";
 import { CastParamType } from "@neynar/nodejs-sdk/build/api";
 import neynar from "@/common/data/api/neynar";

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -1,8 +1,8 @@
-import { Metadata } from "next/types";
+import type { Metadata } from "next";
 import { WEBSITE_URL } from "@/constants/app";
 
 export const dynamic = "force-dynamic";
-export const metadataBase = new URL(WEBSITE_URL);
+export const metadata: Metadata = { metadataBase: new URL(WEBSITE_URL) };
 import neynar from "@/common/data/api/neynar";
 import { CastParamType } from "@neynar/nodejs-sdk/build/api";
 import { getCastMetadataStructure } from "@/common/lib/utils/castMetadata";

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { Metadata } from "next";
+import type { Metadata, LayoutProps } from "next";
 
 import { WEBSITE_URL } from "@/constants/app";
 import { CastParamType } from "@neynar/nodejs-sdk/build/api";
@@ -15,10 +15,9 @@ const defaultMetadata = {
 
 export async function generateMetadata({
   params,
-}: {
-  params: { slug?: string[] };
-}): Promise<Metadata> {
-  const segments: string[] = Array.isArray(params.slug) ? params.slug : [];
+}: LayoutProps<{ slug?: string[] }>): Promise<Metadata> {
+  const { slug } = await params;
+  const segments: string[] = Array.isArray(slug) ? slug : [];
   let castHash: string | undefined;
   let username: string | undefined;
 

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -1,4 +1,6 @@
 import { Metadata } from "next/types";
+
+export const dynamic = "force-dynamic";
 import neynar from "@/common/data/api/neynar";
 import { CastParamType } from "@neynar/nodejs-sdk/build/api";
 import { getCastMetadataStructure } from "@/common/lib/utils/castMetadata";
@@ -32,7 +34,7 @@ export async function generateMetadata({ params }): Promise<Metadata> {
     });
   } catch (error) {
     console.error("Error generating cast metadata:", error);
-    return {};
+    return getCastMetadataStructure({ hash: castHash });
   }
 }
 

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -1,7 +1,5 @@
 import type { Metadata } from "next";
 import { WEBSITE_URL } from "@/constants/app";
-
-export const dynamic = "force-dynamic";
 import neynar from "@/common/data/api/neynar";
 import { CastParamType } from "@neynar/nodejs-sdk/build/api";
 import { getCastMetadataStructure } from "@/common/lib/utils/castMetadata";

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from "next";
+
+export const dynamic = "force-dynamic";
 import { WEBSITE_URL } from "@/constants/app";
 import { CastParamType } from "@neynar/nodejs-sdk/build/api";
 import { getCastMetadataStructure } from "@/common/lib/utils/castMetadata";
 import { defaultFrame } from "@/common/lib/frames/metadata";
+import { unstable_noStore as noStore } from "next/cache";
 
 const defaultMetadata = {
   other: {
@@ -11,6 +14,7 @@ const defaultMetadata = {
 };
 
 export async function generateMetadata({ params }): Promise<Metadata> {
+  noStore();
   const segments: string[] = Array.isArray(params.slug) ? params.slug : [];
   let castHash: string | undefined;
   let username: string | undefined;
@@ -29,6 +33,7 @@ export async function generateMetadata({ params }): Promise<Metadata> {
   try {
     const res = await fetch(
       `${WEBSITE_URL}/api/farcaster/neynar/cast?identifier=${castHash}&type=${CastParamType.Hash}`,
+      { cache: "no-store" },
     );
     if (!res.ok) {
       throw new Error(`Failed to load cast: ${res.status}`);

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -19,7 +19,7 @@ export async function generateMetadata({ params }): Promise<Metadata> {
   }
 
   if (!castHash) {
-    return { metadataBase: new URL(WEBSITE_URL) };
+    return {};
   }
 
   try {
@@ -29,7 +29,6 @@ export async function generateMetadata({ params }): Promise<Metadata> {
     });
 
     return {
-      metadataBase: new URL(WEBSITE_URL),
       ...getCastMetadataStructure({
         hash: cast.hash,
         username: cast.author.username,
@@ -40,10 +39,7 @@ export async function generateMetadata({ params }): Promise<Metadata> {
     };
   } catch (error) {
     console.error("Error generating cast metadata:", error);
-    return {
-      metadataBase: new URL(WEBSITE_URL),
-      ...getCastMetadataStructure({ hash: castHash, username }),
-    };
+    return getCastMetadataStructure({ hash: castHash, username });
   }
 }
 

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 
 import { WEBSITE_URL } from "@/constants/app";
 import { CastParamType } from "@neynar/nodejs-sdk/build/api";
+import neynar from "@/common/data/api/neynar";
 import { getCastMetadataStructure } from "@/common/lib/utils/castMetadata";
 import { defaultFrame } from "@/common/lib/frames/metadata";
 
@@ -28,13 +29,10 @@ export async function generateMetadata({ params }): Promise<Metadata> {
   }
 
   try {
-    const res = await fetch(
-      `${WEBSITE_URL}/api/farcaster/neynar/cast?identifier=${castHash}&type=${CastParamType.Hash}`,
-    );
-    if (!res.ok) {
-      throw new Error(`Failed to load cast: ${res.status}`);
-    }
-    const { cast } = await res.json();
+    const { cast } = await neynar.lookupCastByHashOrWarpcastUrl({
+      identifier: castHash,
+      type: CastParamType.Hash,
+    });
 
     const baseMetadata = getCastMetadataStructure({
       hash: cast.hash,

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import type { Metadata } from "next";
 
 import { WEBSITE_URL } from "@/constants/app";
@@ -12,7 +13,11 @@ const defaultMetadata = {
   },
 };
 
-export async function generateMetadata({ params }): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: {
+  params: { slug?: string[] };
+}): Promise<Metadata> {
   const segments: string[] = Array.isArray(params.slug) ? params.slug : [];
   let castHash: string | undefined;
   let username: string | undefined;

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -97,8 +97,10 @@ export async function generateMetadata({
 
 export default function HomebaseSlugLayout({
   children,
+  params,
 }: {
   children: React.ReactNode;
+  params: { slug?: string[] };
 }) {
   return children;
 }

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -13,11 +13,7 @@ const defaultMetadata = {
   },
 };
 
-export async function generateMetadata({
-  params,
-}: {
-  params: { slug?: string[] };
-}): Promise<Metadata> {
+export async function generateMetadata({ params }): Promise<Metadata> {
   const { slug } = params;
   const segments: string[] = Array.isArray(slug) ? slug : [];
   let castHash: string | undefined;

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -1,11 +1,9 @@
 import type { Metadata } from "next";
 
-export const dynamic = "force-dynamic";
 import { WEBSITE_URL } from "@/constants/app";
 import { CastParamType } from "@neynar/nodejs-sdk/build/api";
 import { getCastMetadataStructure } from "@/common/lib/utils/castMetadata";
 import { defaultFrame } from "@/common/lib/frames/metadata";
-import { unstable_noStore as noStore } from "next/cache";
 
 const defaultMetadata = {
   other: {
@@ -14,7 +12,6 @@ const defaultMetadata = {
 };
 
 export async function generateMetadata({ params }): Promise<Metadata> {
-  noStore();
   const segments: string[] = Array.isArray(params.slug) ? params.slug : [];
   let castHash: string | undefined;
   let username: string | undefined;
@@ -33,7 +30,6 @@ export async function generateMetadata({ params }): Promise<Metadata> {
   try {
     const res = await fetch(
       `${WEBSITE_URL}/api/farcaster/neynar/cast?identifier=${castHash}&type=${CastParamType.Hash}`,
-      { cache: "no-store" },
     );
     if (!res.ok) {
       throw new Error(`Failed to load cast: ${res.status}`);

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -1,0 +1,45 @@
+import { Metadata } from "next/types";
+import neynar from "@/common/data/api/neynar";
+import { CastParamType } from "@neynar/nodejs-sdk/build/api";
+import { getCastMetadataStructure } from "@/common/lib/utils/castMetadata";
+
+export async function generateMetadata({ params }): Promise<Metadata> {
+  const segments: string[] = Array.isArray(params.slug) ? params.slug : [];
+  let castHash: string | undefined;
+
+  if (segments.length >= 3 && segments[0] === "c") {
+    castHash = decodeURIComponent(segments[2]);
+  } else if (segments.length >= 2) {
+    castHash = decodeURIComponent(segments[1]);
+  }
+
+  if (!castHash) {
+    return {};
+  }
+
+  try {
+    const { cast } = await neynar.lookupCastByHashOrWarpcastUrl({
+      identifier: castHash,
+      type: CastParamType.Hash,
+    });
+
+    return getCastMetadataStructure({
+      hash: cast.hash,
+      username: cast.author.username,
+      displayName: cast.author.display_name,
+      pfpUrl: cast.author.pfp_url,
+      text: cast.text,
+    });
+  } catch (error) {
+    console.error("Error generating cast metadata:", error);
+    return {};
+  }
+}
+
+export default function HomebaseSlugLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { WEBSITE_URL } from "@/constants/app";
 
 export const dynamic = "force-dynamic";
-export const metadata: Metadata = { metadataBase: new URL(WEBSITE_URL) };
 import neynar from "@/common/data/api/neynar";
 import { CastParamType } from "@neynar/nodejs-sdk/build/api";
 import { getCastMetadataStructure } from "@/common/lib/utils/castMetadata";
@@ -20,7 +19,7 @@ export async function generateMetadata({ params }): Promise<Metadata> {
   }
 
   if (!castHash) {
-    return {};
+    return { metadataBase: new URL(WEBSITE_URL) };
   }
 
   try {
@@ -29,16 +28,22 @@ export async function generateMetadata({ params }): Promise<Metadata> {
       type: CastParamType.Hash,
     });
 
-    return getCastMetadataStructure({
-      hash: cast.hash,
-      username: cast.author.username,
-      displayName: cast.author.display_name,
-      pfpUrl: cast.author.pfp_url,
-      text: cast.text,
-    });
+    return {
+      metadataBase: new URL(WEBSITE_URL),
+      ...getCastMetadataStructure({
+        hash: cast.hash,
+        username: cast.author.username,
+        displayName: cast.author.display_name,
+        pfpUrl: cast.author.pfp_url,
+        text: cast.text,
+      }),
+    };
   } catch (error) {
     console.error("Error generating cast metadata:", error);
-    return getCastMetadataStructure({ hash: castHash, username });
+    return {
+      metadataBase: new URL(WEBSITE_URL),
+      ...getCastMetadataStructure({ hash: castHash, username }),
+    };
   }
 }
 

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -97,10 +97,8 @@ export async function generateMetadata({
 
 export default function HomebaseSlugLayout({
   children,
-  params,
 }: {
   children: React.ReactNode;
-  params: { slug?: string[] };
 }) {
   return children;
 }

--- a/src/app/(spaces)/s/[handle]/layout.tsx
+++ b/src/app/(spaces)/s/[handle]/layout.tsx
@@ -12,12 +12,8 @@ const defaultMetadata = {
   },
 };
 
-export async function generateMetadata({
-  params,
-}: {
-  params: { handle?: string; tabName?: string };
-}): Promise<Metadata> {
-  const { handle, tabName: tabNameParam } = params;
+export async function generateMetadata({ params }): Promise<Metadata> {
+  const { handle, tabName: tabNameParam } = await params;
   
   if (!handle) {
     return defaultMetadata; // Return default metadata if no handle

--- a/src/app/(spaces)/s/[handle]/layout.tsx
+++ b/src/app/(spaces)/s/[handle]/layout.tsx
@@ -5,8 +5,6 @@ import { Metadata } from "next/types";
 import { getUserMetadataStructure } from "@/common/lib/utils/userMetadata";
 import { defaultFrame } from "@/common/lib/frames/metadata";
 
-export const dynamic = "force-dynamic";
-
 // Default metadata (used as fallback)
 const defaultMetadata = {
   other: {

--- a/src/app/(spaces)/s/[handle]/layout.tsx
+++ b/src/app/(spaces)/s/[handle]/layout.tsx
@@ -14,6 +14,8 @@ const defaultMetadata = {
 
 export async function generateMetadata({
   params,
+}: {
+  params: { handle?: string; tabName?: string };
 }): Promise<Metadata> {
   const { handle, tabName: tabNameParam } = await params;
   

--- a/src/app/(spaces)/s/[handle]/layout.tsx
+++ b/src/app/(spaces)/s/[handle]/layout.tsx
@@ -1,5 +1,7 @@
 import { WEBSITE_URL } from "@/constants/app";
 import React from "react";
+
+export const dynamic = "force-dynamic";
 import { getUserMetadata } from "./utils";
 import { Metadata } from "next/types";
 import { getUserMetadataStructure } from "@/common/lib/utils/userMetadata";

--- a/src/app/(spaces)/s/[handle]/layout.tsx
+++ b/src/app/(spaces)/s/[handle]/layout.tsx
@@ -25,7 +25,11 @@ export async function generateMetadata({
 
   const userMetadata = await getUserMetadata(handle);
   if (!userMetadata) {
-    return defaultMetadata; // Return default metadata if no user metadata
+    const baseMetadata = getUserMetadataStructure({ username: handle });
+    return {
+      ...baseMetadata,
+      other: { "fc:frame": JSON.stringify(defaultFrame) },
+    };
   }
 
   // Process tabName parameter if it exists

--- a/src/app/(spaces)/s/[handle]/layout.tsx
+++ b/src/app/(spaces)/s/[handle]/layout.tsx
@@ -2,6 +2,8 @@ import { WEBSITE_URL } from "@/constants/app";
 import React from "react";
 import { getUserMetadata } from "./utils";
 import type { Metadata } from "next";
+
+export const dynamic = "force-dynamic";
 import { getUserMetadataStructure } from "@/common/lib/utils/userMetadata";
 import { defaultFrame } from "@/common/lib/frames/metadata";
 

--- a/src/app/(spaces)/s/[handle]/layout.tsx
+++ b/src/app/(spaces)/s/[handle]/layout.tsx
@@ -86,8 +86,10 @@ export async function generateMetadata({
 
 export default function RootLayout({
   children,
+  params,
 }: {
   children: React.ReactNode;
+  params: { handle?: string; tabName?: string };
 }) {
   return children;
 }

--- a/src/app/(spaces)/s/[handle]/layout.tsx
+++ b/src/app/(spaces)/s/[handle]/layout.tsx
@@ -1,7 +1,5 @@
 import { WEBSITE_URL } from "@/constants/app";
 import React from "react";
-
-export const dynamic = "force-dynamic";
 import { getUserMetadata } from "./utils";
 import { Metadata } from "next/types";
 import { getUserMetadataStructure } from "@/common/lib/utils/userMetadata";

--- a/src/app/(spaces)/s/[handle]/layout.tsx
+++ b/src/app/(spaces)/s/[handle]/layout.tsx
@@ -1,9 +1,7 @@
 import { WEBSITE_URL } from "@/constants/app";
 import React from "react";
 import { getUserMetadata } from "./utils";
-import type { Metadata } from "next";
-
-export const dynamic = "force-dynamic";
+import type { Metadata } from "next/types";
 import { getUserMetadataStructure } from "@/common/lib/utils/userMetadata";
 import { defaultFrame } from "@/common/lib/frames/metadata";
 
@@ -15,7 +13,7 @@ const defaultMetadata = {
 };
 
 export async function generateMetadata({ params }): Promise<Metadata> {
-  const { handle, tabName: tabNameParam } = await params;
+  const { handle, tabName: tabNameParam } = params;
   
   if (!handle) {
     return defaultMetadata; // Return default metadata if no handle

--- a/src/app/(spaces)/s/[handle]/layout.tsx
+++ b/src/app/(spaces)/s/[handle]/layout.tsx
@@ -5,6 +5,8 @@ import { Metadata } from "next/types";
 import { getUserMetadataStructure } from "@/common/lib/utils/userMetadata";
 import { defaultFrame } from "@/common/lib/frames/metadata";
 
+export const dynamic = "force-dynamic";
+
 // Default metadata (used as fallback)
 const defaultMetadata = {
   other: {

--- a/src/app/(spaces)/s/[handle]/layout.tsx
+++ b/src/app/(spaces)/s/[handle]/layout.tsx
@@ -86,10 +86,8 @@ export async function generateMetadata({
 
 export default function RootLayout({
   children,
-  params,
 }: {
   children: React.ReactNode;
-  params: { handle?: string; tabName?: string };
 }) {
   return children;
 }

--- a/src/app/(spaces)/s/[handle]/layout.tsx
+++ b/src/app/(spaces)/s/[handle]/layout.tsx
@@ -1,7 +1,7 @@
 import { WEBSITE_URL } from "@/constants/app";
 import React from "react";
 import { getUserMetadata } from "./utils";
-import { Metadata } from "next/types";
+import type { Metadata, LayoutProps } from "next";
 import { getUserMetadataStructure } from "@/common/lib/utils/userMetadata";
 import { defaultFrame } from "@/common/lib/frames/metadata";
 
@@ -14,9 +14,7 @@ const defaultMetadata = {
 
 export async function generateMetadata({
   params,
-}: {
-  params: { handle?: string; tabName?: string };
-}): Promise<Metadata> {
+}: LayoutProps<{ handle?: string; tabName?: string }>): Promise<Metadata> {
   const { handle, tabName: tabNameParam } = await params;
   
   if (!handle) {

--- a/src/app/(spaces)/s/[handle]/layout.tsx
+++ b/src/app/(spaces)/s/[handle]/layout.tsx
@@ -84,12 +84,6 @@ export async function generateMetadata({
   return metadataWithFrame;
 }
 
-export default function RootLayout({
-  children,
-  params,
-}: {
-  children: React.ReactNode;
-  params: { handle?: string; tabName?: string };
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return children;
 }

--- a/src/app/(spaces)/s/[handle]/layout.tsx
+++ b/src/app/(spaces)/s/[handle]/layout.tsx
@@ -1,7 +1,7 @@
 import { WEBSITE_URL } from "@/constants/app";
 import React from "react";
 import { getUserMetadata } from "./utils";
-import type { Metadata, LayoutProps } from "next";
+import type { Metadata } from "next";
 import { getUserMetadataStructure } from "@/common/lib/utils/userMetadata";
 import { defaultFrame } from "@/common/lib/frames/metadata";
 
@@ -14,8 +14,10 @@ const defaultMetadata = {
 
 export async function generateMetadata({
   params,
-}: LayoutProps<{ handle?: string; tabName?: string }>): Promise<Metadata> {
-  const { handle, tabName: tabNameParam } = await params;
+}: {
+  params: { handle?: string; tabName?: string };
+}): Promise<Metadata> {
+  const { handle, tabName: tabNameParam } = params;
   
   if (!handle) {
     return defaultMetadata; // Return default metadata if no handle

--- a/src/app/(spaces)/s/[handle]/page.tsx
+++ b/src/app/(spaces)/s/[handle]/page.tsx
@@ -48,7 +48,7 @@ const loadUserSpaceData = async (
 const ProfileSpacePage = async ({
   params,
 }) => {
-  const { handle, tabName: tabNameParam } = await params;
+  const { handle, tabName: tabNameParam } = params;
   
   console.log("ProfileSpacePage rendering with params:", {
     handle,

--- a/src/app/(spaces)/s/[handle]/utils.ts
+++ b/src/app/(spaces)/s/[handle]/utils.ts
@@ -1,7 +1,6 @@
 import createSupabaseServerClient from "@/common/data/database/supabase/clients/server";
 import { UserMetadata } from "@/common/lib/utils/userMetadata";
 import { WEBSITE_URL } from "@/constants/app";
-import { unstable_noStore as noStore } from 'next/cache';
 
 export type Tab = {
   spaceId: string;
@@ -12,10 +11,8 @@ export const getUserMetadata = async (
   handle: string,
 ): Promise<UserMetadata | null> => {
   try {
-    noStore();
     const res = await fetch(
       `${WEBSITE_URL}/api/farcaster/neynar/user?username=${handle}`,
-      { cache: "no-store" },
     );
     if (!res.ok) {
       throw new Error(`Failed to load user: ${res.status}`);
@@ -36,7 +33,6 @@ export const getUserMetadata = async (
 };
 
 export const getTabList = async (fid: number): Promise<Tab[]> => {
-  noStore();
 
   try {
     console.log("Getting tablist for fid:", fid);

--- a/src/app/(spaces)/s/[handle]/utils.ts
+++ b/src/app/(spaces)/s/[handle]/utils.ts
@@ -1,6 +1,6 @@
 import createSupabaseServerClient from "@/common/data/database/supabase/clients/server";
 import { UserMetadata } from "@/common/lib/utils/userMetadata";
-import { WEBSITE_URL } from "@/constants/app";
+import neynar from "@/common/data/api/neynar";
 
 export type Tab = {
   spaceId: string;
@@ -11,13 +11,7 @@ export const getUserMetadata = async (
   handle: string,
 ): Promise<UserMetadata | null> => {
   try {
-    const res = await fetch(
-      `${WEBSITE_URL}/api/farcaster/neynar/user?username=${handle}`,
-    );
-    if (!res.ok) {
-      throw new Error(`Failed to load user: ${res.status}`);
-    }
-    const user = await res.json();
+    const { user } = await neynar.lookupUserByUsername({ username: handle });
 
     return {
       fid: user.fid,

--- a/src/app/(spaces)/s/[handle]/utils.ts
+++ b/src/app/(spaces)/s/[handle]/utils.ts
@@ -12,8 +12,10 @@ export const getUserMetadata = async (
   handle: string,
 ): Promise<UserMetadata | null> => {
   try {
+    noStore();
     const res = await fetch(
       `${WEBSITE_URL}/api/farcaster/neynar/user?username=${handle}`,
+      { cache: "no-store" },
     );
     if (!res.ok) {
       throw new Error(`Failed to load user: ${res.status}`);

--- a/src/app/(spaces)/s/[handle]/utils.ts
+++ b/src/app/(spaces)/s/[handle]/utils.ts
@@ -1,6 +1,6 @@
-import neynar from "@/common/data/api/neynar";
 import createSupabaseServerClient from "@/common/data/database/supabase/clients/server";
 import { UserMetadata } from "@/common/lib/utils/userMetadata";
+import { WEBSITE_URL } from "@/constants/app";
 import { unstable_noStore as noStore } from 'next/cache';
 
 export type Tab = {
@@ -8,16 +8,24 @@ export type Tab = {
   spaceName: string;
 };
 
-export const getUserMetadata = async (handle: string): Promise<UserMetadata | null> => {
+export const getUserMetadata = async (
+  handle: string,
+): Promise<UserMetadata | null> => {
   try {
-    const { user } = await neynar.lookupUserByUsername({username: handle});
+    const res = await fetch(
+      `${WEBSITE_URL}/api/farcaster/neynar/user?username=${handle}`,
+    );
+    if (!res.ok) {
+      throw new Error(`Failed to load user: ${res.status}`);
+    }
+    const user = await res.json();
 
     return {
       fid: user.fid,
       username: user.username,
       displayName: user.display_name,
       pfpUrl: user.pfp_url,
-      bio: user.profile.bio.text,
+      bio: user.profile?.bio?.text || "",
     };
   } catch (e) {
     console.error(e);

--- a/src/app/api/metadata/cast/route.tsx
+++ b/src/app/api/metadata/cast/route.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-import { NextApiRequest, NextApiResponse } from "next";
+import { NextRequest } from "next/server";
 import { ImageResponse } from "next/og";
 
-export const config = {
-  runtime: "edge",
-};
+export const runtime = "edge";
 
 interface CastCardData {
   username: string;
@@ -13,20 +11,13 @@ interface CastCardData {
   text: string;
 }
 
-export default async function GET(
-  req: NextApiRequest,
-  res: NextApiResponse<ImageResponse | string>,
-) {
-  if (!req.url) {
-    return res.status(404).send("Url not found");
-  }
-
-  const params = new URLSearchParams(req.url.split("?")[1]);
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
   const data: CastCardData = {
-    username: params.get("username") || "",
-    displayName: params.get("displayName") || "",
-    pfpUrl: params.get("pfpUrl") || "",
-    text: params.get("text") || "",
+    username: searchParams.get("username") || "",
+    displayName: searchParams.get("displayName") || "",
+    pfpUrl: searchParams.get("pfpUrl") || "",
+    text: searchParams.get("text") || "",
   };
 
   return new ImageResponse(<CastCard data={data} />, {

--- a/src/common/lib/utils/castMetadata.tsx
+++ b/src/common/lib/utils/castMetadata.tsx
@@ -39,17 +39,23 @@ export const getCastMetadataStructure = (
 
   const ogImageUrl = `${WEBSITE_URL}/api/metadata/cast?${params.toString()}`;
 
+  const ogImage = {
+    url: ogImageUrl,
+    width: 1200,
+    height: 630,
+  };
+
   const metadata: Metadata = {
     title,
     openGraph: {
       title,
       url: castUrl,
-      images: [ogImageUrl],
+      images: [ogImage],
     },
     twitter: {
       title,
       site: "https://nounspace.com/",
-      images: [ogImageUrl],
+      images: [ogImage],
       card: "summary_large_image",
     },
   };

--- a/src/common/lib/utils/castMetadata.tsx
+++ b/src/common/lib/utils/castMetadata.tsx
@@ -1,0 +1,63 @@
+import { WEBSITE_URL } from "@/constants/app";
+import { merge } from "lodash";
+import { Metadata } from "next";
+
+export type CastMetadata = {
+  hash?: string;
+  username?: string;
+  displayName?: string;
+  pfpUrl?: string;
+  text?: string;
+};
+
+export const getCastMetadataStructure = (
+  cast: CastMetadata,
+): Metadata => {
+  if (!cast) {
+    return {};
+  }
+
+  const { hash, username, displayName, pfpUrl, text } = cast;
+
+  const title = displayName
+    ? `${displayName}'s Cast`
+    : username
+    ? `@${username}'s Cast`
+    : "Farcaster Cast";
+
+  const castUrl = hash ? `https://nounspace.com/c/${hash}` : undefined;
+
+  const params = new URLSearchParams({
+    username: username || "",
+    displayName: displayName || "",
+    pfpUrl: pfpUrl || "",
+    text: text || "",
+  });
+
+  const ogImageUrl = `${WEBSITE_URL}/api/metadata/cast?${params.toString()}`;
+
+  const metadata: Metadata = {
+    title,
+    openGraph: {
+      title,
+      url: castUrl,
+      images: [ogImageUrl],
+    },
+    twitter: {
+      title,
+      site: "https://nounspace.com/",
+      images: [ogImageUrl],
+      card: "summary_large_image",
+    },
+  };
+
+  if (text) {
+    merge(metadata, {
+      description: text,
+      openGraph: { description: text },
+      twitter: { description: text },
+    });
+  }
+
+  return metadata;
+};

--- a/src/common/lib/utils/castMetadata.tsx
+++ b/src/common/lib/utils/castMetadata.tsx
@@ -25,7 +25,10 @@ export const getCastMetadataStructure = (
     ? `@${username}'s Cast`
     : "Farcaster Cast";
 
-  const castUrl = hash ? `https://nounspace.com/c/${hash}` : undefined;
+  const castUrl =
+    hash && username
+      ? `https://nounspace.com/homebase/c/${username}/${hash}`
+      : undefined;
 
   const params = new URLSearchParams({
     username: username || "",

--- a/src/common/lib/utils/castMetadata.tsx
+++ b/src/common/lib/utils/castMetadata.tsx
@@ -27,7 +27,7 @@ export const getCastMetadataStructure = (
 
   const castUrl =
     hash && username
-      ? `https://nounspace.com/homebase/c/${username}/${hash}`
+      ? `${WEBSITE_URL}/homebase/c/${username}/${hash}`
       : undefined;
 
   const params = new URLSearchParams({

--- a/src/common/lib/utils/gridCleanup.ts
+++ b/src/common/lib/utils/gridCleanup.ts
@@ -164,3 +164,4 @@ export function resolveOverlaps(
 
   return { cleanedLayout, removedFidgetIds };
 } 
+export const cleanupLayout = comprehensiveCleanup;

--- a/src/common/lib/utils/userMetadata.tsx
+++ b/src/common/lib/utils/userMetadata.tsx
@@ -27,18 +27,23 @@ export const getUserMetadataStructure = (
   const encodedBio = encodeURIComponent(bio || "");
 
   const ogImageUrl = `${WEBSITE_URL}/api/metadata/spaces?username=${username}&displayName=${encodedDisplayName}&pfpUrl=${encodedPfpUrl}&bio=${encodedBio}`;
+  const ogImage = {
+    url: ogImageUrl,
+    width: 1200,
+    height: 630,
+  };
 
   const metadata: Metadata = {
     title,
     openGraph: {
       title,
       url: spaceUrl,
-      images: [ogImageUrl],
+      images: [ogImage],
     },
     twitter: {
       title,
       site: "https://nounspace.com/",
-      images: [ogImageUrl],
+      images: [ogImage],
       card: "summary_large_image",
     },
   };

--- a/src/common/lib/utils/userMetadata.tsx
+++ b/src/common/lib/utils/userMetadata.tsx
@@ -28,16 +28,18 @@ export const getUserMetadataStructure = (
 
   const ogImageUrl = `${WEBSITE_URL}/api/metadata/spaces?username=${username}&displayName=${encodedDisplayName}&pfpUrl=${encodedPfpUrl}&bio=${encodedBio}`;
 
-  const metadata = {
+  const metadata: Metadata = {
     title,
     openGraph: {
       title,
       url: spaceUrl,
+      images: [ogImageUrl],
     },
     twitter: {
       title,
-      domain: "https://nounspace.com/",
-      url: spaceUrl,
+      site: "https://nounspace.com/",
+      images: [ogImageUrl],
+      card: "summary_large_image",
     },
   };
 
@@ -52,17 +54,8 @@ export const getUserMetadataStructure = (
       },
     });
   }
-  if (pfpUrl) {
-    merge(metadata, {
-      twitter: {
-        card: pfpUrl,
-        image: ogImageUrl,
-      },
-      openGraph: {
-        image: ogImageUrl,
-      },
-    });
-  }
+
+
 
   return metadata;
 };

--- a/src/constants/app.ts
+++ b/src/constants/app.ts
@@ -3,7 +3,7 @@ export const WEBSITE_URL =
     ? typeof window !== "undefined"
       ? window.location.origin
       : `https://${process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL}`
-    : process.env.NEXT_PUBLIC_URL;
+    : process.env.NEXT_PUBLIC_URL || "https://nounspace.com";
 
 export const APP_FID = process.env.NEXT_PUBLIC_APP_FID
   ? Number(process.env.NEXT_PUBLIC_APP_FID)

--- a/src/pages/api/metadata/cast.tsx
+++ b/src/pages/api/metadata/cast.tsx
@@ -1,8 +1,10 @@
 import React from "react";
-import { NextRequest } from "next/server";
+import { NextApiRequest, NextApiResponse } from "next";
 import { ImageResponse } from "next/og";
 
-export const runtime = "edge";
+export const config = {
+  runtime: "edge",
+};
 
 interface CastCardData {
   username: string;
@@ -11,13 +13,20 @@ interface CastCardData {
   text: string;
 }
 
-export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
+export default async function GET(
+  req: NextApiRequest,
+  res: NextApiResponse<ImageResponse | string>,
+) {
+  if (!req.url) {
+    return res.status(404).send("Url not found");
+  }
+
+  const params = new URLSearchParams(req.url.split("?")[1]);
   const data: CastCardData = {
-    username: searchParams.get("username") || "",
-    displayName: searchParams.get("displayName") || "",
-    pfpUrl: searchParams.get("pfpUrl") || "",
-    text: searchParams.get("text") || "",
+    username: params.get("username") || "",
+    displayName: params.get("displayName") || "",
+    pfpUrl: params.get("pfpUrl") || "",
+    text: params.get("text") || "",
   };
 
   return new ImageResponse(<CastCard data={data} />, {

--- a/src/pages/api/metadata/cast.tsx
+++ b/src/pages/api/metadata/cast.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { NextApiRequest, NextApiResponse } from "next";
+import { ImageResponse } from "next/og";
+
+export const config = {
+  runtime: "edge",
+};
+
+interface CastCardData {
+  username: string;
+  displayName: string;
+  pfpUrl: string;
+  text: string;
+}
+
+export default async function GET(
+  req: NextApiRequest,
+  res: NextApiResponse<ImageResponse | string>,
+) {
+  if (!req.url) {
+    return res.status(404).send("Url not found");
+  }
+
+  const params = new URLSearchParams(req.url.split("?")[1]);
+  const data: CastCardData = {
+    username: params.get("username") || "",
+    displayName: params.get("displayName") || "",
+    pfpUrl: params.get("pfpUrl") || "",
+    text: params.get("text") || "",
+  };
+
+  return new ImageResponse(<CastCard data={data} />, {
+    width: 1200,
+    height: 630,
+  });
+}
+
+const CastCard = ({ data }: { data: CastCardData }) => (
+  <div
+    style={{
+      width: "100%",
+      height: "100%",
+      padding: "40px",
+      display: "flex",
+      flexDirection: "column",
+      background: "white",
+      fontFamily: "Arial, sans-serif",
+    }}
+  >
+    <div style={{ display: "flex", alignItems: "center", gap: "20px" }}>
+      {data.pfpUrl && (
+        <img
+          src={data.pfpUrl}
+          width="120"
+          height="120"
+          style={{ borderRadius: "60px" }}
+        />
+      )}
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        <span style={{ fontSize: "48px", fontWeight: "bold" }}>{data.displayName}</span>
+        <span style={{ fontSize: "36px", color: "#555" }}>@{data.username}</span>
+      </div>
+    </div>
+    <p
+      style={{
+        fontSize: "40px",
+        marginTop: "40px",
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-word",
+      }}
+    >
+      {data.text}
+    </p>
+  </div>
+);


### PR DESCRIPTION
## Summary
- User profile spaces and cast URLs were already generating dynamic metadata for their mini app thumbnails, but this wasn't implemented for standard open graph data
- This extends the dynamic meta data for cast URLs and user profile spaces to Open Graph data

Note: for some reason the built in open graph simulator in vercel is not working, but if you use https://www.opengraph.xyz/url/https%3A%2F%2Fnounspace-8usmh45dp-nounspace.vercel.app%2Fhomebase%2Fc%2Fx0x0x0x0%2F0xa466171052464af5ab9f2aaa9650088a68dea19c you can see it works

https://www.opengraph.xyz/url/https%3A%2F%2Fnounspace-8usmh45dp-nounspace.vercel.app%2Fs%2Fwillywonka.eth

<img width="470" height="641" alt="image" src="https://github.com/user-attachments/assets/104ef5db-649d-4537-a471-e3324fb5e368" />
<img width="491" height="740" alt="image" src="https://github.com/user-attachments/assets/24d3131e-7e62-4076-b031-d1dc83f08850" />


## Testing
- `npm run lint`
- `npm run check-types` *(fails: Module '../src/common/lib/utils/gridCleanup' has no exported member 'cleanupLayout')*

------
https://chatgpt.com/codex/tasks/task_e_687546aec0d48325bc3e0d140156ebb0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced dynamic metadata and Open Graph image generation for cast-related pages, enhancing link previews and sharing.
  * Added an API endpoint that generates visually rich Open Graph images for casts, displaying user profile information and cast text.
* **Bug Fixes**
  * Corrected parameter handling and improved error fallback in user profile metadata generation.
* **Improvements**
  * Streamlined and consolidated metadata structures for user and cast pages, ensuring consistent and accurate previews.
  * Enhanced reliability of website URL configuration with a fallback default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->