### PR TITLE
DRAFT: add farcaster signer to frame components

### DIFF
--- a/src/fidgets/farcaster/components/Embeds/FrameV2Embed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/FrameV2Embed.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import FrameRenderer from "@/fidgets/framesV2/components/FrameRenderer";
+import { useFarcasterSigner } from "@/fidgets/farcaster/index";
 
 interface FrameV2EmbedProps {
   url: string;
@@ -7,6 +8,8 @@ interface FrameV2EmbedProps {
 }
 
 const FrameV2Embed: React.FC<FrameV2EmbedProps> = ({ url }) => {
+  const { fid } = useFarcasterSigner("frame-v2-embed");
+  const isConnected = fid > 0;
   return (
     <div
       style={{
@@ -37,6 +40,8 @@ const FrameV2Embed: React.FC<FrameV2EmbedProps> = ({ url }) => {
           frameUrl={url}
           collapsed={true} // Always use collapsed mode for inline cast embeds
           showTitle={false} // No title in cast embeds to save space for feed
+          isConnected={isConnected}
+          fid={isConnected ? fid : undefined}
         />
       </div>
     </div>

--- a/src/fidgets/framesV2/components/FramesFidget.tsx
+++ b/src/fidgets/framesV2/components/FramesFidget.tsx
@@ -12,6 +12,7 @@ import { defaultStyleFields, ErrorWrapper } from "@/fidgets/helpers";
 import SwitchButton from "@/common/components/molecules/SwitchButton";
 import { BsCloud, BsCloudFill } from "react-icons/bs";
 import FrameRenderer from "./FrameRenderer";
+import { useFarcasterSigner } from "@/fidgets/farcaster/index";
 
 export type FramesFidgetSettings = {
   url: string;
@@ -97,6 +98,8 @@ const frameConfig: FidgetProperties = {
 const FramesFidget: React.FC<FidgetArgs<FramesFidgetSettings>> = ({
   settings: { url, collapsed = false, title, headingFont },
 }) => {
+  const { fid } = useFarcasterSigner("frames-fidget");
+  const isConnected = fid > 0;
   if (!url) {
     return (
       <ErrorWrapper icon="➕" message="Provide a Frame URL to display here." />
@@ -113,6 +116,8 @@ const FramesFidget: React.FC<FidgetArgs<FramesFidgetSettings>> = ({
       title={title}
       headingFont={headingFont}
       showTitle={true}
+      isConnected={isConnected}
+      fid={isConnected ? fid : undefined}
     />
   );
 };


### PR DESCRIPTION
## Summary
- integrate Farcaster signer into FramesFidget for connection-aware rendering
- supply Farcaster credentials to FrameV2Embed renderer

## Testing
- `npm run lint`
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_689149de9304832c90ba898435ef7948