### PR TITLE
Fix channel follow button

### DIFF
--- a/src/fidgets/farcaster/utils.ts
+++ b/src/fidgets/farcaster/utils.ts
@@ -148,11 +148,11 @@ export const unfollowUser = async (
 
 export const followChannel = async (
   channelId: string,
-  signerUuid: string,
+  signer: Signer,
 ) => {
   try {
     await axiosBackend.post("/api/farcaster/neynar/channel-follow", {
-      signer_uuid: signerUuid,
+      signer: Signer,
       channel_id: channelId,
     });
     return true;
@@ -163,11 +163,11 @@ export const followChannel = async (
 
 export const unfollowChannel = async (
   channelId: string,
-  signerUuid: string,
+  signer: Signer,
 ) => {
   try {
     await axiosBackend.delete("/api/farcaster/neynar/channel-follow", {
-      data: { signer_uuid: signerUuid, channel_id: channelId },
+      data: { signer: Signer, channel_id: channelId },
     });
     return true;
   } catch (e) {

--- a/src/fidgets/farcaster/utils.ts
+++ b/src/fidgets/farcaster/utils.ts
@@ -146,6 +146,35 @@ export const unfollowUser = async (
   return false;
 };
 
+export const followChannel = async (
+  channelId: string,
+  signerUuid: string,
+) => {
+  try {
+    await axiosBackend.post("/api/farcaster/neynar/channel-follow", {
+      signer_uuid: signerUuid,
+      channel_id: channelId,
+    });
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+export const unfollowChannel = async (
+  channelId: string,
+  signerUuid: string,
+) => {
+  try {
+    await axiosBackend.delete("/api/farcaster/neynar/channel-follow", {
+      data: { signer_uuid: signerUuid, channel_id: channelId },
+    });
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
 export const submitCast = async (
   signedCastMessage: Message,
   fid: number,

--- a/src/fidgets/farcaster/utils.ts
+++ b/src/fidgets/farcaster/utils.ts
@@ -152,7 +152,7 @@ export const followChannel = async (
 ) => {
   try {
     await axiosBackend.post("/api/farcaster/neynar/channel-follow", {
-      signer: Signer,
+      signer,
       channel_id: channelId,
     });
     return true;
@@ -167,7 +167,7 @@ export const unfollowChannel = async (
 ) => {
   try {
     await axiosBackend.delete("/api/farcaster/neynar/channel-follow", {
-      data: { signer: Signer, channel_id: channelId },
+      data: { signer, channel_id: channelId },
     });
     return true;
   } catch (e) {

--- a/src/fidgets/farcaster/utils.ts
+++ b/src/fidgets/farcaster/utils.ts
@@ -152,7 +152,7 @@ export const followChannel = async (
 ) => {
   try {
     await axiosBackend.post("/api/farcaster/neynar/channel-follow", {
-      signer,
+      signer_uuid: signer,
       channel_id: channelId,
     });
     return true;
@@ -167,7 +167,7 @@ export const unfollowChannel = async (
 ) => {
   try {
     await axiosBackend.delete("/api/farcaster/neynar/channel-follow", {
-      data: { signer, channel_id: channelId },
+      data: { signer_uuid: signer, channel_id: channelId },
     });
     return true;
   } catch (e) {

--- a/src/pages/api/farcaster/neynar/channel-follow.ts
+++ b/src/pages/api/farcaster/neynar/channel-follow.ts
@@ -1,0 +1,54 @@
+import requestHandler from "@/common/data/api/requestHandler";
+import axios, { AxiosRequestConfig, isAxiosError } from "axios";
+import { NextApiRequest, NextApiResponse } from "next/types";
+
+async function followChannel(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const options: AxiosRequestConfig = {
+      method: "POST",
+      url: "https://api.neynar.com/v2/farcaster/channel/follow/",
+      headers: {
+        accept: "application/json",
+        "x-api-key": process.env.NEYNAR_API_KEY!,
+        "Content-Type": "application/json",
+      },
+      data: req.body,
+    };
+    const { data } = await axios.request(options);
+    res.status(200).json(data);
+  } catch (e) {
+    if (isAxiosError(e)) {
+      res.status(e.response?.status || 500).json(e.response?.data || "An unknown error occurred");
+    } else {
+      res.status(500).json("An unknown error occurred");
+    }
+  }
+}
+
+async function unfollowChannel(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const options: AxiosRequestConfig = {
+      method: "DELETE",
+      url: "https://api.neynar.com/v2/farcaster/channel/follow/",
+      headers: {
+        accept: "application/json",
+        "x-api-key": process.env.NEYNAR_API_KEY!,
+        "Content-Type": "application/json",
+      },
+      data: req.body,
+    };
+    const { data } = await axios.request(options);
+    res.status(200).json(data);
+  } catch (e) {
+    if (isAxiosError(e)) {
+      res.status(e.response?.status || 500).json(e.response?.data || "An unknown error occurred");
+    } else {
+      res.status(500).json("An unknown error occurred");
+    }
+  }
+}
+
+export default requestHandler({
+  post: followChannel,
+  delete: unfollowChannel,
+});


### PR DESCRIPTION
## Summary
- add Neynar channel follow API route
- support following/unfollowing a channel from utils
- wire channel fidget to use Farcaster signer and toggle follow state

## Testing
- `npm run lint`
- `npm run check-types` *(fails: Module '../src/common/lib/utils/gridCleanup' has no exported member 'cleanupLayout')*

------
https://chatgpt.com/codex/tasks/task_e_687abf8714148325b4e6bec300ba473a