### PR TITLE
Disable link prefetch on navigation

### DIFF
--- a/src/common/components/atoms/reorderable-tab.tsx
+++ b/src/common/components/atoms/reorderable-tab.tsx
@@ -55,6 +55,7 @@ export const Tab = ({
           }
         }}
         onDragStart={(e) => e.preventDefault()}
+        prefetch={false}
       >
         <div
           className={`static flex md:p-2 items-center transition-colors duration-300 group 

--- a/src/common/components/molecules/BrandHeader.tsx
+++ b/src/common/components/molecules/BrandHeader.tsx
@@ -21,6 +21,7 @@ const BrandHeader = () => {
             href="/home"
             className="flex items-center ps-2.5"
             rel="noopener noreferrer"
+            prefetch={false}
           >
             <TooltipTrigger asChild>
               <Image

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -151,6 +151,7 @@ const Navigation: React.FC<NavProps> = ({
           onClick={handleClick}
           rel={openInNewTab ? "noopener noreferrer" : undefined}
           target={openInNewTab ? "_blank" : undefined}
+          prefetch={false}
         >
           {badgeText && <NavIconBadge>{badgeText}</NavIconBadge>}
           <Icon />
@@ -364,6 +365,7 @@ const Navigation: React.FC<NavProps> = ({
                   )}
                   rel="noopener noreferrer"
                   target="_blank"
+                  prefetch={false}
                 >
                   <FaDiscord className="text-[#5865f2] w-6 h-6" />
                   {!shrunk && "Join"}
@@ -371,10 +373,10 @@ const Navigation: React.FC<NavProps> = ({
                 <div
                   className="flex flex-col items-center text-xs text-gray-500 mt-5"
                 >
-                  <Link href="/terms" className="hover:underline">
+                  <Link href="/terms" className="hover:underline" prefetch={false}>
                     Terms
                   </Link>
-                  <Link href="/privacy" className="hover:underline">
+                  <Link href="/privacy" className="hover:underline" prefetch={false}>
                     Privacy
                   </Link>
                 </div>


### PR DESCRIPTION
## Summary
- avoid unwanted page loads by turning off Next.js prefetching on navigation links and tab links
- disable prefetch for brand header and footer links to prevent extra server requests

## Testing
- `npm run lint`
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_689a4a41af648325999555344e5b5f43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled automatic prefetching on multiple navigation links (tabs, brand header Home, main nav items, Discord join, Terms & Privacy) to reduce background network requests. Visual UI and routing behavior remain unchanged; no changes to public interfaces or user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->