### PR TITLE
Add Empire Builder token support to editability check

### DIFF
--- a/src/app/(spaces)/t/[network]/[contractAddress]/[tabName]/page.tsx
+++ b/src/app/(spaces)/t/[network]/[contractAddress]/[tabName]/page.tsx
@@ -7,6 +7,7 @@ import { MasterToken, TokenProvider } from "@/common/providers/TokenProvider";
 import { Address } from "viem";
 import { fetchTokenData } from "@/common/lib/utils/fetchTokenData";
 import { fetchClankerByAddress } from "@/common/data/queries/clanker";
+import { fetchEmpireByAddress } from "@/common/data/queries/empireBuilder";
 import { EtherScanChainName } from "@/constants/etherscanChainIds";
 import ContractPrimarySpaceContent from "../../ContractPrimarySpaceContent";
 
@@ -14,25 +15,18 @@ async function loadTokenData(
   contractAddress: Address,
   network: EtherScanChainName
 ): Promise<MasterToken> {
-  if (network === "base") {
-    const [tokenResponse, clankerResponse] = await Promise.all([
-      fetchTokenData(contractAddress, null, network),
-      fetchClankerByAddress(contractAddress),
-    ]);
+  const [tokenResponse, clankerResponse, empireResponse] = await Promise.all([
+    fetchTokenData(contractAddress, null, network),
+    network === "base" ? fetchClankerByAddress(contractAddress) : Promise.resolve(null),
+    fetchEmpireByAddress(contractAddress),
+  ]);
 
-    return {
-      network,
-      geckoData: tokenResponse,
-      clankerData: clankerResponse,
-    };
-  } else {
-    const tokenResponse = await fetchTokenData(contractAddress, null, network);
-    return {
-      network,
-      geckoData: tokenResponse,
-      clankerData: null,
-    };
-  }
+  return {
+    network,
+    geckoData: tokenResponse,
+    clankerData: clankerResponse,
+    empireData: empireResponse,
+  };
 }
 
 export default async function WrappedContractPrimarySpace({ params }) {

--- a/src/common/providers/TokenProvider.tsx
+++ b/src/common/providers/TokenProvider.tsx
@@ -13,11 +13,13 @@ import {
   GeckoTokenAttribute,
 } from "../lib/utils/fetchTokenData";
 import { ClankerToken } from "../data/queries/clanker";
+import { fetchEmpireByAddress, EmpireToken } from "../data/queries/empireBuilder";
 import { EtherScanChainName } from "@/constants/etherscanChainIds";
 
 export interface MasterToken {
   geckoData: GeckoTokenAttribute | null;
   clankerData: ClankerToken | null;
+  empireData: EmpireToken | null;
   network: EtherScanChainName;
 }
 
@@ -47,14 +49,16 @@ export const fetchMasterToken = async (
       String(network),
     );
 
-    const clankerResponse = await fetch(
-      `/api/clanker/ca?address=${address}`,
-    ).then((res) => res.json());
+    const [clankerResponse, empireResponse] = await Promise.all([
+      fetch(`/api/clanker/ca?address=${address}`).then((res) => res.json()),
+      fetchEmpireByAddress(address as Address),
+    ]);
 
     return {
       network: network,
       geckoData: tokenResponse,
       clankerData: clankerResponse,
+      empireData: empireResponse,
     };
 };
 

--- a/src/common/utils/spaceEditability.ts
+++ b/src/common/utils/spaceEditability.ts
@@ -80,13 +80,15 @@ export const createEditabilityChecker = (context: EditabilityContext) => {
     }
 
     // Check if user owns the wallet address (doesn't require clankerData)
+    const ownerAddress =
+      spaceOwnerAddress || (tokenData?.empireData?.owner as Address | undefined);
     if (
-      spaceOwnerAddress &&
-      wallets.some((w) => isAddressEqual(w.address as Address, spaceOwnerAddress))
+      ownerAddress &&
+      wallets.some((w) => isAddressEqual(w.address as Address, ownerAddress))
     ) {
       // console.log('Editable: User owns by address', {
-      //   spaceOwnerAddress,
-      //   matchingWallet: wallets.find(w => w.address === spaceOwnerAddress),
+      //   spaceOwnerAddress: ownerAddress,
+      //   matchingWallet: wallets.find(w => w.address === ownerAddress),
       // });
       return { isEditable: true, isLoading: false };
     }


### PR DESCRIPTION
## Summary
- extend MasterToken to include Empire Builder token data
- fetch Empire Builder info when loading token data
- allow token space owners with Empire Builder tokens to edit spaces

## Testing
- `npm run lint`
- `npm run check-types`


------
https://chatgpt.com/codex/tasks/task_e_68c0975b82b083259ded6a5dbfba8493