### PR TITLE
Channel Spaces - Generated based on Documentation

### DIFF
--- a/src/app/(spaces)/channel/[channelName]/ChannelSpace.tsx
+++ b/src/app/(spaces)/channel/[channelName]/ChannelSpace.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import React, { useMemo } from "react";
+import { ChannelSpaceData } from "@/common/types/spaceData";
+import PublicSpace from "../../PublicSpace";
+
+export interface ChannelSpaceProps {
+  spaceData: Omit<ChannelSpaceData, 'isEditable' | 'spacePageUrl'>;
+  tabName: string;
+}
+
+const ChannelSpace: React.FC<ChannelSpaceProps> = ({
+  spaceData,
+  tabName,
+}) => {
+  const spaceDataWithEditability = useMemo(() => ({
+    ...spaceData,
+    isEditable: (currentUserFid: number | undefined, wallets?: { address: any }[]) => 
+      isChannelSpaceEditable(spaceData.spaceOwnerFid, currentUserFid),
+    spacePageUrl: (tabName: string) => `/channel/${spaceData.channelName}/${tabName}`,
+  }), [spaceData]);
+
+  return (
+    <PublicSpace
+      spacePageData={spaceDataWithEditability}
+      tabName={tabName}
+    />
+  );
+};
+
+// Channel space editability logic
+const isChannelSpaceEditable = (
+  spaceOwnerFid: number | undefined,
+  currentUserFid: number | undefined,
+): boolean => {
+  if (!currentUserFid || !spaceOwnerFid) {
+    return false;
+  }
+  
+  // Channel spaces are editable by the channel lead/owner
+  return currentUserFid === spaceOwnerFid;
+};
+
+export default ChannelSpace;

--- a/src/app/(spaces)/channel/[channelName]/[tabName]/page.tsx
+++ b/src/app/(spaces)/channel/[channelName]/[tabName]/page.tsx
@@ -1,0 +1,2 @@
+// Re-export the main page component for tab routing
+export { default } from "../page";

--- a/src/app/(spaces)/channel/[channelName]/page.tsx
+++ b/src/app/(spaces)/channel/[channelName]/page.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { loadChannelSpaceData } from "./utils";
+import ChannelSpace from "./ChannelSpace";
+import SpaceNotFound from "@/app/(spaces)/SpaceNotFound";
+
+export default async function ChannelSpacePage({ 
+  params 
+}: {
+  params: Promise<{ channelName: string; tabName?: string }>
+}) {
+  const { channelName, tabName: tabNameParam } = await params;
+  
+  if (!channelName) {
+    return <SpaceNotFound />;
+  }
+
+  const decodedTabName = tabNameParam ? decodeURIComponent(tabNameParam) : undefined;
+  const channelSpaceData = await loadChannelSpaceData(
+    channelName,
+    decodedTabName,
+  );
+
+  if (!channelSpaceData) {
+    return <SpaceNotFound />;
+  }
+
+  return (
+    <ChannelSpace
+      spaceData={channelSpaceData}
+      tabName={decodedTabName || channelSpaceData.defaultTab}
+    />
+  );
+}

