### PR TITLE
shifted position of onboarding fidget

### DIFF
--- a/src/constants/intialHomebase.ts
+++ b/src/constants/intialHomebase.ts
@@ -84,8 +84,8 @@ const INITIAL_HOMEBASE_CONFIG: SpaceConfig = {
         {
           w: 6,
           h: 7,
-          x: 8,
-          y: 3,
+          x: 0,
+          y: 0,
           i: onboardingFidgetID,
           moved: false,
           static: false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the initial on-screen position of the onboarding fidget to appear at the top-left by default.
  * Ensures the first-time layout presents the fidget in a predictable, clearly visible location.
  * No changes to interactions or functionality; only the starting coordinates were updated.
  * Rendering and navigation remain the same outside of this positional update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->