### PR TITLE
turned off on hover buttons when resizing

### DIFF
--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -166,6 +166,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   }>();
   const [selectedFidgetID, setSelectedFidgetID] = useState("");
   const [currentlyDragging, setCurrentlyDragging] = useState(false);
+  const [currentlyResizing, setCurrentlyResizing] = useState(false);
   const [currentFidgetSettings, setCurrentFidgetSettings] =
     useState<React.ReactNode>(<></>);
   const [isPickingFidget, setIsPickingFidget] = useState(false);
@@ -713,7 +714,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   // CSS Grid auto-placement overlay component
   const GridOverlay = ({ inEditMode }: { inEditMode: boolean }) => {
     // Don't show overlay during interactions that should block it, or when over control buttons
-    if (!inEditMode || currentlyDragging || isMouseOverControlButtons) {
+    if (!inEditMode || currentlyDragging || currentlyResizing || isMouseOverControlButtons) {
       return null;
     }
 
@@ -837,6 +838,8 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
               droppingItem={externalDraggedItem}
               onDrop={handleDrop}
               onLayoutChange={saveLayoutConditional}
+              onResizeStart={() => setCurrentlyResizing(true)}
+              onResizeStop={() => setCurrentlyResizing(false)}
               className={`grid-overlap ${itemsVisible ? "items-visible" : ""} z-10`}
               style={{
                 height: rowHeight * memoizedGridDetails.maxRows + "px",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved grid interaction by hiding the overlay while resizing grid items, ensuring a smoother user experience during resize operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->