### PR TITLE
fix: improve image cropping behavior in feeds

### DIFF
--- a/src/common/components/molecules/ExpandOnClick.tsx
+++ b/src/common/components/molecules/ExpandOnClick.tsx
@@ -4,9 +4,10 @@ import { Dialog, DialogContent } from "@/common/components/atoms/dialog";
 
 interface ExpandOnClickProps {
   children: React.ReactNode;
+  expandedChildren?: React.ReactNode;
 }
 
-const ExpandOnClick: React.FC<ExpandOnClickProps> = ({ children }) => {
+const ExpandOnClick: React.FC<ExpandOnClickProps> = ({ children, expandedChildren }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleOpen = useCallback((e: React.MouseEvent) => {
@@ -27,13 +28,11 @@ const ExpandOnClick: React.FC<ExpandOnClickProps> = ({ children }) => {
       </div>
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
         <DialogContent
-          className="p-0 bg-transparent border-none shadow-none max-w-[max-content]"
+          className="p-0 bg-transparent border-none shadow-none max-w-fit max-h-fit"
           onOpenAutoFocus={onOpenAutoFocus}
           showCloseButton={false}
         >
-          <div className="max-w-[calc(100vw-88px)] max-h-[calc(100vh-88px)] rounded-lg overflow-hidden">
-            {children}
-          </div>
+          {expandedChildren || children}
         </DialogContent>
       </Dialog>
     </>

--- a/src/fidgets/farcaster/components/Embeds/ImageEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/ImageEmbed.tsx
@@ -8,15 +8,29 @@ const ImageEmbed = ({ url }: { url: string }) => {
     console.debug("error loading image", url);
   }, [url]);
 
-  return (
-    <ExpandOnClick>
+  const collapsedImage = (
+    <LazyImage
+      className="object-cover w-full h-full max-h-[500px] rounded-lg"
+      src={url}
+      onError={onError}
+      referrerPolicy="no-referrer"
+      alt="Embedded image"
+    />
+  );
+
+  const expandedImage = (
       <LazyImage
-        className="object-contain size-full max-h-[inherit]"
+        className="object-contain max-w-[95vw] max-h-[95vh] rounded-lg"
         src={url}
         onError={onError}
         referrerPolicy="no-referrer"
         alt="Embedded image"
       />
+  );
+
+  return (
+    <ExpandOnClick expandedChildren={expandedImage}>
+      {collapsedImage}
     </ExpandOnClick>
   );
 };


### PR DESCRIPTION
## Changes

### Modified Files
- `src/common/components/molecules/ExpandOnClick.tsx`
- `src/fidgets/farcaster/components/Embeds/ImageEmbed.tsx`


### Features Added
- **Enhanced image cropping behavior** to match Farcaster UX
- **Dual-state image rendering** (collapsed vs expanded)


### Technical Changes
- Added `expandedChildren` prop to `ExpandOnClick` component
- Implemented `object-cover` for collapsed images (proper cropping)
- Implemented `object-contain` for expanded images (full display)


before : 

<img width="822" height="902" alt="Captura_de_tela_de_2025-07-16_12-36-03" src="https://github.com/user-attachments/assets/d81682e8-fdd9-4ea8-8e12-d991f9f67dfe" />

after : 
<img width="738" height="900" alt="Captura_de_tela_de_2025-07-16_12-35-51" src="https://github.com/user-attachments/assets/222758b6-15f7-48f3-9f1a-3f1495af8f32" />

