### PR TITLE
Fix video playback for embedded casts

### DIFF
--- a/src/fidgets/farcaster/components/Embeds/VideoEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/VideoEmbed.tsx
@@ -23,11 +23,16 @@ const VideoEmbed = ({ url }: { url: string }) => {
     (e: React.MouseEvent) => {
       e.preventDefault();
 
+      if (!playerRef.current) return;
+
       if (didUnmute) {
         togglePlay();
       } else {
+        // Unmute and immediately begin playback so a single click starts the video
+        playerRef.current.muted = false;
         setMuted(false);
         setDidUnmute(true);
+        playerRef.current.play();
       }
     },
     [didUnmute, togglePlay],


### PR DESCRIPTION
## Summary
- ensure `VideoEmbed` un-mutes and starts playback on the initial click

## Testing
- `npm test` *(fails: connect ECONNREFUSED ::1:3000)*

------
https://chatgpt.com/codex/tasks/task_e_68b7372ce6488325a5f3a65adbe5fbb6