### PR TITLE
chore: allow data and Google font sources

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,7 +13,7 @@ const cspHeader = `
     script-src 'self' 'unsafe-eval' 'unsafe-inline' https://challenges.cloudflare.com https://www.youtube.com/iframe_api https://auth.privy.nounspace.com;
     style-src 'self' 'unsafe-inline' https://i.ytimg.com https://mint.highlight.xyz;
     img-src 'self' blob: data: https:;
-    font-src 'self' https: data: https://fonts.googleapis.com https://fonts.gstatic.com;
+    font-src 'self' https: data: blob: https://fonts.googleapis.com https://fonts.gstatic.com;
     object-src 'none';
     base-uri 'self';
     form-action 'self';

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,7 +13,7 @@ const cspHeader = `
     script-src 'self' 'unsafe-eval' 'unsafe-inline' https://challenges.cloudflare.com https://www.youtube.com/iframe_api https://auth.privy.nounspace.com;
     style-src 'self' 'unsafe-inline' https://i.ytimg.com https://mint.highlight.xyz;
     img-src 'self' blob: data: https:;
-    font-src 'self' https:;
+    font-src 'self' https: data: https://fonts.googleapis.com https://fonts.gstatic.com;
     object-src 'none';
     base-uri 'self';
     form-action 'self';


### PR DESCRIPTION
## Summary
- allow data URL fonts and Google Fonts in CSP

## Testing
- `npm run lint`
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_6893bfcdc1508325bd7515464bfb1a27