### PR TITLE
🛹 refactor: optimize dynamic import for ReactGridLayout and update lodash imports

### DIFF
--- a/src/common/components/organisms/FidgetTray.tsx
+++ b/src/common/components/organisms/FidgetTray.tsx
@@ -1,5 +1,5 @@
 import React, { Dispatch, SetStateAction } from "react";
-import { map } from "lodash";
+import map from "lodash/map";
 import { FidgetBundle, FidgetInstanceData } from "@/common/fidgets";
 import { CompleteFidgets } from "@/fidgets";
 import { Button } from "@/common/components/atoms/button";

--- a/src/common/components/organisms/FidgetTray.tsx
+++ b/src/common/components/organisms/FidgetTray.tsx
@@ -4,17 +4,10 @@ import { FidgetBundle, FidgetInstanceData } from "@/common/fidgets";
 import { CompleteFidgets } from "@/fidgets";
 import { Button } from "@/common/components/atoms/button";
 import AddFidgetIcon from "@/common/components/atoms/icons/AddFidget";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-  TooltipProvider,
-} from "@/common/components/atoms/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/common/components/atoms/tooltip";
 import { FaInfoCircle } from "react-icons/fa";
 export interface FidgetTrayProps {
-  setExternalDraggedItem: Dispatch<
-    SetStateAction<{ i: string; w: number; h: number } | undefined>
-  >;
+  setExternalDraggedItem: Dispatch<SetStateAction<{ i: string; w: number; h: number } | undefined>>;
   contents: FidgetInstanceData[];
   openFidgetPicker: () => void;
   saveTrayContents: (fidgetTrayContents: FidgetInstanceData[]) => Promise<void>;
@@ -33,13 +26,13 @@ export const FidgetTray: React.FC<FidgetTrayProps> = ({
   selectFidget,
 }) => {
   const hasContents = contents.length > 0;
-  
+
   return (
     <div className="w-full h-screen flex flex-col justify-start items-center gap-2 bg-sky-50 py-7 px-6 overflow-auto">
-      <div 
+      <div
         className={`
           transition-all duration-300 ease-in-out w-full flex flex-col justify-start items-center gap-2
-          ${hasContents ? 'opacity-100 delay-150' : 'opacity-0 delay-0'}
+          ${hasContents ? "opacity-100 delay-150" : "opacity-0 delay-0"}
         `}
       >
         <TooltipProvider>
@@ -60,9 +53,7 @@ export const FidgetTray: React.FC<FidgetTrayProps> = ({
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
-        <h5 className="text-xs font-medium text-center -mx-3 mb-3">
-          Fidget Tray
-        </h5>
+        <h5 className="text-xs font-medium text-center -mx-3 mb-3">Fidget Tray</h5>
         {map(contents, (fidgetData: FidgetInstanceData) => {
           const fidgetBundle = {
             ...fidgetData,
@@ -79,9 +70,7 @@ export const FidgetTray: React.FC<FidgetTrayProps> = ({
             <div key={fidgetData.id} className="w-full">
               <div
                 className={`z-20 droppable-element px-2 py-2 flex justify-center items-center border rounded-md hover:bg-sky-100 group cursor-pointer ${
-                  selectedFidgetID === fidgetData.id
-                    ? "outline outline-4 outline-offset-1 outline-sky-600"
-                    : ""
+                  selectedFidgetID === fidgetData.id ? "outline outline-4 outline-offset-1 outline-sky-600" : ""
                 }`}
                 draggable={true}
                 // unselectable helps with IE support
@@ -90,22 +79,15 @@ export const FidgetTray: React.FC<FidgetTrayProps> = ({
                 onClick={onClick}
                 onDragStart={(e) => {
                   setCurrentlyDragging(true);
-                  e.dataTransfer.setData(
-                    "text/plain",
-                    JSON.stringify(fidgetData),
-                  );
+                  e.dataTransfer.setData("text/plain", JSON.stringify(fidgetData));
                   setExternalDraggedItem({
                     i: fidgetData.id,
-                    w: CompleteFidgets[fidgetData.fidgetType].properties.size
-                      .minWidth,
-                    h: CompleteFidgets[fidgetData.fidgetType].properties.size
-                      .minHeight,
+                    w: CompleteFidgets[fidgetData.fidgetType].properties.size.minWidth,
+                    h: CompleteFidgets[fidgetData.fidgetType].properties.size.minHeight,
                   });
                 }}
               >
-                {String.fromCodePoint(
-                  CompleteFidgets[fidgetData.fidgetType].properties.icon,
-                )}
+                {String.fromCodePoint(CompleteFidgets[fidgetData.fidgetType].properties.icon)}
               </div>
             </div>
           );

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -4,7 +4,7 @@ import { useAppStore, useLogout } from "@/common/data/stores/app";
 import { mergeClasses } from "@/common/lib/utils/mergeClasses";
 import { useFarcasterSigner } from "@/fidgets/farcaster";
 import CreateCast from "@/fidgets/farcaster/components/CreateCast";
-import { first } from "lodash";
+import first from "lodash/first";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import React, { useCallback, useMemo, useRef, useState } from "react";

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -9,11 +9,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import React, { useCallback, useMemo, useRef, useState } from "react";
 import { CgProfile } from "react-icons/cg";
-import {
-    FaChevronLeft,
-    FaChevronRight,
-    FaDiscord,
-} from "react-icons/fa6";
+import { FaChevronLeft, FaChevronRight, FaDiscord } from "react-icons/fa6";
 import { Button } from "../atoms/button";
 import BrandHeader from "../molecules/BrandHeader";
 import Modal from "../molecules/Modal";
@@ -66,20 +62,13 @@ const NavIconBadge = ({ children }) => {
   );
 };
 
-const Navigation: React.FC<NavProps> = ({
-  isEditable,
-  enterEditMode,
-  mobile = false,
-  onNavigate,
-}) => {
+const Navigation: React.FC<NavProps> = ({ isEditable, enterEditMode, mobile = false, onNavigate }) => {
   const searchRef = useRef<HTMLInputElement>(null);
-  const { setModalOpen, getIsAccountReady, getIsInitializing } = useAppStore(
-    (state) => ({
-      setModalOpen: state.setup.setModalOpen,
-      getIsAccountReady: state.getIsAccountReady,
-      getIsInitializing: state.getIsInitializing,
-    })
-  );
+  const { setModalOpen, getIsAccountReady, getIsInitializing } = useAppStore((state) => ({
+    setModalOpen: state.setup.setModalOpen,
+    getIsAccountReady: state.getIsAccountReady,
+    getIsInitializing: state.getIsInitializing,
+  }));
   const userTheme: UserTheme = useUserTheme();
 
   const logout = useLogout();
@@ -113,14 +102,7 @@ const Navigation: React.FC<NavProps> = ({
 
   const CurrentUserImage = useCallback(
     () =>
-      user && user.pfp_url ? (
-        <img
-          className="aspect-square rounded-full w-6 h-6"
-          src={user.pfp_url}
-        />
-      ) : (
-        <CgProfile />
-      ),
+      user && user.pfp_url ? <img className="aspect-square rounded-full w-6 h-6" src={user.pfp_url} /> : <CgProfile />,
     [user]
   );
 
@@ -160,13 +142,7 @@ const Navigation: React.FC<NavProps> = ({
     );
   };
 
-  const NavButton: React.FC<NavButtonProps> = ({
-    label,
-    Icon,
-    onClick,
-    disable = false,
-    badgeText = null,
-  }) => {
+  const NavButton: React.FC<NavButtonProps> = ({ label, Icon, onClick, disable = false, badgeText = null }) => {
     return (
       <li>
         <button
@@ -196,35 +172,19 @@ const Navigation: React.FC<NavProps> = ({
       id="logo-sidebar"
       className={mergeClasses(
         "border-r-2 bg-white",
-        mobile
-          ? "w-[270px]"
-          : "w-full transition-transform -translate-x-full sm:translate-x-0"
+        mobile ? "w-[270px]" : "w-full transition-transform -translate-x-full sm:translate-x-0"
       )}
       aria-label="Sidebar"
     >
-      <Modal
-        open={showCastModal}
-        setOpen={setShowCastModal}
-        focusMode={false}
-        showClose={false}
-      >
+      <Modal open={showCastModal} setOpen={setShowCastModal} focusMode={false} showClose={false}>
         <CreateCast afterSubmit={() => setShowCastModal(false)} />
       </Modal>
       <SearchModal ref={searchRef} />
-      <div
-        className={mergeClasses(
-          "pt-12 pb-12 h-full",
-          mobile ? "block" : "md:block hidden"
-        )}
-      >
+      <div className={mergeClasses("pt-12 pb-12 h-full", mobile ? "block" : "md:block hidden")}>
         <div
           className={mergeClasses(
             "flex flex-col h-full transition-all duration-300 relative",
-            mobile
-              ? "w-[270px]"
-              : shrunk
-              ? "w-[90px]"
-              : "w-[270px]"
+            mobile ? "w-[270px]" : shrunk ? "w-[90px]" : "w-[270px]"
           )}
         >
           {!mobile && (
@@ -233,11 +193,7 @@ const Navigation: React.FC<NavProps> = ({
               className="absolute right-0 top-4 transform translate-x-1/2 bg-white rounded-full border border-gray-200 shadow-sm p-2 hover:bg-gray-50 sidebar-expand-button z-50"
               aria-label={shrunk ? "Expand sidebar" : "Collapse sidebar"}
             >
-              {shrunk ? (
-                <FaChevronRight size={14} />
-              ) : (
-                <FaChevronLeft size={14} />
-              )}
+              {shrunk ? <FaChevronRight size={14} /> : <FaChevronLeft size={14} />}
             </button>
           )}
 
@@ -256,18 +212,14 @@ const Navigation: React.FC<NavProps> = ({
                   label={isLoggedIn ? "Homebase" : "Home"}
                   Icon={HomeIcon}
                   href={isLoggedIn ? "/homebase" : "/home"}
-                  onClick={() =>
-                    trackAnalyticsEvent(AnalyticsEvent.CLICK_HOMEBASE)
-                  }
+                  onClick={() => trackAnalyticsEvent(AnalyticsEvent.CLICK_HOMEBASE)}
                 />
                 {isLoggedIn && (
                   <NavItem
                     label="Notifications"
                     Icon={NotificationsIcon}
                     href="/notifications"
-                    onClick={() =>
-                      trackAnalyticsEvent(AnalyticsEvent.CLICK_NOTIFICATIONS)
-                    }
+                    onClick={() => trackAnalyticsEvent(AnalyticsEvent.CLICK_NOTIFICATIONS)}
                     badgeText={notificationBadgeText}
                   />
                 )}
@@ -283,17 +235,13 @@ const Navigation: React.FC<NavProps> = ({
                   label="Explore"
                   Icon={ExploreIcon}
                   href="/explore"
-                  onClick={() =>
-                    trackAnalyticsEvent(AnalyticsEvent.CLICK_EXPLORE)
-                  }
+                  onClick={() => trackAnalyticsEvent(AnalyticsEvent.CLICK_EXPLORE)}
                 />
                 <NavItem
                   label="$SPACE"
                   Icon={RocketIcon}
                   href="https://nounspace.com/t/base/0x48C6740BcF807d6C47C864FaEEA15Ed4dA3910Ab/Profile"
-                  onClick={() =>
-                    trackAnalyticsEvent(AnalyticsEvent.CLICK_SPACE_FAIR_LAUNCH)
-                  }
+                  onClick={() => trackAnalyticsEvent(AnalyticsEvent.CLICK_SPACE_FAIR_LAUNCH)}
                   openInNewTab
                 />
                 {isLoggedIn && (
@@ -301,18 +249,10 @@ const Navigation: React.FC<NavProps> = ({
                     label={"My Space"}
                     Icon={CurrentUserImage}
                     href={`/s/${username}`}
-                    onClick={() =>
-                      trackAnalyticsEvent(AnalyticsEvent.CLICK_MY_SPACE)
-                    }
+                    onClick={() => trackAnalyticsEvent(AnalyticsEvent.CLICK_MY_SPACE)}
                   />
                 )}
-                {isLoggedIn && (
-                  <NavButton
-                    label={"Logout"}
-                    Icon={LogoutIcon}
-                    onClick={handleLogout}
-                  />
-                )}
+                {isLoggedIn && <NavButton label={"Logout"} Icon={LogoutIcon} onClick={handleLogout} />}
                 {!isLoggedIn && (
                   <NavButton
                     label={isInitializing ? "Complete Signup" : "Login"}
@@ -324,20 +264,12 @@ const Navigation: React.FC<NavProps> = ({
             </div>
           </div>
           <div className="flex flex-col flex-auto justify-between border-t px-4">
-            <div
-              className={mergeClasses("mt-8 px-2", shrunk ? "px-0" : "px-2")}
-            >
-              <Player
-                url={userTheme?.properties?.musicURL || NOUNISH_LOWFI_URL}
-                shrunk={shrunk}
-              />
+            <div className={mergeClasses("mt-8 px-2", shrunk ? "px-0" : "px-2")}>
+              <Player url={userTheme?.properties?.musicURL || NOUNISH_LOWFI_URL} shrunk={shrunk} />
             </div>
             {isLoggedIn && (
               <div
-                className={mergeClasses(
-                  "pt-3 flex items-center gap-2 justify-center",
-                  shrunk ? "flex-col gap-1" : ""
-                )}
+                className={mergeClasses("pt-3 flex items-center gap-2 justify-center", shrunk ? "flex-col gap-1" : "")}
               >
                 <Button
                   onClick={openCastModal}
@@ -368,9 +300,7 @@ const Navigation: React.FC<NavProps> = ({
                   <FaDiscord className="text-[#5865f2] w-6 h-6" />
                   {!shrunk && "Join"}
                 </Link>
-                <div
-                  className="flex flex-col items-center text-xs text-gray-500 mt-5"
-                >
+                <div className="flex flex-col items-center text-xs text-gray-500 mt-5">
                   <Link href="/terms" className="hover:underline">
                     Terms
                   </Link>

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -63,7 +63,7 @@ function TabBar({
   isTokenPage,
   contractAddress,
   pageType,
-  isEditable
+  isEditable,
 }: TabBarProps) {
   const isMobile = useIsMobile();
   const { mobilePreview } = useMobilePreview();
@@ -116,19 +116,21 @@ function TabBar({
     switchTabTo(tabName);
 
     // Handle the remote operations in the background
-    creationPromise.then(result => {
-      if (result?.tabName) {
-        // If the tab name changed during creation, update the URL
-        if (result.tabName !== tabName) {
-          switchTabTo(result.tabName);
+    creationPromise
+      .then((result) => {
+        if (result?.tabName) {
+          // If the tab name changed during creation, update the URL
+          if (result.tabName !== tabName) {
+            switchTabTo(result.tabName);
+          }
         }
-      }
-      // Commit the tab order in the background
-      commitTabOrder();
-    }).catch(error => {
-      console.error("Failed to create tab:", error);
-      // Optionally show an error message to the user
-    });
+        // Commit the tab order in the background
+        commitTabOrder();
+      })
+      .catch((error) => {
+        console.error("Failed to create tab:", error);
+        // Optionally show an error message to the user
+      });
   }
 
   async function handleDeleteTab(tabName: string) {
@@ -158,9 +160,7 @@ function TabBar({
 
     const uniqueName = generateUniqueTabName(newName);
     await renameTab(tabName, uniqueName);
-    updateTabOrder(
-      tabList.map((name) => (name === tabName ? uniqueName : name)),
-    );
+    updateTabOrder(tabList.map((name) => (name === tabName ? uniqueName : name)));
     await commitTab(uniqueName);
     await commitTabOrder();
     switchTabTo(uniqueName);
@@ -184,33 +184,34 @@ function TabBar({
     }
   }
 
-  const handleTabClick = React.useCallback((tabName: string, e?: React.MouseEvent) => {
-    if (e) {
-      e.stopPropagation();
-      e.preventDefault();
-    }
+  const handleTabClick = React.useCallback(
+    (tabName: string, e?: React.MouseEvent) => {
+      if (e) {
+        e.stopPropagation();
+        e.preventDefault();
+      }
 
-    console.log("Tab clicked:", tabName, "Current tab:", currentTab);
+      console.log("Tab clicked:", tabName, "Current tab:", currentTab);
 
-    switchTabTo(tabName, true);
-  }, [switchTabTo]);
+      switchTabTo(tabName, true);
+    },
+    [switchTabTo]
+  );
 
   const isLoggedIn = getIsLoggedIn();
 
-
-
   return (
     <TooltipProvider>
-      <div className="flex flex-col md:flex-row justify-start md:h-16 z-30 bg-white w-full"> 
+      <div className="flex flex-col md:flex-row justify-start md:h-16 z-30 bg-white w-full">
         {isTokenPage && contractAddress && (
           <div className="flex flex-row justify-start h-16 w-full md:w-fit z-20 bg-white">
             <TokenDataHeader />
           </div>
         )}
-        <div className="flex w-full h-16 bg-white items-center justify-between"> 
+        <div className="flex w-full h-16 bg-white items-center justify-between">
           {/* Tabs Section - grows until it hits buttons */}
           <div className="flex-1 min-w-0 overflow-hidden">
-            <div className="overflow-x-auto scrollbar-hide" style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}>
+            <div className="overflow-x-auto scrollbar-hide" style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}>
               <Reorder.Group
                 as="ol"
                 axis="x"
@@ -219,31 +220,28 @@ function TabBar({
                 values={tabList}
               >
                 <AnimatePresence initial={false}>
-                  {map(
-                    inHomebase ? ["Feed", ...tabList] : tabList,
-                    (tabName: string) => (
-                      <Tab
-                        key={tabName}
-                        getSpacePageUrl={getSpacePageUrl}
-                        tabName={tabName}
-                        inEditMode={inEditMode}
-                        isSelected={currentTab === tabName}
-                        onClick={() => handleTabClick(tabName)}
-                        removeable={isEditableTab(tabName)}
-                        draggable={inEditMode}
-                        renameable={isEditableTab(tabName)}
-                        onRemove={() => handleDeleteTab(tabName)}
-                        renameTab={handleRenameTab}
-                      />
-                    )
-                  )}
+                  {map(inHomebase ? ["Feed", ...tabList] : tabList, (tabName: string) => (
+                    <Tab
+                      key={tabName}
+                      getSpacePageUrl={getSpacePageUrl}
+                      tabName={tabName}
+                      inEditMode={inEditMode}
+                      isSelected={currentTab === tabName}
+                      onClick={() => handleTabClick(tabName)}
+                      removeable={isEditableTab(tabName)}
+                      draggable={inEditMode}
+                      renameable={isEditableTab(tabName)}
+                      onRemove={() => handleDeleteTab(tabName)}
+                      renameTab={handleRenameTab}
+                    />
+                  ))}
                 </AnimatePresence>
               </Reorder.Group>
             </div>
           </div>
 
           {/* Action Buttons - pushed to right side */}
-          {(isEditable) && (
+          {isEditable && (
             <div className="flex items-center gap-2 px-2 flex-shrink-0">
               {!inEditMode && (
                 <Button
@@ -254,7 +252,7 @@ function TabBar({
                   {!isMobile && <span className="ml-2">Customize</span>}
                 </Button>
               )}
-              {(inEditMode) && (
+              {inEditMode && (
                 <Button
                   onClick={() => handleCreateTab(generateNewTabName())}
                   className="flex items-center rounded-xl p-2 bg-[#F3F4F6] hover:bg-sky-100 text-[#1C64F2] font-semibold shadow-md"

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React from "react";
 import { FaPlus, FaPaintbrush } from "react-icons/fa6";
-import { map } from "lodash";
+import map from "lodash/map";
 import { Reorder, AnimatePresence } from "framer-motion";
 import { Tab } from "../atoms/reorderable-tab";
 import { Address } from "viem";

--- a/src/common/data/loaders/contractPagePropsLoader.ts
+++ b/src/common/data/loaders/contractPagePropsLoader.ts
@@ -1,4 +1,7 @@
-import { isArray, isNil, isString, isUndefined } from "lodash";
+import isArray from "lodash/isArray";
+import isNil from "lodash/isNil";
+import isString from "lodash/isString";
+import isUndefined from "lodash/isUndefined";
 import {
   contractOwnerFromContract,
   loadViemViewOnlyContract,

--- a/src/common/data/stores/app/homebase/homebaseStore.ts
+++ b/src/common/data/stores/app/homebase/homebaseStore.ts
@@ -4,7 +4,11 @@ import axios from "axios";
 import { createClient } from "@/common/data/database/supabase/clients/component";
 import { homebasePath } from "@/constants/supabase";
 import { SignedFile } from "@/common/lib/signedFiles";
-import { cloneDeep, debounce, isArray, isUndefined, mergeWith } from "lodash";
+import cloneDeep from "lodash/cloneDeep";
+import debounce from "lodash/debounce";
+import isArray from "lodash/isArray";
+import isUndefined from "lodash/isUndefined";
+import mergeWith from "lodash/mergeWith";
 import stringify from "fast-json-stable-stringify";
 import axiosBackend from "@/common/data/api/backend";
 import {

--- a/src/common/utils/spaceEditability.ts
+++ b/src/common/utils/spaceEditability.ts
@@ -1,4 +1,4 @@
-import { isNil } from 'lodash';
+import isNil from 'lodash/isNil';
 import { Address } from 'viem';
 import { MasterToken } from '@/common/providers/TokenProvider';
 

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -1,13 +1,4 @@
-import React, {
-  DragEvent,
-  useEffect,
-  useMemo,
-  useState,
-  useCallback,
-  useRef,
-  ComponentType,
-  ErrorInfo,
-} from "react";
+import React, { DragEvent, useEffect, useMemo, useState, useCallback, useRef, ComponentType, ErrorInfo } from "react";
 import dynamic from "next/dynamic";
 import useWindowSize from "@/common/lib/hooks/useWindowSize";
 import {
@@ -25,10 +16,7 @@ import { CompleteFidgets } from "..";
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import EditorPanel from "@/common/components/organisms/EditorPanel";
-import {
-  FidgetWrapper,
-  getSettingsWithDefaults,
-} from "@/common/fidgets/FidgetWrapper";
+import { FidgetWrapper, getSettingsWithDefaults } from "@/common/fidgets/FidgetWrapper";
 import map from "lodash/map";
 import reject from "lodash/reject";
 import fromPairs from "lodash/fromPairs";
@@ -70,12 +58,7 @@ export interface PlacedGridItem extends GridItem {
   isBounded?: boolean;
 }
 
-const makeGridDetails = (
-  hasProfile: boolean,
-  hasFeed: boolean,
-  spacing: number,
-  borderRadius: string,
-) => ({
+const makeGridDetails = (hasProfile: boolean, hasFeed: boolean, spacing: number, borderRadius: string) => ({
   items: 0,
   isDroppable: true,
   isBounded: false,
@@ -124,7 +107,7 @@ interface ReactGridLayoutProps {
 
 // Loading component for the grid layout
 const GridLayoutLoader: React.FC<{ height: number }> = ({ height }) => (
-  <div 
+  <div
     className="flex items-center justify-center bg-gray-50 rounded-lg border-2 border-dashed border-gray-200"
     style={{ height: `${height}px` }}
   >
@@ -137,13 +120,13 @@ const GridLayoutLoader: React.FC<{ height: number }> = ({ height }) => (
 
 // Error component for failed grid layout loading
 const GridLayoutError: React.FC<{ height: number; onRetry: () => void }> = ({ height, onRetry }) => (
-  <div 
+  <div
     className="flex items-center justify-center bg-red-50 rounded-lg border-2 border-dashed border-red-200"
     style={{ height: `${height}px` }}
   >
     <div className="text-center">
       <p className="text-sm text-red-600 mb-2">Failed to load grid layout</p>
-      <button 
+      <button
         onClick={onRetry}
         className="px-3 py-1 text-xs bg-red-100 text-red-700 rounded hover:bg-red-200 transition-colors"
       >
@@ -154,15 +137,18 @@ const GridLayoutError: React.FC<{ height: number; onRetry: () => void }> = ({ he
 );
 
 const ReactGridLayout = dynamic(
-  () => import('react-grid-layout').then(mod => {
-    const RGL = mod.default;
-    const WidthProvider = mod.WidthProvider;
-    return WidthProvider(RGL);
-  }).catch(error => {
-    console.error('Failed to load react-grid-layout:', error);
-    throw error;
-  }),
-  { 
+  () =>
+    import("react-grid-layout")
+      .then((mod) => {
+        const RGL = mod.default;
+        const WidthProvider = RGL.WidthProvider;
+        return WidthProvider(RGL);
+      })
+      .catch((error) => {
+        console.error("Failed to load react-grid-layout:", error);
+        throw error;
+      }),
+  {
     ssr: false,
     loading: () => <GridLayoutLoader height={600} />,
   }
@@ -177,14 +163,7 @@ interface GridlinesProps {
   borderRadius: string;
 }
 
-const Gridlines: React.FC<GridlinesProps> = ({
-  maxRows,
-  cols,
-  rowHeight,
-  margin,
-  containerPadding,
-  borderRadius,
-}) => {
+const Gridlines: React.FC<GridlinesProps> = ({ maxRows, cols, rowHeight, margin, containerPadding, borderRadius }) => {
   return (
     <div
       className="absolute inset-0 grid-overlap w-full h-full opacity-50 pointer-events-none z-0"
@@ -230,7 +209,7 @@ class GridErrorBoundary extends React.Component<
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('Grid layout error:', error, errorInfo);
+    console.error("Grid layout error:", error, errorInfo);
   }
 
   render() {
@@ -257,9 +236,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   fid,
 }) => {
   // State to handle selecting, dragging, and Grid edit functionality
-  const [element, setElement] = useState<HTMLDivElement | null>(
-    portalRef.current,
-  );
+  const [element, setElement] = useState<HTMLDivElement | null>(portalRef.current);
   useEffect(() => {
     setElement(portalRef.current);
   }, []);
@@ -271,8 +248,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   const [selectedFidgetID, setSelectedFidgetID] = useState("");
   const [currentlyDragging, setCurrentlyDragging] = useState(false);
   const [currentlyResizing, setCurrentlyResizing] = useState(false);
-  const [currentFidgetSettings, setCurrentFidgetSettings] =
-    useState<React.ReactNode>(<></>);
+  const [currentFidgetSettings, setCurrentFidgetSettings] = useState<React.ReactNode>(<></>);
   const [isFidgetPickerModalOpen, setIsFidgetPickerModalOpen] = useState(false);
   const [targetPosition, setTargetPosition] = useState<{ x: number; y: number } | null>(null);
   const [gridLoadError, setGridLoadError] = useState(false);
@@ -290,58 +266,51 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
         hasProfile,
         hasFeed,
         parseInt(theme?.properties?.gridSpacing ?? "16"),
-        theme?.properties?.fidgetBorderRadius ?? "12px",
+        theme?.properties?.fidgetBorderRadius ?? "12px"
       ),
-    [
-      hasProfile,
-      hasFeed,
-      theme?.properties?.gridSpacing,
-      theme?.properties?.fidgetBorderRadius,
-    ],
+    [hasProfile, hasFeed, theme?.properties?.gridSpacing, theme?.properties?.fidgetBorderRadius]
   );
 
   // Consolidated collision detection utility
-  const isSpaceAvailable = useCallback((
-    x: number,
-    y: number,
-    w: number,
-    h: number,
-    options: {
-      checkBoundaries?: boolean;
-      excludeItemId?: string;
-    } = {}
-  ): boolean => {
-    const { checkBoundaries = false, excludeItemId } = options;
-    
-    // Check boundaries if requested
-    if (checkBoundaries) {
-      if (x + w > memoizedGridDetails.cols || y + h > memoizedGridDetails.maxRows) {
-        return false;
+  const isSpaceAvailable = useCallback(
+    (
+      x: number,
+      y: number,
+      w: number,
+      h: number,
+      options: {
+        checkBoundaries?: boolean;
+        excludeItemId?: string;
+      } = {}
+    ): boolean => {
+      const { checkBoundaries = false, excludeItemId } = options;
+
+      // Check boundaries if requested
+      if (checkBoundaries) {
+        if (x + w > memoizedGridDetails.cols || y + h > memoizedGridDetails.maxRows) {
+          return false;
+        }
+        if (x < 0 || y < 0) {
+          return false;
+        }
       }
-      if (x < 0 || y < 0) {
-        return false;
+
+      // Check for collisions with existing items
+      for (const item of layoutConfig.layout) {
+        // Skip the item we're excluding (useful for resizing/moving)
+        if (excludeItemId && item.i === excludeItemId) {
+          continue;
+        }
+
+        if (x < item.x + item.w && x + w > item.x && y < item.y + item.h && y + h > item.y) {
+          return false;
+        }
       }
-    }
-    
-    // Check for collisions with existing items
-    for (const item of layoutConfig.layout) {
-      // Skip the item we're excluding (useful for resizing/moving)
-      if (excludeItemId && item.i === excludeItemId) {
-        continue;
-      }
-      
-      if (
-        x < item.x + item.w &&
-        x + w > item.x &&
-        y < item.y + item.h &&
-        y + h > item.y
-      ) {
-        return false;
-      }
-    }
-    
-    return true;
-  }, [layoutConfig.layout, memoizedGridDetails.cols, memoizedGridDetails.maxRows]);
+
+      return true;
+    },
+    [layoutConfig.layout, memoizedGridDetails.cols, memoizedGridDetails.maxRows]
+  );
 
   const saveTrayContents = async (newTrayData: typeof fidgetTrayContents) => {
     return await saveConfig({
@@ -349,9 +318,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     });
   };
 
-  const saveFidgetInstanceDatums = async (
-    datums: typeof fidgetInstanceDatums,
-  ) => {
+  const saveFidgetInstanceDatums = async (datums: typeof fidgetInstanceDatums) => {
     return await saveConfig({
       fidgetInstanceDatums: datums,
     });
@@ -378,25 +345,24 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   }, [fidgetInstanceDatums]);
 
   const saveFidgetConfig = useCallback(
-    (id: string, fidgetType?: string) =>
-      async (newInstanceConfig: FidgetConfig<FidgetSettings>) => {
-        const currentDatums = fidgetInstanceDatumsRef.current;
-        const existing = currentDatums[id];
+    (id: string, fidgetType?: string) => async (newInstanceConfig: FidgetConfig<FidgetSettings>) => {
+      const currentDatums = fidgetInstanceDatumsRef.current;
+      const existing = currentDatums[id];
 
-        const determinedFidgetType = existing?.fidgetType ?? fidgetType ?? "unknown";
+      const determinedFidgetType = existing?.fidgetType ?? fidgetType ?? "unknown";
 
-        const updatedDatum: FidgetInstanceData = {
-          id: existing?.id ?? id,
-          fidgetType: determinedFidgetType,
-          config: newInstanceConfig,
-        };
+      const updatedDatum: FidgetInstanceData = {
+        id: existing?.id ?? id,
+        fidgetType: determinedFidgetType,
+        config: newInstanceConfig,
+      };
 
-        return await saveFidgetInstanceDatums({
-          ...currentDatums,
-          [id]: updatedDatum,
-        });
-      },
-    [saveFidgetInstanceDatums],
+      return await saveFidgetInstanceDatums({
+        ...currentDatums,
+        [id]: updatedDatum,
+      });
+    },
+    [saveFidgetInstanceDatums]
   );
 
   // Debounced save function
@@ -404,7 +370,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     debounce((config) => {
       saveConfig(config);
     }, 100),
-    [saveConfig],
+    [saveConfig]
   );
 
   function unselectFidget() {
@@ -424,16 +390,13 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   }
 
   function selectFidget(bundle: FidgetBundle) {
-    const settingsWithDefaults = getSettingsWithDefaults(
-      bundle.config.settings,
-      bundle.properties,
-    );
-    const onSave = async (
-      newSettings: FidgetSettings,
-      shouldUnselect?: boolean,
-    ) => {
+    const settingsWithDefaults = getSettingsWithDefaults(bundle.config.settings, bundle.properties);
+    const onSave = async (newSettings: FidgetSettings, shouldUnselect?: boolean) => {
       try {
-        await saveFidgetConfig(bundle.id, bundle.fidgetType)({
+        await saveFidgetConfig(
+          bundle.id,
+          bundle.fidgetType
+        )({
           ...bundle.config,
           settings: newSettings,
         });
@@ -455,7 +418,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
         onSave={onSave}
         unselect={unselectFidget}
         removeFidget={removeFidget}
-      />,
+      />
     );
   }
 
@@ -464,14 +427,14 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     return fromPairs(
       map(fidget.properties.fields, (field) => {
         return [field.fieldName, field.default];
-      }),
+      })
     );
   }
 
   function generateFidgetInstance(
     fidgetId: string,
     fidget: FidgetModule<FidgetArgs>,
-    customSettings?: Partial<FidgetSettings>,
+    customSettings?: Partial<FidgetSettings>
   ): FidgetInstanceData {
     const baseSettings = allFields(fidget);
     const finalSettings = customSettings ? { ...baseSettings, ...customSettings } : baseSettings;
@@ -491,12 +454,12 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
 
   // Common helper function to add a fidget with optional custom settings
   function addFidgetCommon(
-    fidgetId: string, 
-    fidget: FidgetModule<FidgetArgs>, 
+    fidgetId: string,
+    fidget: FidgetModule<FidgetArgs>,
     customSettings?: Partial<FidgetSettings>
   ) {
     const newFidgetInstanceData = generateFidgetInstance(fidgetId, fidget, customSettings);
-    
+
     // Create a new copy of fidgetInstanceDatums and add the new fidget instance
     const newFidgetInstanceDatums = {
       ...fidgetInstanceDatums,
@@ -531,8 +494,8 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
 
   // Add fidget with custom settings to grid if space is available, otherwise add to tray
   function addFidgetWithCustomSettings(
-    fidgetId: string, 
-    fidget: FidgetModule<FidgetArgs>, 
+    fidgetId: string,
+    fidget: FidgetModule<FidgetArgs>,
     customSettings: Partial<FidgetSettings>
   ) {
     addFidgetCommon(fidgetId, fidget, customSettings);
@@ -549,23 +512,17 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
           memoizedGridDetails.margin[0] * (memoizedGridDetails.maxRows - 1) -
           memoizedGridDetails.containerPadding[0] * 2) /
           memoizedGridDetails.maxRows
-              : memoizedGridDetails.rowHeight;
+      : memoizedGridDetails.rowHeight;
   }, [
-    height, 
-    hasProfile, 
-    memoizedGridDetails.margin, 
-    memoizedGridDetails.containerPadding, 
-    memoizedGridDetails.maxRows
+    height,
+    hasProfile,
+    memoizedGridDetails.margin,
+    memoizedGridDetails.containerPadding,
+    memoizedGridDetails.maxRows,
   ]);
 
-  async function handleDrop(
-    _layout: PlacedGridItem[],
-    item: PlacedGridItem,
-    e: DragEvent<HTMLDivElement>,
-  ) {
-    const fidgetData: FidgetInstanceData = JSON.parse(
-      e.dataTransfer.getData("text/plain"),
-    );
+  async function handleDrop(_layout: PlacedGridItem[], item: PlacedGridItem, e: DragEvent<HTMLDivElement>) {
+    const fidgetData: FidgetInstanceData = JSON.parse(e.dataTransfer.getData("text/plain"));
 
     const newItem: PlacedGridItem = {
       i: fidgetData.id,
@@ -602,10 +559,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   }
 
   function removeFidgetFromTray(fidgetId: string) {
-    const newFidgetTrayContents = reject(
-      fidgetTrayContents,
-      (fidget) => fidget.id === fidgetId,
-    );
+    const newFidgetTrayContents = reject(fidgetTrayContents, (fidget) => fidget.id === fidgetId);
 
     saveTrayContents(newFidgetTrayContents);
   }
@@ -622,17 +576,11 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
 
     // Create new state objects
     const newLayout = layoutConfig.layout.filter((item) => item.i !== fidgetId);
-    const newTrayContents = fidgetTrayContents.filter(
-      (fidget) => fidget.id !== fidgetId,
-    );
-    const { [fidgetId]: removed, ...newFidgetInstanceDatums } =
-      fidgetInstanceDatums;
+    const newTrayContents = fidgetTrayContents.filter((fidget) => fidget.id !== fidgetId);
+    const { [fidgetId]: removed, ...newFidgetInstanceDatums } = fidgetInstanceDatums;
 
     // Only save if we have fidgets left or if we're removing the last one
-    if (
-      Object.keys(newFidgetInstanceDatums).length > 0 ||
-      newLayout.length === 0
-    ) {
+    if (Object.keys(newFidgetInstanceDatums).length > 0 || newLayout.length === 0) {
       debouncedSaveConfig({
         layoutConfig: { layout: newLayout },
         fidgetTrayContents: newTrayContents,
@@ -642,10 +590,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   }
 
   function moveFidgetFromGridToTray(fidgetId: string) {
-    const newFidgetTrayContents = [
-      ...fidgetTrayContents,
-      fidgetInstanceDatums[fidgetId],
-    ];
+    const newFidgetTrayContents = [...fidgetTrayContents, fidgetInstanceDatums[fidgetId]];
     saveTrayContents(newFidgetTrayContents);
     removeFidgetFromGrid(fidgetId);
   }
@@ -655,11 +600,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
     // We only update if the same items exist
     // We aren't adding or removing an item
     // And we are in edit mode
-    if (
-      !currentlyDragging &&
-      inEditMode &&
-      newLayout.length === layoutConfig.layout.length
-    ) {
+    if (!currentlyDragging && inEditMode && newLayout.length === layoutConfig.layout.length) {
       debouncedSaveConfig({
         layoutConfig: { layout: newLayout },
       });
@@ -761,11 +702,11 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
             fidgetTrayContents,
             layoutConfig,
             theme,
-            layoutID: layoutConfig.layout.length > 0 ? 'grid' : undefined,
+            layoutID: layoutConfig.layout.length > 0 ? "grid" : undefined,
           })}
           onApplySpaceConfig={saveConfig}
         />,
-        portalNode,
+        portalNode
       )
     ) : (
       <></>
@@ -777,17 +718,16 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   // so that SSR and hydration don't render blank content.
 
   // Log initial config state
-  useEffect(() => {
-  }, []);
+  useEffect(() => {}, []);
 
   // Export function to generate SpaceConfig JSON
   const exportSpaceConfig = useCallback(() => {
     // Convert theme to UserTheme if needed
     let exportTheme: typeof defaultUserTheme = defaultUserTheme;
-    if (theme && 'properties' in theme) {
+    if (theme && "properties" in theme) {
       // Check if all required UserTheme properties exist
       const requiredKeys = Object.keys(defaultUserTheme.properties);
-      const hasAllKeys = requiredKeys.every(key => key in theme.properties);
+      const hasAllKeys = requiredKeys.every((key) => key in theme.properties);
       if (hasAllKeys) {
         exportTheme = theme as typeof defaultUserTheme;
       } else {
@@ -819,11 +759,11 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
 
     // Create and download the JSON file
     const dataStr = JSON.stringify(spaceConfig, null, 2);
-    const dataBlob = new Blob([dataStr], { type: 'application/json' });
+    const dataBlob = new Blob([dataStr], { type: "application/json" });
     const url = URL.createObjectURL(dataBlob);
-    const link = document.createElement('a');
+    const link = document.createElement("a");
     link.href = url;
-    link.download = `space-config-${new Date().toISOString().split('T')[0]}.json`;
+    link.download = `space-config-${new Date().toISOString().split("T")[0]}.json`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -838,21 +778,24 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   const [isMouseOverControlButtons, setIsMouseOverControlButtons] = useState(false);
 
   // DOM-based control button detection
-  const checkControlButtonArea = useCallback((e: MouseEvent) => {
-    const elementUnderMouse = document.elementFromPoint(e.clientX, e.clientY);
-    const controlElement = elementUnderMouse?.closest('[data-fidget-controls]');
-    const isOverControls = !!controlElement;
-    
-    if (isOverControls !== isMouseOverControlButtons) {
-      setIsMouseOverControlButtons(isOverControls);
-    }
-  }, [isMouseOverControlButtons]);
+  const checkControlButtonArea = useCallback(
+    (e: MouseEvent) => {
+      const elementUnderMouse = document.elementFromPoint(e.clientX, e.clientY);
+      const controlElement = elementUnderMouse?.closest("[data-fidget-controls]");
+      const isOverControls = !!controlElement;
+
+      if (isOverControls !== isMouseOverControlButtons) {
+        setIsMouseOverControlButtons(isOverControls);
+      }
+    },
+    [isMouseOverControlButtons]
+  );
 
   // Add document-level mouse detection
   useEffect(() => {
     if (inEditMode) {
-      document.addEventListener('mousemove', checkControlButtonArea);
-      return () => document.removeEventListener('mousemove', checkControlButtonArea);
+      document.addEventListener("mousemove", checkControlButtonArea);
+      return () => document.removeEventListener("mousemove", checkControlButtonArea);
     }
   }, [inEditMode, checkControlButtonArea]);
 
@@ -871,26 +814,33 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
   const firstEmptySquare = useMemo(() => findFirstEmptySquare(), [findFirstEmptySquare]);
 
   // Simplified grid cell click handler using CSS Grid auto-placement
-  const handleGridCellClick = useCallback((e: React.MouseEvent) => {
-    if (!inEditMode) return;
-    
-    // Find the clicked cell using event delegation
-    const target = e.target as HTMLElement;
-    const cellElement = target.closest('[data-grid-x]') as HTMLElement;
-    
-    if (!cellElement) return;
-    
-    // Get grid position from data attributes (much simpler!)
-    const gridX = parseInt(cellElement.dataset.gridX || '0');
-    const gridY = parseInt(cellElement.dataset.gridY || '0');
-    
-    // Check if position is valid and not occupied
-    if (gridX >= 0 && gridX < memoizedGridDetails.cols && 
-        gridY >= 0 && gridY < memoizedGridDetails.maxRows && 
-        isSpaceAvailable(gridX, gridY, 1, 1)) {
-      openFidgetPickerAtPosition(gridX, gridY);
-    }
-  }, [inEditMode, memoizedGridDetails.cols, memoizedGridDetails.maxRows, isSpaceAvailable]);
+  const handleGridCellClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (!inEditMode) return;
+
+      // Find the clicked cell using event delegation
+      const target = e.target as HTMLElement;
+      const cellElement = target.closest("[data-grid-x]") as HTMLElement;
+
+      if (!cellElement) return;
+
+      // Get grid position from data attributes (much simpler!)
+      const gridX = parseInt(cellElement.dataset.gridX || "0");
+      const gridY = parseInt(cellElement.dataset.gridY || "0");
+
+      // Check if position is valid and not occupied
+      if (
+        gridX >= 0 &&
+        gridX < memoizedGridDetails.cols &&
+        gridY >= 0 &&
+        gridY < memoizedGridDetails.maxRows &&
+        isSpaceAvailable(gridX, gridY, 1, 1)
+      ) {
+        openFidgetPickerAtPosition(gridX, gridY);
+      }
+    },
+    [inEditMode, memoizedGridDetails.cols, memoizedGridDetails.maxRows, isSpaceAvailable]
+  );
 
   // CSS Grid auto-placement overlay component
   const GridOverlay = ({ inEditMode }: { inEditMode: boolean }) => {
@@ -938,10 +888,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
                 duration-300 
                 ease-out 
                 group
-                ${isHintSquare 
-                  ? 'opacity-30' 
-                  : 'opacity-0'
-                }
+                ${isHintSquare ? "opacity-30" : "opacity-0"}
                 hover:opacity-80
               `}
               style={{
@@ -953,7 +900,7 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
               onClick={handleGridCellClick}
             >
               {/* Visual feedback area - matches original cell size */}
-              <div 
+              <div
                 className={`
                   absolute
                   inset-0
@@ -961,26 +908,23 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
                   duration-300 
                   ease-out 
                   group-hover:border-blue-200
-                  ${isHintSquare 
-                    ? 'border-blue-100' 
-                    : ''
-                  }
+                  ${isHintSquare ? "border-blue-100" : ""}
                 `}
                 style={{
                   borderRadius: memoizedGridDetails.borderRadius,
-                  border: '2px solid transparent',
+                  border: "2px solid transparent",
                   // Position within the padded area to match original cell size
                   margin: `${memoizedGridDetails.margin[0] / 2}px ${memoizedGridDetails.margin[1] / 2}px`,
                   ...(isHintSquare && {
-                    borderColor: 'rgba(59, 130, 246, 0.1)',
+                    borderColor: "rgba(59, 130, 246, 0.1)",
                   }),
                 }}
               >
-                <div className={`absolute inset-0 flex items-center justify-center transition-opacity duration-400 ease-out ${
-                  isHintSquare 
-                    ? 'opacity-30 group-hover:opacity-100' 
-                    : 'opacity-0 group-hover:opacity-100'
-                }`}>
+                <div
+                  className={`absolute inset-0 flex items-center justify-center transition-opacity duration-400 ease-out ${
+                    isHintSquare ? "opacity-30 group-hover:opacity-100" : "opacity-0 group-hover:opacity-100"
+                  }`}
+                >
                   <div className="text-blue-600 hover:text-blue-700 transition-colors duration-250 ease-out">
                     <AddFidgetIcon />
                   </div>
@@ -999,105 +943,88 @@ const Grid: LayoutFidget<GridLayoutProps> = ({
 
       <div className="flex flex-col z-0">
         <div className="flex-1 grid-container grow relative">
-          {inEditMode && (
-            <Gridlines 
-              {...memoizedGridDetails} 
-              rowHeight={rowHeight} 
-            />
-          )}
+          {inEditMode && <Gridlines {...memoizedGridDetails} rowHeight={rowHeight} />}
 
           <div className="relative">
             {gridLoadError ? (
-              <GridLayoutError 
-                height={rowHeight * memoizedGridDetails.maxRows} 
-                onRetry={handleGridRetry}
-              />
+              <GridLayoutError height={rowHeight * memoizedGridDetails.maxRows} onRetry={handleGridRetry} />
             ) : (
-              <React.Suspense 
-                fallback={<GridLayoutLoader height={rowHeight * memoizedGridDetails.maxRows} />}
-              >
+              <React.Suspense fallback={<GridLayoutLoader height={rowHeight * memoizedGridDetails.maxRows} />}>
                 <GridErrorBoundary
                   fallback={
-                    <GridLayoutError 
-                      height={rowHeight * memoizedGridDetails.maxRows} 
-                      onRetry={handleGridRetry}
-                    />
+                    <GridLayoutError height={rowHeight * memoizedGridDetails.maxRows} onRetry={handleGridRetry} />
                   }
                 >
                   <ReactGridLayout
-                  {...memoizedGridDetails}
-                  isDraggable={inEditMode}
-                  isResizable={inEditMode}
-                  resizeHandles={resizeDirections}
-                  layout={layoutConfig.layout}
-                  items={layoutConfig.layout.length}
-                  rowHeight={rowHeight}
-                  isDroppable={true}
-                  droppingItem={externalDraggedItem}
-                  onDrop={handleDrop}
-                  onLayoutChange={saveLayoutConditional}
-                  onResizeStart={() => setCurrentlyResizing(true)}
-                  onResizeStop={() => setCurrentlyResizing(false)}
-                  className={`grid-overlap ${itemsVisible ? "items-visible" : ""} z-10`}
-                  style={{
-                    height: rowHeight * memoizedGridDetails.maxRows + "px",
-                    transition: "opacity 0.2s ease-in",
-                    opacity: itemsVisible ? 1 : 0,
-                    position: "relative",
-                  }}
-                >
-                {map(layoutConfig.layout, (gridItem: PlacedGridItem) => {
-                  const fidgetDatum = fidgetInstanceDatums[gridItem.i];
-                  const fidgetModule = fidgetDatum
-                    ? CompleteFidgets[fidgetDatum.fidgetType]
-                    : null;
-                  if (!fidgetModule) return null;
-
-                  return (
-                    <div
-                      key={gridItem.i}
-                      className="grid-item"
-                      style={{
-                        borderRadius: memoizedGridDetails.borderRadius,
-                        outline:
-                          selectedFidgetID === gridItem.i
-                            ? "4px solid rgb(2 132 199)" /* sky-600 */
-                            : undefined,
-                    outlineOffset:
-                      selectedFidgetID === gridItem.i
-                        ? -parseInt(theme?.properties?.fidgetBorderWidth ?? "0")
-                        : undefined,
-                  }}
-                >
-                  <FidgetWrapper
-                    fidget={fidgetModule.fidget}
-                    context={{ theme }}
-                    borderRadius={memoizedGridDetails.borderRadius}
-                    removeFidget={removeFidget}
-                    minimizeFidget={moveFidgetFromGridToTray}
-                    saveConfig={saveFidgetConfig(fidgetDatum.id)}
-                    setCurrentFidgetSettings={setCurrentFidgetSettings}
-                    setSelectedFidgetID={setSelectedFidgetID}
-                    selectedFidgetID={selectedFidgetID}
-                    bundle={{
-                      ...fidgetDatum,
-                      properties: fidgetModule.properties,
-                      config: { ...fidgetDatum.config, editable: inEditMode },
+                    {...memoizedGridDetails}
+                    isDraggable={inEditMode}
+                    isResizable={inEditMode}
+                    resizeHandles={resizeDirections}
+                    layout={layoutConfig.layout}
+                    items={layoutConfig.layout.length}
+                    rowHeight={rowHeight}
+                    isDroppable={true}
+                    droppingItem={externalDraggedItem}
+                    onDrop={handleDrop}
+                    onLayoutChange={saveLayoutConditional}
+                    onResizeStart={() => setCurrentlyResizing(true)}
+                    onResizeStop={() => setCurrentlyResizing(false)}
+                    className={`grid-overlap ${itemsVisible ? "items-visible" : ""} z-10`}
+                    style={{
+                      height: rowHeight * memoizedGridDetails.maxRows + "px",
+                      transition: "opacity 0.2s ease-in",
+                      opacity: itemsVisible ? 1 : 0,
+                      position: "relative",
                     }}
-                  />
-                </div>
-              );
-            })}
-            </ReactGridLayout>
-            </GridErrorBoundary>
-            </React.Suspense>
+                  >
+                    {map(layoutConfig.layout, (gridItem: PlacedGridItem) => {
+                      const fidgetDatum = fidgetInstanceDatums[gridItem.i];
+                      const fidgetModule = fidgetDatum ? CompleteFidgets[fidgetDatum.fidgetType] : null;
+                      if (!fidgetModule) return null;
+
+                      return (
+                        <div
+                          key={gridItem.i}
+                          className="grid-item"
+                          style={{
+                            borderRadius: memoizedGridDetails.borderRadius,
+                            outline:
+                              selectedFidgetID === gridItem.i ? "4px solid rgb(2 132 199)" /* sky-600 */ : undefined,
+                            outlineOffset:
+                              selectedFidgetID === gridItem.i
+                                ? -parseInt(theme?.properties?.fidgetBorderWidth ?? "0")
+                                : undefined,
+                          }}
+                        >
+                          <FidgetWrapper
+                            fidget={fidgetModule.fidget}
+                            context={{ theme }}
+                            borderRadius={memoizedGridDetails.borderRadius}
+                            removeFidget={removeFidget}
+                            minimizeFidget={moveFidgetFromGridToTray}
+                            saveConfig={saveFidgetConfig(fidgetDatum.id)}
+                            setCurrentFidgetSettings={setCurrentFidgetSettings}
+                            setSelectedFidgetID={setSelectedFidgetID}
+                            selectedFidgetID={selectedFidgetID}
+                            bundle={{
+                              ...fidgetDatum,
+                              properties: fidgetModule.properties,
+                              config: { ...fidgetDatum.config, editable: inEditMode },
+                            }}
+                          />
+                        </div>
+                      );
+                    })}
+                  </ReactGridLayout>
+                </GridErrorBoundary>
+              </React.Suspense>
             )}
-          
-          <GridOverlay inEditMode={inEditMode} />
+
+            <GridOverlay inEditMode={inEditMode} />
           </div>
         </div>
       </div>
-      
+
       <FidgetPickerModal
         isOpen={isFidgetPickerModalOpen}
         setIsOpen={setIsFidgetPickerModalOpen}

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -6,8 +6,8 @@ import React, {
   useCallback,
   useRef,
 } from "react";
+import dynamic from "next/dynamic";
 import useWindowSize from "@/common/lib/hooks/useWindowSize";
-import RGL, { WidthProvider } from "react-grid-layout";
 import {
   LayoutFidget,
   FidgetInstanceData,
@@ -27,10 +27,12 @@ import {
   FidgetWrapper,
   getSettingsWithDefaults,
 } from "@/common/fidgets/FidgetWrapper";
-import { map, reject, fromPairs } from "lodash";
+import map from "lodash/map";
+import reject from "lodash/reject";
+import fromPairs from "lodash/fromPairs";
 import AddFidgetIcon from "@/common/components/atoms/icons/AddFidget";
 import FidgetSettingsEditor from "@/common/components/organisms/FidgetSettingsEditor";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import { AnalyticsEvent } from "@/common/constants/analyticsEvents";
 import { analytics } from "@/common/providers/AnalyticsProvider";
 import { SpaceConfig } from "../../app/(spaces)/Space";
@@ -92,7 +94,14 @@ type GridDetails = ReturnType<typeof makeGridDetails>;
 
 type GridLayoutConfig = LayoutFidgetConfig<PlacedGridItem[]>;
 
-const ReactGridLayout = WidthProvider(RGL);
+const ReactGridLayout = dynamic(
+  () => import('react-grid-layout').then(mod => {
+    const RGL = mod.default;
+    const WidthProvider = mod.WidthProvider;
+    return WidthProvider(RGL);
+  }),
+  { ssr: false }
+) as any; // Type assertion to bypass strict typing for dynamic import
 
 interface GridlinesProps {
   maxRows: number;

--- a/src/fidgets/layout/Grid.tsx
+++ b/src/fidgets/layout/Grid.tsx
@@ -29,6 +29,7 @@ import { SpaceConfig } from "../../app/(spaces)/Space";
 import { defaultUserTheme } from "@/common/lib/theme/defaultTheme";
 import { v4 as uuidv4 } from "uuid";
 import { FidgetPickerModal } from "@/common/components/organisms/FidgetPickerModal";
+import Spinner from "@/common/components/atoms/spinner";
 
 export const resizeDirections = ["s", "w", "e", "n", "sw", "nw", "se", "ne"];
 export type ResizeDirection = (typeof resizeDirections)[number];
@@ -108,13 +109,10 @@ interface ReactGridLayoutProps {
 // Loading component for the grid layout
 const GridLayoutLoader: React.FC<{ height: number }> = ({ height }) => (
   <div
-    className="flex items-center justify-center bg-gray-50 rounded-lg border-2 border-dashed border-gray-200"
+    className="flex items-center justify-center"
     style={{ height: `${height}px` }}
   >
-    <div className="text-center">
-      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-2"></div>
-      <p className="text-sm text-gray-500">Loading grid layout...</p>
-    </div>
+    <Spinner />
   </div>
 );
 

--- a/src/pages/api/farcaster/neynar/cast.ts
+++ b/src/pages/api/farcaster/neynar/cast.ts
@@ -2,7 +2,7 @@ import neynar from "@/common/data/api/neynar";
 import requestHandler from "@/common/data/api/requestHandler";
 import { CastParamType } from "@neynar/nodejs-sdk/build/api";
 import { isAxiosError } from "axios";
-import { isString } from "lodash";
+import isString from "lodash/isString";
 import { NextApiRequest, NextApiResponse } from "next/types";
 
 async function loadCast(req: NextApiRequest, res: NextApiResponse) {

--- a/src/pages/api/farcaster/neynar/conversation.ts
+++ b/src/pages/api/farcaster/neynar/conversation.ts
@@ -2,7 +2,7 @@ import neynar from "@/common/data/api/neynar";
 import requestHandler from "@/common/data/api/requestHandler";
 import { CastParamType } from "@neynar/nodejs-sdk/build/api";
 import { isAxiosError } from "axios";
-import { isString } from "lodash";
+import isString from "lodash/isString";
 import { NextApiRequest, NextApiResponse } from "next/types";
 
 async function loadConversation(req: NextApiRequest, res: NextApiResponse) {

--- a/src/pages/api/farcaster/neynar/feed.ts
+++ b/src/pages/api/farcaster/neynar/feed.ts
@@ -1,7 +1,8 @@
 import requestHandler from "@/common/data/api/requestHandler";
 import { FeedType } from "@neynar/nodejs-sdk/build/api";
 import axios, { AxiosRequestConfig, isAxiosError } from "axios";
-import { isArray, isNil } from "lodash";
+import isArray from "lodash/isArray";
+import isNil from "lodash/isNil";
 import { NextApiRequest, NextApiResponse } from "next/types";
 
 async function loadCasts(req: NextApiRequest, res: NextApiResponse) {

--- a/src/pages/api/farcaster/neynar/searchByKeyword.ts
+++ b/src/pages/api/farcaster/neynar/searchByKeyword.ts
@@ -1,6 +1,6 @@
 import requestHandler from "@/common/data/api/requestHandler";
 import axios, { AxiosRequestConfig, isAxiosError } from "axios";
-import { isNil } from "lodash";
+import isNil from "lodash/isNil";
 import { NextApiRequest, NextApiResponse } from "next/types";
 
 async function searchCasts(req: NextApiRequest, res: NextApiResponse) {

--- a/src/pages/api/fid-link.ts
+++ b/src/pages/api/fid-link.ts
@@ -6,7 +6,10 @@ import { NextApiRequest, NextApiResponse } from "next";
 import neynar from "@/common/data/api/neynar";
 import createSupabaseServerClient from "@/common/data/database/supabase/clients/server";
 import moment from "moment";
-import { first, isArray, isUndefined, map } from "lodash";
+import first from "lodash/first";
+import isArray from "lodash/isArray";
+import isUndefined from "lodash/isUndefined";
+import map from "lodash/map";
 
 export type FidLinkToIdentityRequest = {
   fid: number;

--- a/src/pages/api/notifications/index.ts
+++ b/src/pages/api/notifications/index.ts
@@ -3,7 +3,7 @@ import requestHandler from "@/common/data/api/requestHandler";
 import { NounspaceResponse } from "@/common/data/api/requestHandler";
 import { NotificationsResponse } from "@neynar/nodejs-sdk/build/api";
 import { isAxiosError } from "axios";
-import { isString } from "lodash";
+import isString from "lodash/isString";
 import { NextApiRequest, NextApiResponse } from "next/types";
 import { z, ZodSchema } from "zod";
 

--- a/src/pages/api/search/users.ts
+++ b/src/pages/api/search/users.ts
@@ -6,7 +6,7 @@ import requestHandler, {
 } from "@/common/data/api/requestHandler";
 import neynar from "@/common/data/api/neynar";
 import { User } from "@neynar/nodejs-sdk/build/api";
-import { flatMap } from "lodash";
+import flatMap from "lodash/flatMap";
 
 const QuerySchema = z.object({
   // q is a string of max length 20, or an address

--- a/src/pages/api/signerRequests.ts
+++ b/src/pages/api/signerRequests.ts
@@ -9,7 +9,8 @@ import {
   SIGNED_KEY_REQUEST_VALIDATOR_EIP_712_DOMAIN,
 } from "@farcaster/core";
 import axios from "axios";
-import { isArray, isUndefined } from "lodash";
+import isArray from "lodash/isArray";
+import isUndefined from "lodash/isUndefined";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 /**

--- a/src/pages/api/space/authenticators.ts
+++ b/src/pages/api/space/authenticators.ts
@@ -5,7 +5,9 @@ import createSupabaseServerClient from "@/common/data/database/supabase/clients/
 import { SignedFile, validateSignable } from "@/common/lib/signedFiles";
 import { authenticatorsPath, preKeysPath } from "@/constants/supabase";
 import stringify from "fast-json-stable-stringify";
-import { indexOf, isUndefined, map } from "lodash";
+import indexOf from "lodash/indexOf";
+import isUndefined from "lodash/isUndefined";
+import map from "lodash/map";
 import { NextApiRequest, NextApiResponse } from "next/types";
 
 export type AuthenticatorResponse = NounspaceResponse;

--- a/src/pages/api/space/homebase/tabs/[tabName].ts
+++ b/src/pages/api/space/homebase/tabs/[tabName].ts
@@ -10,7 +10,8 @@ import { NextApiRequest, NextApiResponse } from "next/types";
 import createSupabaseServerClient from "@/common/data/database/supabase/clients/server";
 import stringify from "fast-json-stable-stringify";
 import { homebaseTabsPath } from "@/constants/supabase";
-import { isArray, isUndefined } from "lodash";
+import isArray from "lodash/isArray";
+import isUndefined from "lodash/isUndefined";
 
 export type UpdateHomebaseResponse = NounspaceResponse<boolean>;
 export type UpdateHomebaseRequest = SignedFile;

--- a/src/pages/api/space/homebase/tabs/index.ts
+++ b/src/pages/api/space/homebase/tabs/index.ts
@@ -9,7 +9,10 @@ import {
 import { NextApiRequest, NextApiResponse } from "next/types";
 import createSupabaseServerClient from "@/common/data/database/supabase/clients/server";
 import { homebaseTabsPath } from "@/constants/supabase";
-import { isArray, isNil, isUndefined, map } from "lodash";
+import isArray from "lodash/isArray";
+import isNil from "lodash/isNil";
+import isUndefined from "lodash/isUndefined";
+import map from "lodash/map";
 import { StorageError } from "@supabase/storage-js";
 import stringify from "fast-json-stable-stringify";
 

--- a/src/pages/api/space/registry/[spaceId]/index.ts
+++ b/src/pages/api/space/registry/[spaceId]/index.ts
@@ -7,7 +7,10 @@ import {
   Signable,
   validateSignable,
 } from "@/common/lib/signedFiles";
-import { isArray, isString, isNull, first } from "lodash";
+import isArray from "lodash/isArray";
+import isString from "lodash/isString";
+import isNull from "lodash/isNull";
+import first from "lodash/first";
 import { NextApiRequest, NextApiResponse } from "next/types";
 import { identityCanModifySpace } from "./tabs/[tabId]";
 import stringify from "fast-json-stable-stringify";


### PR DESCRIPTION
# Needs Grid Testing

This pull request refactors the imports in `src/fidgets/layout/Grid.tsx` to optimize bundle size and improve compatibility with server-side rendering (SSR) in Next.js. The most significant change is switching the import of `react-grid-layout` to a dynamic import, which disables SSR for this component and can help prevent hydration errors.

**Optimization of imports and SSR compatibility:**

* Changed the import of `react-grid-layout` and its `WidthProvider` to use Next.js's `dynamic` import with SSR disabled, improving compatibility and potentially reducing client-side bundle size.
* Refactored lodash imports to use direct submodule imports (`lodash/map`, `lodash/reject`, `lodash/fromPairs`, `lodash/debounce`) instead of importing from the main `lodash` package, which can reduce bundle size.
* Removed unused named imports of `RGL` and `WidthProvider` in favor of dynamic import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the way certain libraries are imported to optimize performance and compatibility.
  * Updated import style for utility functions to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->