### PR TITLE
Ensure Cloudinary-hosted cast images render inline

### DIFF
--- a/src/common/lib/utils/urls.ts
+++ b/src/common/lib/utils/urls.ts
@@ -3,9 +3,19 @@ export const isImageUrl = (url: string) => {
     return false;
   }
 
+  try {
+    const { hostname } = new URL(url);
+    if (hostname === "res.cloudinary.com") {
+      return true;
+    }
+  } catch (error) {
+    // Ignore URL parsing errors and fall through to other checks
+  }
+
   return (
-    url.match(/\.(jpeg|jpg|gif|png)$/) != null || url.includes("imagedelivery")
-  || url.startsWith("blob:")
+    url.match(/\.(jpeg|jpg|gif|png)$/) != null ||
+    url.includes("imagedelivery") ||
+    url.startsWith("blob:")
   );
 };
 


### PR DESCRIPTION
## Summary
- treat res.cloudinary.com URLs as images so they render inline in feed embeds

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc335890f08325a13a9bb1436d40f5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloudinary-hosted image links are now consistently recognized as images across the app (galleries, previews, thumbnails).
  * Improved handling of malformed URLs to prevent errors during image detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->