### PR TITLE
Handle quote notifications on notifications page

### DIFF
--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -223,6 +223,40 @@ const RecastNotificationRow: NotificationRowProps = ({
   );
 };
 
+const QuoteNotificationRow: NotificationRowProps = ({
+  notification,
+  onSelect,
+}) => {
+  const quotedByUser = notification.cast?.author ? [notification.cast.author] : [];
+
+  return (
+    <div className="flex flex-col gap-2">
+      <NotificationHeader
+        notification={notification}
+        relatedUsers={quotedByUser}
+        descriptionSuffix="quoted your cast"
+      />
+      <div className="ml-4 w-full">
+        <CastRow
+          cast={notification.cast!}
+          key={notification.cast!.hash}
+          showChannel={false}
+          isFocused={false}
+          isEmbed={true}
+          isReply={false}
+          hasReplies={false}
+          onSelect={onSelect}
+          hideReactions={false}
+          className="border-b-0 px-0 pb-0 hover:bg-transparent"
+          castTextStyle={{
+            fontSize: "16px",
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
 const ReplyNotificationRow: NotificationRowProps = ({
   notification,
   onSelect,
@@ -319,6 +353,7 @@ const NOTIFICATION_ROW_TYPE = {
   [NotificationTypeEnum.Mention]: MentionNotificationRow,
   [NotificationTypeEnum.Follows]: FollowNotificationRow,
   [NotificationTypeEnum.Recasts]: RecastNotificationRow,
+  [NotificationTypeEnum.Quote]: QuoteNotificationRow,
   [NotificationTypeEnum.Reply]: ReplyNotificationRow,
   [NotificationTypeEnum.Likes]: LikeNotificationRow,
 }
@@ -407,9 +442,19 @@ function NotificationsPageContent() {
 
   const filterByType = useCallback(
     (_notifications: Notification[]): Notification[] => {
-      return tab === TAB_OPTIONS.ALL
-        ? _notifications
-        : _notifications.filter((notification) => notification.type === tab)
+      if (tab === TAB_OPTIONS.ALL) {
+        return _notifications
+      }
+
+      if (tab === TAB_OPTIONS.RECASTS) {
+        return _notifications.filter(
+          (notification) =>
+            notification.type === NotificationTypeEnum.Recasts ||
+            notification.type === NotificationTypeEnum.Quote,
+        )
+      }
+
+      return _notifications.filter((notification) => notification.type === tab)
     },
     [tab]
   )

--- a/src/pages/api/notifications/index.ts
+++ b/src/pages/api/notifications/index.ts
@@ -1,7 +1,11 @@
 import neynar from "@/common/data/api/neynar";
 import requestHandler from "@/common/data/api/requestHandler";
 import { NounspaceResponse } from "@/common/data/api/requestHandler";
-import { NotificationsResponse } from "@neynar/nodejs-sdk/build/api";
+import {
+  NotificationType,
+  NotificationTypeEnum,
+  NotificationsResponse,
+} from "@neynar/nodejs-sdk/build/api";
 import { isAxiosError } from "axios";
 import { isString } from "lodash";
 import { NextApiRequest, NextApiResponse } from "next/types";
@@ -46,9 +50,17 @@ const get = async (
 
   try {
     const data = await neynar.fetchAllNotifications({
-      fid, 
+      fid,
       limit,
       cursor,
+      type: [
+        NotificationType.Follows,
+        NotificationType.Recasts,
+        NotificationType.Likes,
+        NotificationType.Mentions,
+        NotificationType.Replies,
+        NotificationType.Quotes,
+      ],
     });
 
     res.status(200).json({


### PR DESCRIPTION
## Summary
- fetch quote notifications from Neynar
- show quote notifications and treat quotes as recasts

## Testing
- `npm run lint`
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_68acde2b98ac8325812206ccedba658e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for Quote notifications with a dedicated display, including embedded cast context.
  - Backend now fetches Quote notifications alongside existing types for a more complete feed.

- Changes
  - Recasts tab now includes both Recasts and Quotes for consolidated viewing; other tabs remain unchanged.

- Tests
  - None noted.

- Chores
  - Updated notification type handling to include Quotes in the retrieval and rendering pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->