### PR TITLE
Fix contract space registration

### DIFF
--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -875,14 +875,14 @@ export const createSpaceStoreFunc = (
         return existingSpace.id;
       }
 
-      // Check if a space already exists for this contract
+      // Check if a space already exists for this contract that the current
+      // identity can modify. We query all modifiable spaces for the identity
+      // and then search for one matching the contract address and network.
       const { data: existingSpaces } = await axiosBackend.get<ModifiableSpacesResponse>(
         "/api/space/registry",
         {
           params: {
             identityPublicKey: get().account.currentSpaceIdentityPublicKey,
-            contractAddress: address,
-            network: network,
           },
         },
       );


### PR DESCRIPTION
Fixes an issue in prod where new token spaces are not successfully being registered when visited by the owner/deployer.

Steps to repro:
1. visit an unregistered token space as the owner/deployer

expected result:
1. token space is automatically registered and you can customize

actual result:
1. token space is not registered

after this fix:
1. token space is registered and you can successfully customize

## Summary
- ensure contract space lookup fetches modifiable spaces correctly

## Testing
- `npm run lint`
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_68815c6b48c48325ba83e8503c194453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved comments to clarify how spaces are fetched and filtered based on user identity, contract address, and network.

* **Refactor**
  * Updated the way spaces are retrieved by changing the backend query to filter only by user identity, with further filtering handled on the client side.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->