### PR TITLE
Improve feed video embed sizing

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,6 +12,7 @@ const cspHeader = `
     default-src 'self';
     script-src 'self' 'unsafe-eval' 'unsafe-inline' https://challenges.cloudflare.com https://www.youtube.com https://www.youtube.com/iframe_api https://auth.privy.nounspace.com https://cdn.segment.com;
     style-src 'self' 'unsafe-inline' https://i.ytimg.com https://mint.highlight.xyz;
+    media-src 'self' blob: data: https://stream.warpcast.com https://stream.farcaster.xyz https://res.cloudinary.com/;
     img-src 'self' blob: data: https:;
     font-src 'self' https: data: blob: https://fonts.googleapis.com https://fonts.gstatic.com;
     object-src 'none';
@@ -39,7 +40,10 @@ const cspHeader = `
       https://api.segment.io
       https://api.imgbb.com
       https://api.goldsky.com
-      https://base-mainnet.g.alchemy.com;
+      https://base-mainnet.g.alchemy.com
+      https://stream.warpcast.com
+      https://stream.farcaster.xyz
+      https://res.cloudinary.com/;
 
     upgrade-insecure-requests;
 `;

--- a/src/fidgets/farcaster/components/Embeds/VideoEmbed.tsx
+++ b/src/fidgets/farcaster/components/Embeds/VideoEmbed.tsx
@@ -1,14 +1,17 @@
-import React, { useCallback, useState } from "react";
+import React, { CSSProperties, useCallback, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 
 const ReactHlsPlayer = dynamic(() => import("@gumlet/react-hls-player"), {
   ssr: false,
 });
 
+const MAX_EMBED_HEIGHT = 500;
+
 const VideoEmbed = ({ url }: { url: string }) => {
   const [muted, setMuted] = useState(true);
   const [didUnmute, setDidUnmute] = useState(false);
   const playerRef = React.useRef<HTMLVideoElement | null>(null);
+  const [videoDimensions, setVideoDimensions] = useState<{ width: number; height: number } | null>(null);
 
   const togglePlay = useCallback(() => {
     if (!playerRef.current) return;
@@ -33,18 +36,64 @@ const VideoEmbed = ({ url }: { url: string }) => {
     [didUnmute, togglePlay],
   );
 
+  const onLoadedMetadata = useCallback(() => {
+    if (!playerRef.current) return;
+
+    const { videoWidth, videoHeight } = playerRef.current;
+    if (!videoWidth || !videoHeight) return;
+
+    setVideoDimensions((prev) => {
+      if (prev?.width === videoWidth && prev?.height === videoHeight) {
+        return prev;
+      }
+
+      return { width: videoWidth, height: videoHeight };
+    });
+  }, []);
+
+  const aspectRatio = useMemo(() => {
+    if (!videoDimensions?.width || !videoDimensions.height) {
+      return null;
+    }
+
+    return videoDimensions.width / videoDimensions.height;
+  }, [videoDimensions]);
+
+  const containerStyles = useMemo(() => {
+    const styles: CSSProperties = {
+      width: "100%",
+    };
+
+    if (aspectRatio && aspectRatio < 1) {
+      styles.maxWidth = `${MAX_EMBED_HEIGHT * aspectRatio}px`;
+    }
+
+    return styles;
+  }, [aspectRatio]);
+
+  const videoStyles = useMemo<CSSProperties>(() => ({
+    width: "100%",
+    height: "auto",
+    maxHeight: MAX_EMBED_HEIGHT,
+  }), []);
+
   return (
-    <ReactHlsPlayer
-      src={url}
-      muted={muted}
-      autoPlay={false}
-      controls={true}
-      width="100%"
-      height="auto"
-      playerRef={playerRef}
-      onClick={onClick}
-      className="object-contain size-full"
-    />
+    <div className="flex w-full justify-center" style={containerStyles}>
+      <ReactHlsPlayer
+        src={url}
+        muted={muted}
+        autoPlay={false}
+        controls={true}
+        width="100%"
+        height="auto"
+        playerRef={playerRef}
+        onClick={onClick}
+        onLoadedMetadata={onLoadedMetadata}
+        playsInline
+        className="h-auto w-full rounded-lg object-contain"
+        style={videoStyles}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- calculate the intrinsic aspect ratio of feed video embeds once metadata is loaded
- constrain portrait videos to an appropriate max width so they fit within the feed container without cropping
- ensure the HLS player stays centered with inline playback enabled

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c95bbe8883259c5de11290d62e29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video embeds now auto-detect dimensions and render with the correct aspect ratio.
  * Responsive layout caps embed height at 500px and adjusts width for narrow videos to preserve aspect ratio.
  * Inline playback enabled for improved mobile experience; player displays full width with automatic height for consistent presentation.

* **Chores**
  * Added support for additional trusted media/streaming hosts to improve playback reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->