### PR TITLE
[WIP - DRAFT] - refactor(images): simplify remotePatterns for image loading

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -41,34 +41,12 @@ const nextConfig = {
   images: {
     remotePatterns: [
       {
-        hostname: "nouns.com",
         protocol: "https",
-        pathname: "*",
+        hostname: "**",
       },
       {
-        hostname: "*",
-        protocol: "https",
-        pathname: "**/*.png",
-      },
-      {
-        hostname: "*",
-        protocol: "https",
-        pathname: "**/*.jpg",
-      },
-      {
-        hostname: "*",
-        protocol: "https",
-        pathname: "**/*.jpeg",
-      },
-      {
-        hostname: "*",
-        protocol: "https",
-        pathname: "**/*.gif",
-      },
-      {
-        hostname: "*",
-        protocol: "https",
-        pathname: "**/*.webp",
+        protocol: "http",
+        hostname: "**",
       },
     ],
   },


### PR DESCRIPTION
This pull request simplifies the configuration for remote image patterns in the `next.config.mjs` file by consolidating and generalizing the allowed patterns.

### Configuration simplification:

* [`next.config.mjs`](diffhunk://#diff-18c049b08c4a0f5ab451c598aeb2c4848bb9d7877b51ca3e5effb94a225814d2L44-R49): Replaced specific `hostname`, `protocol`, and `pathname` patterns for remote images with generalized patterns using `**` for `hostname` and allowing both `https` and `http` protocols. This reduces redundancy and simplifies the configuration.


It was causing forbidden image errors in miniapps. I believe we dont need to be that strict and we might have other ways to pre-load the homepage iframes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Broadened support for remote images by allowing all protocols, hostnames, and file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->