### PR TITLE
chore: allow walletconnect explorer in csp

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,7 +20,7 @@ const cspHeader = `
     frame-ancestors 'self' https://farcaster.xyz https://*.farcaster.xyz https://wallet.coinbase.com https://*.coinbase.com https://base.org https://*.base.org https://nogglesboard.wtf https://*.nogglesboard.wtf;
     frame-src 'self' https://auth.privy.nounspace.com https://verify.walletconnect.com https://verify.walletconnect.org https://challenges.cloudflare.com https://www.youtube.com https://*;
     child-src 'self' https://auth.privy.nounspace.com https://verify.walletconnect.com https://verify.walletconnect.org https://www.youtube.com https://*;
-    connect-src 'self' ${process.env.NEXT_PUBLIC_SUPABASE_URL} https://auth.privy.nounspace.com https://privy.nounspace.com/api/v1/analytics_events wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org https://*.rpc.privy.systems https://auth.privy.io https://auth.privy.io/api/v1/apps/clw9qpfkl01nnpox6rcsb5wy3 wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org https://*.rpc.privy.systems;
+    connect-src 'self' ${process.env.NEXT_PUBLIC_SUPABASE_URL} https://auth.privy.nounspace.com https://privy.nounspace.com/api/v1/analytics_events wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org https://*.rpc.privy.systems https://auth.privy.io https://auth.privy.io/api/v1/apps/clw9qpfkl01nnpox6rcsb5wy3 wss://relay.walletconnect.com wss://relay.walletconnect.org wss://www.walletlink.org https://*.rpc.privy.systems https://explorer-api.walletconnect.com;
     upgrade-insecure-requests;
 `;
 


### PR DESCRIPTION
## Summary
- allow WalletConnect Explorer API domain in `connect-src`
- prevent this error:
<img width="379" height="202" alt="image" src="https://github.com/user-attachments/assets/49d02078-2449-4143-9002-1b8247f5a083" />


## Testing
- `npm run lint`
- `npm run check-types`
- `node -e "import('./next.config.mjs').then(m=>m.default.headers()).then(h=>console.log(JSON.stringify(h,null,2)))"`
- `curl 'https://explorer-api.walletconnect.com/v3/wallets?projectId=invalid'`


------
https://chatgpt.com/codex/tasks/task_e_6893bfc79a348325a69e2192c9bbe4b9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security settings to allow connections to an additional external service, improving compatibility with certain wallet features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->