### PR TITLE
Implement Channel Follow/Unfollow

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@farcaster/core": "^0.14.11",
     "@farcaster/frame-sdk": "^0.0.53",
     "@farcaster/hub-web": "^0.8.12",
+    "@farcaster/hub-nodejs": "^0.15.6",
     "@frames.js/render": "^0.5.6",
     "@googleapis/youtube": "^18.0.0",
     "@gumlet/react-hls-player": "^1.0.1",

--- a/src/fidgets/farcaster/utils.ts
+++ b/src/fidgets/farcaster/utils.ts
@@ -448,3 +448,42 @@ export async function fetchChannelsByName(
     return [] as Channel[];
   }
 }
+
+type ChannelFollowAuth =
+  | { authToken: string }
+  | { fid: number; useServerAuth: true };
+
+export const followChannel = async (channelId: string, auth: ChannelFollowAuth) => {
+  try {
+    if ("authToken" in auth) {
+      await axiosBackend.post("/api/farcaster/channel-follow", { channelId }, {
+        headers: { Authorization: `Bearer ${auth.authToken}` },
+      });
+    } else {
+      await axiosBackend.post("/api/farcaster/channel-follow", { channelId, fid: auth.fid, useServerAuth: true });
+    }
+    return true;
+  } catch (e) {
+    console.error("followChannel failed:", e);
+    return false;
+  }
+};
+
+export const unfollowChannel = async (channelId: string, auth: ChannelFollowAuth) => {
+  try {
+    if ("authToken" in auth) {
+      await axiosBackend.delete("/api/farcaster/channel-follow", {
+        data: { channelId },
+        headers: { Authorization: `Bearer ${auth.authToken}` },
+      });
+    } else {
+      await axiosBackend.delete("/api/farcaster/channel-follow", {
+        data: { channelId, fid: auth.fid, useServerAuth: true },
+      });
+    }
+    return true;
+  } catch (e) {
+    console.error("unfollowChannel failed:", e);
+    return false;
+  }
+};

--- a/src/pages/api/farcaster/channel-follow.ts
+++ b/src/pages/api/farcaster/channel-follow.ts
@@ -1,0 +1,79 @@
+import requestHandler from "@/common/data/api/requestHandler";
+import axios, { isAxiosError } from "axios";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { NobleEd25519Signer } from "@farcaster/hub-nodejs";
+
+function b64url(obj: unknown) {
+  return Buffer.from(JSON.stringify(obj)).toString("base64url");
+}
+
+async function makeAppKeyBearer(fid: number, privHex: string, pubHex: string) {
+  const priv = privHex.replace(/^0x/, "");
+  const pub = pubHex.replace(/^0x/, "");
+  const signer = new NobleEd25519Signer(new Uint8Array(Buffer.from(priv, "hex")));
+
+  const header = { fid, type: "app_key", key: pub };
+  const payload = { exp: Math.floor(Date.now() / 1000) + 300 }; // 5 min
+  const h = b64url(header);
+  const p = b64url(payload);
+
+  // Sign the bytes of "h.p" exactly as in the docs
+  const toSign = Buffer.from(`${h}.${p}`, "utf-8");
+  const sigRes = await signer.signMessageHash(toSign);
+  if (sigRes.isErr()) throw sigRes.error;
+  const s = Buffer.from(sigRes.value).toString("base64url");
+
+  return `Bearer ${h}.${p}.${s}`;
+}
+
+// TODO: replace with real keystore lookup: return the app key registered for this fid.
+// For now, return env values (works only if that app key is registered to the current fid).
+async function getAppKeyForFid(fid: number): Promise<{ privHex: string; pubHex: string } | null> {
+  const privHex = process.env.NOUNSPACE_APP_KEY_PRIV_HEX;
+  const pubHex = process.env.NOUNSPACE_APP_KEY_PUB_HEX;
+  if (!privHex || !pubHex) return null;
+  return { privHex, pubHex };
+}
+
+async function proxy(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const method = (req.method || "POST").toUpperCase();
+    const { channelId, fid, useServerAuth } = (req.body || {}) as {
+      channelId?: string; fid?: number; useServerAuth?: boolean;
+    };
+    if (!channelId || typeof channelId !== "string") {
+      res.status(400).json("channelId is required"); return;
+    }
+
+    // 1) Determine Authorization
+    let authHeader = req.headers.authorization;
+    if ((!authHeader || !authHeader.startsWith("Bearer ")) && useServerAuth && typeof fid === "number") {
+      const kp = await getAppKeyForFid(fid);
+      if (!kp) { res.status(401).json("No app key available for fid"); return; }
+      authHeader = await makeAppKeyBearer(fid, kp.privHex, kp.pubHex);
+    }
+    if (!authHeader?.startsWith("Bearer ")) {
+      res.status(401).json("Missing or invalid Authorization header"); return;
+    }
+
+    // 2) Forward request
+    const url = "https://api.farcaster.xyz/fc/channel-follows";
+    const headers = { Authorization: authHeader, "Content-Type": "application/json" };
+    const response =
+      method === "POST"
+        ? await axios.post(url, { channelId }, { headers })
+        : await axios.delete(url, { headers, data: { channelId } });
+
+    res.status(200).json(response.data);
+  } catch (e) {
+    if (isAxiosError(e)) {
+      console.error(req.method, e.response?.status, e.response?.data);
+      res.status(e.response?.status || 500).json(e.response?.data || "An unknown error occurred");
+    } else {
+      console.error(req.method, e);
+      res.status(500).json("An unknown error occurred");
+    }
+  }
+}
+
+export default requestHandler({ post: proxy, delete: proxy });

--- a/src/pages/api/farcaster/user-channel.ts
+++ b/src/pages/api/farcaster/user-channel.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import axios, { isAxiosError } from "axios";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const { fid, channelId } = req.query as { fid?: string; channelId?: string };
+    if (!fid || !channelId) { res.status(400).json("fid and channelId are required"); return; }
+
+    const url = `https://api.farcaster.xyz/v1/user-channel?fid=${encodeURIComponent(fid)}&channelId=${encodeURIComponent(channelId)}`;
+    const { data } = await axios.get(url);
+    res.status(200).json(data);
+  } catch (e) {
+    if (isAxiosError(e)) {
+      console.error("GET /user-channel", e.response?.status, e.response?.data);
+      res.status(e.response?.status || 500).json(e.response?.data || "An unknown error occurred");
+    } else {
+      console.error("GET /user-channel", e);
+      res.status(500).json("An unknown error occurred");
+    }
+  }
+}


### PR DESCRIPTION
This PR implements the channel follow/unfollow API endpoints for Farcaster integration.

## Changes
- Add  API endpoint for POST/DELETE operations to follow/unfollow channels
- Add  API endpoint for GET operations to retrieve user-channel information
- Include proper error handling and validation
- Support both client and server-side authentication using Farcaster app keys

## API Endpoints
-  - Follow a channel
-  - Unfollow a channel  
-  - Get user-channel information

## Technical Details
- Uses NobleEd25519Signer for app key authentication
- Proxies requests to Farcaster API at 
- Supports environment variable configuration for app keys
- Includes comprehensive error handling for both Axios and general errors