### PR TITLE
allow nogglesboard.wtf website embed

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -17,7 +17,7 @@ const cspHeader = `
     object-src 'none';
     base-uri 'self';
     form-action 'self';
-    frame-ancestors 'self' https://farcaster.xyz https://*.farcaster.xyz https://wallet.coinbase.com https://*.coinbase.com https://base.org https://*.base.org;
+    frame-ancestors 'self' https://nogglesboard.wtf https://farcaster.xyz https://*.farcaster.xyz https://wallet.coinbase.com https://*.coinbase.com https://base.org https://*.base.org;
     frame-src 'self' https://auth.privy.nounspace.com https://verify.walletconnect.com https://verify.walletconnect.org https://challenges.cloudflare.com https://www.youtube.com https://*;
     child-src 'self' https://auth.privy.nounspace.com https://verify.walletconnect.com https://verify.walletconnect.org https://www.youtube.com https://*;
     connect-src 'self' ${process.env.NEXT_PUBLIC_SUPABASE_URL} https://auth.privy.nounspace.com https://privy.nounspace.com/api/v1/analytics_events wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org https://*.rpc.privy.systems https://auth.privy.io https://auth.privy.io/api/v1/apps/clw9qpfkl01nnpox6rcsb5wy3 wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org https://*.rpc.privy.systems;


### PR DESCRIPTION
This pull request makes a small update to the Content Security Policy (CSP) configuration. The change allows the site to be embedded as a frame on `nogglesboard.wtf` in addition to the previously allowed domains.

* Updated the `frame-ancestors` directive in the CSP header within `next.config.mjs` to include `https://nogglesboard.wtf` as an allowed framing source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security settings to allow the site to be embedded within an additional external domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->