### PR TITLE
Fix proposal space lookup issues

### DIFF
--- a/src/app/(spaces)/p/[proposalId]/ProposalPrimarySpaceContent.tsx
+++ b/src/app/(spaces)/p/[proposalId]/ProposalPrimarySpaceContent.tsx
@@ -34,8 +34,16 @@ const ProposalPrimarySpaceContent: React.FC<ProposalPrimarySpaceContentProps> = 
             setSpaceId(fetched);
             setCurrentSpaceId(fetched);
           }
-        } catch {
-          // ignore - space might not exist yet
+        } catch (error) {
+          if (
+            axios.isAxiosError(error) &&
+            error.response?.status === 404 &&
+            error.response.data?.error?.message === "Space not found"
+          ) {
+            // ignore - space might not exist yet
+          } else {
+            console.error("Error fetching proposal space:", error);
+          }
         } finally {
           setIsLoading(false);
         }

--- a/src/app/(spaces)/p/[proposalId]/utils.ts
+++ b/src/app/(spaces)/p/[proposalId]/utils.ts
@@ -21,6 +21,10 @@ export interface ProposalData {
   status?: string;
 }
 
+interface ProposalSpaceRow {
+  spaceId: string;
+}
+
 // Helper function to create timeout signal compatible with Edge runtime
 function createTimeoutSignal(ms: number): AbortSignal {
   const controller = new AbortController();
@@ -208,7 +212,7 @@ export async function loadProposalSpaceId(proposalId: string): Promise<string | 
       console.error("Error fetching proposal space id:", error);
       return null;
     }
-    return data && data.length > 0 ? (data[0] as any).spaceId : null;
+    return data && data.length > 0 ? (data as ProposalSpaceRow[])[0].spaceId : null;
   } catch (e) {
     console.error("Exception in loadProposalSpaceId:", e);
     return null;

--- a/src/app/(spaces)/s/[handle]/ProfileSpace.tsx
+++ b/src/app/(spaces)/s/[handle]/ProfileSpace.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useMemo } from "react";
 import { isArray, isNil } from "lodash";
 import SpaceNotFound from "@/app/(spaces)/SpaceNotFound";
 import createIntialPersonSpaceConfigForFid from "@/constants/initialPersonSpace";
@@ -25,9 +25,13 @@ export const ProfileSpace = ({
     return <SpaceNotFound />;
   }
 
-  const INITIAL_PERSONAL_SPACE_CONFIG = createIntialPersonSpaceConfigForFid(
-    spaceOwnerFid,
-    spaceOwnerUsername ?? undefined,
+  const INITIAL_PERSONAL_SPACE_CONFIG = useMemo(
+    () =>
+      createIntialPersonSpaceConfigForFid(
+        spaceOwnerFid,
+        spaceOwnerUsername ?? undefined,
+      ),
+    [spaceOwnerFid, spaceOwnerUsername],
   );
 
   const getSpacePageUrl = (tabName: string) => {

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -100,7 +100,6 @@ interface LocalSpace extends CachedSpace {
     [newName: string]: string;
   };
   fid?: number | null;
-  proposalId?: string | null;
 }
 
 interface SpaceState {
@@ -1096,7 +1095,7 @@ export const createSpaceStoreFunc = (
                   contractAddress: spaceInfo.contractAddress,
                   network: spaceInfo.network,
                   fid: spaceInfo.fid,
-                  proposalId: (spaceInfo as any).proposalId,
+                  proposalId: spaceInfo.proposalId,
                 };
               }
             });

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -988,24 +988,34 @@ export const createSpaceStoreFunc = (
   },
   registerProposalSpace: async (proposalId, initialConfig) => {
     try {
-      // Check if a space already exists for this proposal
-      const { data: existingSpaces } = await axiosBackend.get<ModifiableSpacesResponse>(
-        "/api/space/registry",
-        {
-          params: {
-            identityPublicKey: get().account.currentSpaceIdentityPublicKey,
-            proposalId,
-          },
-        },
-      );
+      let existingSpaceId: string | undefined;
 
-      if (existingSpaces.value) {
-        const existingSpace = existingSpaces.value.spaces.find(
-          (space) => space.proposalId === proposalId
+      // Check if a space already exists for this proposal
+      try {
+        const { data: existingSpaces } = await axiosBackend.get<ModifiableSpacesResponse>(
+          "/api/space/registry",
+          {
+            params: {
+              identityPublicKey: get().account.currentSpaceIdentityPublicKey,
+              proposalId,
+            },
+          },
         );
-        if (existingSpace) {
-          return existingSpace.spaceId;
+
+        if (existingSpaces.value) {
+          const existingSpace = existingSpaces.value.spaces.find(
+            (space) => space.proposalId === proposalId
+          );
+          if (existingSpace) {
+            existingSpaceId = existingSpace.spaceId;
+          }
         }
+      } catch (checkError) {
+        console.error("Error checking for existing proposal space:", checkError);
+      }
+
+      if (existingSpaceId) {
+        return existingSpaceId;
       }
 
       // Register a new space for the proposal


### PR DESCRIPTION
## Summary
- handle unexpected proposal space fetch errors
- clean up typing for proposal space data
- memoize profile space config
- drop redundant proposalId property

## Testing
- `npm run lint`
- `npm run check-types` *(fails: Module '../src/common/lib/utils/gridCleanup' has no exported member 'cleanupLayout')*

------
https://chatgpt.com/codex/tasks/task_e_6876a3e245c48325b3adafaabc20f544