### PR TITLE
refactor: remove duplicate sidebar provider

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -46,6 +46,7 @@ const cspHeader = `
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  reactStrictMode: false,
   // output: 'export', // Outputs a Single-Page Application (SPA).
   // distDir: './dist', // Changes the build output directory to `./dist/`.
   transpilePackages: [

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -46,7 +46,6 @@ const cspHeader = `
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: false,
   // output: 'export', // Outputs a Single-Page Application (SPA).
   // distDir: './dist', // Changes the build output directory to `./dist/`.
   transpilePackages: [

--- a/src/common/components/organisms/ClientMobileHeaderWrapper.tsx
+++ b/src/common/components/organisms/ClientMobileHeaderWrapper.tsx
@@ -2,15 +2,10 @@
 
 import React from "react";
 import MobileHeader from "./MobileHeader";
-import { SidebarContextProvider } from "./Sidebar";
 
 export const ClientMobileHeaderWrapper: React.FC = React.memo(
   function ClientMobileHeaderWrapper() {
-    return (
-      <SidebarContextProvider>
-        <MobileHeader />
-      </SidebarContextProvider>
-    );
+    return <MobileHeader />;
   }
 );
 

--- a/src/common/data/stores/app/index.tsx
+++ b/src/common/data/stores/app/index.tsx
@@ -118,6 +118,7 @@ const {
   context: AppStoreContext,
 } = createStoreBindings<AppStore>("AppStore", createAppStore);
 
+// TODO: Replace this with React suspense fallback system
 const HydrationGate: React.FC<{ children: React.ReactNode; fallback?: React.ReactNode }> = ({ children, fallback }) => {
   const store = React.useContext(AppStoreContext);
   const [hydrated, setHydrated] = React.useState(false);


### PR DESCRIPTION
Fixes an issue where the nav would disappear from the UI and re-render upon initial page load. Note: would only occur when loading the app without cached resources

Steps to reproduce:
1. Clear cache (or open incognito window)
2. visit nounspace.com
3. watch as the nav disappears from the UI before reappearing

## Summary
- remove extra `SidebarContextProvider` around `MobileHeader`
- Added a hydration gate around the Zustand-backed app store so the UI renders only after the store finishes hydrating, eliminating the first-load remount that hid the navigation components

## Testing
- `yarn lint`
- `yarn test` *(fails: connect ECONNREFUSED ::1:3000)*

------
https://chatgpt.com/codex/tasks/task_e_68b7277d0e6083259a3f62ec8c210065

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added hydration gating to delay rendering until the app state is ready, improving initial load experience.
- Bug Fixes
  - Reduced UI flicker and inconsistent content during first render by ensuring views appear only after hydration.
- Refactor
  - Simplified the mobile header wrapper for cleaner composition.
  - Reorganized application state provider and context exposure to support the new hydration flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->