### PR TITLE
chore: warn when segment key missing

### DIFF
--- a/src/common/providers/AnalyticsProvider.tsx
+++ b/src/common/providers/AnalyticsProvider.tsx
@@ -53,11 +53,15 @@ const AnalyticsProviderContent: React.FC<{ children: ReactNode }> = ({
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    if (writeKey) {
-      segment.load({ writeKey }).catch((e) => {
+    if (!writeKey) {
+      console.warn("NEXT_PUBLIC_SEGMENT_WRITE_KEY is not defined; analytics disabled");
+      return;
+    }
+    segment
+      .load({ writeKey })
+      .catch((e) => {
         console.error(e);
       });
-    }
   }, [writeKey]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- log a warning when Segment key is missing so analytics load can be skipped safely

## Testing
- `npm run lint`
- `npm run check-types`
- `NEXT_PUBLIC_SEGMENT_WRITE_KEY=dummy npm run build` *(fails: terminated due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68939342de5c8325a1a8d33dd94bb526