### PR TITLE
Expose mini app Ethereum provider to iframe content

### DIFF
--- a/src/common/providers/MiniAppSdkProvider.tsx
+++ b/src/common/providers/MiniAppSdkProvider.tsx
@@ -3,6 +3,25 @@
 import React, { createContext, useEffect, useState } from "react";
 import { sdk as frameSdk, Context } from "@farcaster/frame-sdk";
 
+export const MINI_APP_PROVIDER_METADATA = {
+  uuid: "nounspace-miniapp-eth-provider",
+  name: "Nounspace Mini App",
+  iconPath: "/images/mini_app_icon.png",
+  rdns: "wtf.nounspace",
+};
+
+declare global {
+  interface Window {
+    __nounspaceMiniAppEthProvider?: unknown;
+    __nounspaceMiniAppProviderInfo?: {
+      uuid: string;
+      name: string;
+      icon: string;
+      rdns: string;
+    };
+  }
+}
+
 // Types for the context
 type MiniAppContext = {
   isInitializing: boolean;
@@ -67,6 +86,83 @@ export const MiniAppSdkProvider: React.FC<{ children: React.ReactNode }> = ({
 
     initializeSdk();
   }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (!state.isReady || !state.sdk?.wallet?.ethProvider) {
+      return;
+    }
+
+    const ethProvider = state.sdk.wallet.ethProvider;
+    if (!ethProvider) {
+      return;
+    }
+
+    const win = window as Window;
+    win.__nounspaceMiniAppEthProvider = ethProvider;
+
+    const iconUrl = new URL(
+      MINI_APP_PROVIDER_METADATA.iconPath,
+      window.location.origin,
+    ).toString();
+
+    const providerInfo = {
+      uuid: MINI_APP_PROVIDER_METADATA.uuid,
+      name: MINI_APP_PROVIDER_METADATA.name,
+      icon: iconUrl,
+      rdns: MINI_APP_PROVIDER_METADATA.rdns,
+    } as const;
+
+    win.__nounspaceMiniAppProviderInfo = providerInfo;
+
+    const announceProvider = () => {
+      const detail = Object.freeze({
+        info: Object.freeze({ ...providerInfo }),
+        provider: ethProvider,
+      });
+
+      window.dispatchEvent(
+        new CustomEvent("eip6963:announceProvider", {
+          detail,
+        }),
+      );
+    };
+
+    window.dispatchEvent(new Event("ethereum#initialized"));
+    announceProvider();
+
+    const handleRequestProvider = () => {
+      announceProvider();
+    };
+
+    window.addEventListener(
+      "eip6963:requestProvider",
+      handleRequestProvider,
+    );
+
+    window.dispatchEvent(new CustomEvent("eip6963:requestProvider"));
+
+    return () => {
+      if (win.__nounspaceMiniAppEthProvider === ethProvider) {
+        delete win.__nounspaceMiniAppEthProvider;
+      }
+
+      if (
+        win.__nounspaceMiniAppProviderInfo &&
+        win.__nounspaceMiniAppProviderInfo.uuid === providerInfo.uuid
+      ) {
+        delete win.__nounspaceMiniAppProviderInfo;
+      }
+
+      window.removeEventListener(
+        "eip6963:requestProvider",
+        handleRequestProvider,
+      );
+    };
+  }, [state.isReady, state.sdk]);
 
   return (
     <MiniAppSdkContext.Provider value={state}>


### PR DESCRIPTION
## Summary
- expose the Farcaster frame wallet provider on window once the SDK is ready and announce it via the standard EIP-6963 events
- detect mini-app iframe usage and bootstrap child documents so they inherit the host provider across direct URLs and sanitized embed code

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1826a988483258b0ff3c278083f44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mini‑app aware iframe embedding with secure bootstrap for direct and iframely embeds, preserving sizing, loading, referrer, allow, and frameborder behavior.
  * Automatic provider discovery and broadcast in mini‑app environments so embedded content and compatible tools can detect/connect to the provider.
  * Unified, stricter sandbox defaults across embeds for improved security and consistency.
  * Enhanced parsing of embed HTML for more reliable iframe rendering while preserving existing URL-based flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->