--- a/src/app/(spaces)/channel/[channelName]/utils.ts
+++ b/src/app/(spaces)/channel/[channelName]/utils.ts
@@ -1,0 +1,77 @@
+import axiosBackend from "@/common/data/api/backend";
+import { unstable_noStore as noStore } from "next/cache";
+import { ChannelSpaceData, SPACE_TYPES } from "@/common/types/spaceData";
+import createInitialChannelSpaceConfigForName from "@/constants/initialChannelSpace";
+
+export interface ChannelMetadata {
+  id: string;
+  name: string;
+  leadFid?: number | null;
+}
+
+export const getChannelMetadata = async (
+  channelName: string,
+): Promise<ChannelMetadata | null> => {
+  try {
+    const { data } = await axiosBackend.get("/api/farcaster/neynar/channel", {
+      params: { id: channelName.toLowerCase() },
+    });
+    const ch = data.channel;
+    return {
+      id: ch.id,
+      name: ch.name,
+      leadFid: ch.lead_fid ?? ch.owner_fid ?? ch.host_fid ?? null,
+    } as ChannelMetadata;
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+};
+
+export const createChannelSpaceData = (
+  spaceId: string,
+  spaceName: string,
+  channelName: string,
+  channelId: string,
+  spaceOwnerFid?: number,
+  tabName?: string,
+): Omit<ChannelSpaceData, 'isEditable' | 'spacePageUrl'> => {
+  const config = createInitialChannelSpaceConfigForName(channelName);
+  
+  return {
+    spaceId,
+    spaceName,
+    spaceType: SPACE_TYPES.CHANNEL,
+    updatedAt: new Date().toISOString(),
+    defaultTab: "Channel",
+    config,
+    channelName: channelName.toLowerCase(),
+    channelId,
+    spaceOwnerFid,
+  };
+};
+
+export const loadChannelSpaceData = async (
+  channelName: string,
+  tabNameParam?: string,
+): Promise<Omit<ChannelSpaceData, 'isEditable' | 'spacePageUrl'> | null> => {
+  noStore();
+  
+  const channelMetadata = await getChannelMetadata(channelName);
+  if (!channelMetadata) {
+    return null;
+  }
+
+  const spaceId = `channel-${channelMetadata.id}`;
+  const spaceName = channelMetadata.name;
+  const spaceOwnerFid = channelMetadata.leadFid ?? undefined;
+
+  return createChannelSpaceData(
+    spaceId,
+    spaceName,
+    channelName,
+    channelMetadata.id,
+    spaceOwnerFid,
+    tabNameParam,
+  );
+};

--- a/src/app/(spaces)/channel/[channelName]/utils.ts
+++ b/src/app/(spaces)/channel/[channelName]/utils.ts
@@ -36,7 +36,10 @@ export const createChannelSpaceData = (
   spaceOwnerFid?: number,
   tabName?: string,
 ): Omit<ChannelSpaceData, 'isEditable' | 'spacePageUrl'> => {
-  const config = createInitialChannelSpaceConfigForName(channelName);
+  const config = {
+    ...createInitialChannelSpaceConfigForName(channelName),
+    timestamp: new Date().toISOString(),
+  };
   
   return {
     spaceId,

--- a/src/common/types/spaceData.ts
+++ b/src/common/types/spaceData.ts
@@ -1,78 +1,74 @@
-import { SpaceConfig } from '@/app/(spaces)/Space';
-import { Address } from 'viem';
-import { MasterToken } from '@/common/providers/TokenProvider';
-import { ProposalData } from '@/app/(spaces)/p/[proposalId]/utils';
+import { Address } from "viem";
+import { MasterToken } from "@/common/providers/TokenProvider";
+import { SpaceConfig } from "@/app/(spaces)/Space";
 
-// Space type definitions - the single source of truth for space types
-export const SPACE_TYPES = {
-  PROFILE: 'profile',
-  TOKEN: 'token', 
-  PROPOSAL: 'proposal',
-} as const;
+export enum SPACE_TYPES {
+  PROFILE = "profile",
+  TOKEN = "token", 
+  PROPOSAL = "proposal",
+  CHANNEL = "channel",
+}
 
-// TypeScript type derived from the constants (for type checking)
-export type SpaceTypeValue = typeof SPACE_TYPES[keyof typeof SPACE_TYPES];
+export type SpaceTypeValue = `${SPACE_TYPES}`;
 
-// Base space interface with common properties
-export interface SpacePageData {
-  // Metadata
-  spaceId: string | undefined;
+// Base space data interface
+export interface SpaceData {
+  spaceId?: string; // Set by PublicSpace through registration
   spaceName: string;
-  spaceType: SpaceTypeValue;
+  spaceType: SPACE_TYPES;
   updatedAt: string;
-  defaultTab: string;
-  currentTab: string;
-  spaceOwnerFid: number | undefined;
-  
-  // URL generation function for this space
   spacePageUrl: (tabName: string) => string;
-  
-  // Each space type implements its own logic for editability
-  isEditable: (currentUserFid: number | undefined, wallets?: { address: Address }[]) => boolean;
-  
-  // Configuration - using Omit<SpaceConfig, "isEditable"> since isEditable is determined at runtime
-  config: Omit<SpaceConfig, "isEditable">;
+  isEditable: (currentUserFid?: number, wallets?: { address: Address }[]) => boolean;
+  defaultTab: string; // Default tab name for this space
+  config: SpaceConfig;
 }
 
-// Type-specific space interfaces
-export interface ProfileSpacePageData extends SpacePageData {
-  spaceType: typeof SPACE_TYPES.PROFILE;
-  defaultTab: 'Profile';
-  identityPublicKey?: string;
+// Type-specific space data interfaces
+export interface ProfileSpaceData extends SpaceData {
+  fid: number;
+  spaceOwnerFid?: number;
 }
 
-export interface TokenSpacePageData extends SpacePageData {
-  spaceType: typeof SPACE_TYPES.TOKEN;
-  defaultTab: 'Token';
-  contractAddress: string;
+export interface TokenSpaceData extends SpaceData {
+  contractAddress: Address;
   network: string;
-  spaceOwnerAddress: Address;
-  tokenData?: MasterToken; // Optional to allow for loading states
-  identityPublicKey?: string;
+  ownerAddress: Address;
+  tokenData?: MasterToken;
 }
 
-export interface ProposalSpacePageData extends SpacePageData {
-  spaceType: typeof SPACE_TYPES.PROPOSAL;
-  defaultTab: 'Overview';
+export interface ProposalSpaceData extends SpaceData {
   proposalId: string;
-  spaceOwnerAddress: Address;
-  proposalData?: ProposalData;
-  identityPublicKey?: string;
+  ownerAddress: Address;
 }
 
-// Union type for all spaces
-export type Space = ProfileSpacePageData | TokenSpacePageData | ProposalSpacePageData;
-
-// Type guards (actual TypeScript type guards that narrow types)
-export function isProfileSpace(space: SpacePageData): space is ProfileSpacePageData {
-  return space.spaceType === SPACE_TYPES.PROFILE;
+export interface ChannelSpaceData extends SpaceData {
+  channelName: string;
+  channelId: string;
+  spaceOwnerFid?: number;
 }
 
-export function isTokenSpace(space: SpacePageData): space is TokenSpacePageData {
-  return space.spaceType === SPACE_TYPES.TOKEN;
+// Union type for all space data types
+export type SpacePageData = ProfileSpaceData | TokenSpaceData | ProposalSpaceData | ChannelSpaceData;
+
+// Type guards for space data
+export function isProfileSpace(spaceData: SpacePageData): spaceData is ProfileSpaceData {
+  return spaceData.spaceType === SPACE_TYPES.PROFILE;
 }
 
-export function isProposalSpace(space: SpacePageData): space is ProposalSpacePageData {
-  return space.spaceType === SPACE_TYPES.PROPOSAL;
+export function isTokenSpace(spaceData: SpacePageData): spaceData is TokenSpaceData {
+  return spaceData.spaceType === SPACE_TYPES.TOKEN;
 }
 
+export function isProposalSpace(spaceData: SpacePageData): spaceData is ProposalSpaceData {
+  return spaceData.spaceType === SPACE_TYPES.PROPOSAL;
+}
+
+export function isChannelSpace(spaceData: SpacePageData): spaceData is ChannelSpaceData {
+  return spaceData.spaceType === SPACE_TYPES.CHANNEL;
+}
+
+// Backward compatibility aliases
+export type ProfileSpacePageData = ProfileSpaceData;
+export type TokenSpacePageData = TokenSpaceData;
+export type ProposalSpacePageData = ProposalSpaceData;
+export type ChannelSpacePageData = ChannelSpaceData;

--- a/src/constants/initialChannelSpace.ts
+++ b/src/constants/initialChannelSpace.ts
@@ -1,0 +1,56 @@
+import { SpaceConfig } from "@/app/(spaces)/Space";
+import { FeedType, FilterType } from "@neynar/nodejs-sdk/build/api";
+import { cloneDeep } from "lodash";
+import { getLayoutConfig } from "@/common/utils/layoutFormatUtils";
+import { INITIAL_SPACE_CONFIG_EMPTY } from "./initialSpaceConfig";
+
+// Set default tabNames for channel spaces
+const INITIAL_CHANNEL_SPACE_CONFIG = cloneDeep(INITIAL_SPACE_CONFIG_EMPTY);
+INITIAL_CHANNEL_SPACE_CONFIG.tabNames = ["Channel"];
+
+const createInitialChannelSpaceConfigForName = (
+  channelName: string,
+): Omit<SpaceConfig, "isEditable"> => {
+  const config = cloneDeep(INITIAL_CHANNEL_SPACE_CONFIG);
+  config.fidgetInstanceDatums = {
+    "feed:channel": {
+      config: {
+        editable: false,
+        settings: {
+          feedType: FeedType.Filter,
+          filterType: FilterType.ChannelId,
+          channel: channelName,
+        },
+        data: {},
+      },
+      fidgetType: "feed",
+      id: "feed:channel",
+    },
+  };
+  const layoutItems = [
+    {
+      w: 12,
+      h: 8,
+      x: 0,
+      y: 0,
+      i: "feed:channel",
+      minW: 4,
+      maxW: 36,
+      minH: 6,
+      maxH: 36,
+      moved: false,
+      static: false,
+    },
+  ];
+
+  // Set the layout configuration
+  const layoutConfig = getLayoutConfig(config.layoutDetails);
+  layoutConfig.layout = layoutItems;
+  
+  // Set default tab names
+  config.tabNames = ["Channel"];
+  
+  return config;
+};
+
+export default createInitialChannelSpaceConfigForName;

--- a/src/pages/api/space/registry/index.ts
+++ b/src/pages/api/space/registry/index.ts
@@ -43,10 +43,18 @@ export interface SpaceRegistrationProposer extends SpaceRegistrationBase {
   proposalId: string;
 }
 
+export interface SpaceRegistrationChannel extends SpaceRegistrationBase {
+  spaceType: typeof SPACE_TYPES.CHANNEL;
+  channelName: string;
+  channelId: string;
+  spaceOwnerFid?: number;
+}
+
 export type SpaceRegistration =
   | SpaceRegistrationContract
   | SpaceRegistrationFid
-  | SpaceRegistrationProposer;
+  | SpaceRegistrationProposer
+  | SpaceRegistrationChannel;
 
 type SpaceInfo = SpaceRegistrationBase & {
   spaceId: string;
@@ -54,6 +62,8 @@ type SpaceInfo = SpaceRegistrationBase & {
   contractAddress: string | null;
   network: string | null;
   proposalId?: string | null;
+  channelName?: string | null;
+  channelId?: string | null;
 };
 
 function isSpaceRegistration(maybe: unknown): maybe is SpaceRegistration {
@@ -91,6 +101,16 @@ function isSpaceRegistrationProposer(maybe: unknown): maybe is SpaceRegistration
     isSpaceRegistration(maybe) &&
     maybe["spaceType"] === SPACE_TYPES.PROPOSAL &&
     typeof maybe["proposalId"] === "string"
+  );
+}
+
+// Type guard to handle SpaceRegistrationChannel
+function isSpaceRegistrationChannel(maybe: unknown): maybe is SpaceRegistrationChannel {
+  return (
+    isSpaceRegistration(maybe) &&
+    maybe["spaceType"] === SPACE_TYPES.CHANNEL &&
+    typeof maybe["channelName"] === "string" &&
+    typeof maybe["channelId"] === "string"
   );
 }
 
@@ -218,6 +238,9 @@ async function registerNewSpace(
     }
   } else if (isSpaceRegistrationProposer(registration)) {
     // Handle proposer-specific logic if needed
+  } else if (isSpaceRegistrationChannel(registration)) {
+    // Handle channel-specific logic if needed
+    // For now, allow any identity to register channel spaces
   }
 
   if ("tokenOwnerFid" in registration && registration.tokenOwnerFid) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added channel spaces with dedicated routes and tab support (e.g., /channel/{name}), including graceful "not found" handling.
  - Channel pages auto-load channel metadata and use a tailored default layout.
  - Owners can edit channel spaces; others have view-only access.
  - Visiting a channel reuses any matching local space to preserve content and selected tab.

- Improvements
  - Streamlined channel registration and initial config generation for fast setup; registration can be invoked from the app store.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->