### PR TITLE
Fix CSP for warpcast and farcaster video streams

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -45,7 +45,7 @@ const cspHeader = `
       https://base-mainnet.g.alchemy.com
       https://eth-mainnet.g.alchemy.com
       https://cloudflare-eth.com
-      https://api.coingecko.com;
+      https://api.coingecko.com
       https://stream.warpcast.com
       https://stream.farcaster.xyz
       https://res.cloudinary.com/;


### PR DESCRIPTION
Accidentally removed warpcast and farcaster stream domains from the CSP when resolving a merge conflict earlier in another branch (left a stray semicolon behind). This fixes

## Summary
- ensure stream.warpcast.com and stream.farcaster.xyz are included inside the connect-src directive
- prevent Content-Security-Policy parsing errors that blocked HLS video playback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df05d3f0e48325b82061b35502f52e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Content Security Policy syntax in the connect-src directive to prevent parsing issues.
  * Improves cross-browser compatibility and reduces blocked network requests to external APIs (e.g., market data provider).
  * Results in more reliable data fetching and fewer console warnings.
* **Chores**
  * Minor configuration cleanup with no changes to UI or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->