### PR TITLE
chore: relax font-src directive

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,7 +13,7 @@ const cspHeader = `
     script-src 'self' 'unsafe-eval' 'unsafe-inline' https://challenges.cloudflare.com https://www.youtube.com/iframe_api https://auth.privy.nounspace.com;
     style-src 'self' 'unsafe-inline' https://i.ytimg.com https://mint.highlight.xyz;
     img-src 'self' blob: data: https:;
-    font-src 'self' https:;
+    font-src 'self' https: data: blob: https://fonts.googleapis.com https://fonts.gstatic.com;
     object-src 'none';
     base-uri 'self';
     form-action 'self';


### PR DESCRIPTION
## Summary
- relax `font-src` in CSP to allow data and blob sources along with Google Fonts

## Testing
- `npm run lint`
- `npm run check-types`
- `npm run build` *(fails: JavaScript heap out of memory)*
- `curl -I http://localhost:3000` *(308 redirect without CSP header)*


------
https://chatgpt.com/codex/tasks/task_e_6894d2a15ba483259cf1e41297135df2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security settings to allow fonts from additional trusted sources, improving compatibility with various font providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->