### PR TITLE
feat: add Walrus video uploads

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,6 +13,7 @@ const cspHeader = `
     script-src 'self' 'unsafe-eval' 'unsafe-inline' https://challenges.cloudflare.com https://www.youtube.com https://www.youtube.com/iframe_api https://auth.privy.nounspace.com https://cdn.segment.com;
     style-src 'self' 'unsafe-inline' https://i.ytimg.com https://mint.highlight.xyz;
     img-src 'self' blob: data: https:;
+    media-src 'self' https://aggregator.walrus-testnet.walrus.space;
     font-src 'self' https: data: blob: https://fonts.googleapis.com https://fonts.gstatic.com;
     object-src 'none';
     base-uri 'self';
@@ -39,7 +40,9 @@ const cspHeader = `
       https://api.segment.io
       https://api.imgbb.com
       https://api.goldsky.com
-      https://base-mainnet.g.alchemy.com;
+      https://base-mainnet.g.alchemy.com
+      https://publisher.walrus-testnet.walrus.space
+      https://aggregator.walrus-testnet.walrus.space;
 
     upgrade-insecure-requests;
 `;

--- a/src/common/lib/utils/urls.ts
+++ b/src/common/lib/utils/urls.ts
@@ -22,6 +22,10 @@ const VIDEO_STREAM_DOMAINS = [
   "https://stream.farcaster.xyz",
 ];
 
+const WALRUS_AGGREGATOR_DOMAINS = [
+  "https://aggregator.walrus-testnet.walrus.space",
+];
+
 const VIDEO_PATH_REGEX = /\/~\/(video|shorts)\//i;
 
 const VIDEO_EXTENSION_REGEX = /\.(m3u8|mp4|webm|mov|ogg)(\?|$)/i;
@@ -35,6 +39,7 @@ export const isVideoUrl = (url: string): boolean => {
 
   return (
     VIDEO_STREAM_DOMAINS.some((domain) => lowerUrl.startsWith(domain)) ||
+    WALRUS_AGGREGATOR_DOMAINS.some((domain) => lowerUrl.startsWith(domain)) ||
     VIDEO_PATH_REGEX.test(lowerUrl) ||
     VIDEO_EXTENSION_REGEX.test(lowerUrl)
   );

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -213,7 +213,7 @@ const CreateCast: React.FC<CreateCastProps> = ({
     if (!blobId) {
       throw new Error("Invalid Walrus response");
     }
-    return `${WALRUS_AGGREGATOR_URL}/v1/blobs/${blobId}`;
+    return `${WALRUS_AGGREGATOR_URL}/v1/blobs/${blobId}#video.mp4`;
   }
 
   // Drop handler

--- a/src/fidgets/farcaster/components/Embeds/VideoEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/VideoEmbed.tsx
@@ -1,23 +1,54 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 
 const ReactHlsPlayer = dynamic(() => import("@gumlet/react-hls-player"), {
   ssr: false,
 });
 
+const WALRUS_AGGREGATOR_URL =
+  "https://aggregator.walrus-testnet.walrus.space";
+
 const VideoEmbed = ({ url }: { url: string }) => {
+  const realUrl = url.split("#")[0];
+  const isHls = realUrl.toLowerCase().endsWith(".m3u8");
   const [muted, setMuted] = useState(true);
   const [didUnmute, setDidUnmute] = useState(false);
+  const [src, setSrc] = useState(realUrl);
   const playerRef = React.useRef<HTMLVideoElement | null>(null);
+
+  useEffect(() => {
+    if (!realUrl.startsWith(WALRUS_AGGREGATOR_URL)) {
+      setSrc(realUrl);
+      return;
+    }
+
+    let objectUrl: string | undefined;
+    (async () => {
+      try {
+        const res = await fetch(realUrl);
+        const blob = await res.blob();
+        objectUrl = URL.createObjectURL(
+          blob.type.startsWith("video/") ? blob : blob.slice(0, blob.size, "video/mp4"),
+        );
+        setSrc(objectUrl);
+      } catch {
+        setSrc(realUrl);
+      }
+    })();
+
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [realUrl]);
 
   const togglePlay = useCallback(() => {
     if (!playerRef.current) return;
-    if (playerRef?.current.paused) {
-      playerRef?.current?.play();
+    if (playerRef.current.paused) {
+      void playerRef.current.play();
     } else {
-      playerRef?.current?.pause();
+      playerRef.current.pause();
     }
-  }, [playerRef?.current]);
+  }, []);
 
   const onClick = useCallback(
     (e: React.MouseEvent) => {
@@ -33,15 +64,28 @@ const VideoEmbed = ({ url }: { url: string }) => {
     [didUnmute, togglePlay],
   );
 
+  if (isHls) {
+    return (
+      <ReactHlsPlayer
+        src={realUrl}
+        muted={muted}
+        autoPlay={false}
+        controls
+        width="100%"
+        height="auto"
+        playerRef={playerRef}
+        onClick={onClick}
+        className="object-contain size-full"
+      />
+    );
+  }
+
   return (
-    <ReactHlsPlayer
-      src={url}
+    <video
+      src={src}
       muted={muted}
-      autoPlay={false}
-      controls={true}
-      width="100%"
-      height="auto"
-      playerRef={playerRef}
+      controls
+      ref={playerRef}
       onClick={onClick}
       className="object-contain size-full"
     />

--- a/tests/urls.test.ts
+++ b/tests/urls.test.ts
@@ -13,6 +13,11 @@ describe('isVideoUrl', () => {
         'https://aggregator.walrus-testnet.walrus.space/v1/blobs/abc',
       ),
     ).toBe(true);
+    expect(
+      isVideoUrl(
+        'https://aggregator.walrus-testnet.walrus.space/v1/blobs/abc#video.mp4',
+      ),
+    ).toBe(true);
   });
 
   it('returns false for non-video URLs', () => {

--- a/tests/urls.test.ts
+++ b/tests/urls.test.ts
@@ -8,6 +8,11 @@ describe('isVideoUrl', () => {
     expect(isVideoUrl('https://Stream.Warpcast.com/video.WEBM')).toBe(true);
     expect(isVideoUrl('https://warpcast.com/~/video/123')).toBe(true);
     expect(isVideoUrl('https://example.com/test.MOV')).toBe(true);
+    expect(
+      isVideoUrl(
+        'https://aggregator.walrus-testnet.walrus.space/v1/blobs/abc',
+      ),
+    ).toBe(true);
   });
 
   it('returns false for non-video URLs', () => {


### PR DESCRIPTION
## Summary
- support Walrus Testnet video uploads in cast composer with 100MB limit and upload spinner
- recognize Walrus aggregator URLs as videos for embed rendering
- add unit test for Walrus video URLs

## Testing
- `npm test` *(fails: connect ECONNREFUSED ::1:3000, ECONNREFUSED 127.0.0.1:3000, category mismatch)*
- `npm run lint`
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_689fe61e231c8325a9b5c0a3949aabc5