### PR TITLE
chore: allow youtube scripts

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,7 +10,7 @@ const withBundleAnalyzer = bundlerAnalyzer({
 
 const cspHeader = `
     default-src 'self';
-    script-src 'self' 'unsafe-eval' 'unsafe-inline' https://challenges.cloudflare.com https://www.youtube.com/iframe_api https://auth.privy.nounspace.com;
+    script-src 'self' 'unsafe-eval' 'unsafe-inline' https://challenges.cloudflare.com https://www.youtube.com https://www.youtube.com/iframe_api https://auth.privy.nounspace.com;
     style-src 'self' 'unsafe-inline' https://i.ytimg.com https://mint.highlight.xyz;
     img-src 'self' blob: data: https:;
     font-src 'self' https:;


### PR DESCRIPTION
## Summary
- allow loading scripts from youtube

## Testing
- `npm run lint`
- `npm run check-types`
- `npm test` *(fails: connect ECONNREFUSED)*


------
https://chatgpt.com/codex/tasks/task_e_6893bfcf358c832598eaebef5c2535fd