### PR TITLE
fix build due to duplicate resolvedPageType in PublicSpace

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -173,14 +173,6 @@ export default function PublicSpace({
     [editabilityCheck],
   );
 
-  const resolvedPageType = useMemo(() => {
-    if (pageType) return pageType;
-    if (isTokenPage) return "token";
-    if (spaceOwnerFid) return "person";
-    if (providedSpaceId?.startsWith("proposal:")) return "proposal";
-    return "person"; // Default to person page
-  }, [pageType, isTokenPage, spaceOwnerFid, providedSpaceId]);
-
   // Control to avoid infinite space/tab update cycles
   const prevSpaceId = useRef<string | null>(null);
   const prevTabName = useRef<string | null>(null);


### PR DESCRIPTION
## Summary
- remove duplicate resolvedPageType definition in PublicSpace to fix compilation

## Testing
- `npm test` *(fails: connect ECONNREFUSED ::1:3000)*
- `npm run lint`
- `npm run build` *(fails: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68af3556897c8325bd0d4f5c8944cc24