### PR TITLE
Signal readiness once the mini app UI mounts

### DIFF
--- a/src/common/components/utilities/MiniAppReady.tsx
+++ b/src/common/components/utilities/MiniAppReady.tsx
@@ -3,9 +3,17 @@
 import { useEffect, useRef } from "react";
 import { useMiniAppSdk } from "@/common/lib/hooks/useMiniAppSdk";
 
+const MAX_ATTEMPTS = 120;
+const MAX_DURATION_MS = 10_000;
+const FALLBACK_DELAY_MS = 1_500;
+
 const MiniAppReady = () => {
   const { sdk } = useMiniAppSdk();
   const hasSignaledReady = useRef(false);
+  const attemptCount = useRef(0);
+  const startTime = useRef<number | null>(null);
+  const fallbackAttempted = useRef(false);
+  const lastLoggedError = useRef<string | null>(null);
 
   useEffect(() => {
     if (!sdk || hasSignaledReady.current) {
@@ -19,24 +27,90 @@ const MiniAppReady = () => {
       hasSignaledReady.current = true;
     };
 
+    const getTimestamp = () => {
+      if (typeof performance !== "undefined" && typeof performance.now === "function") {
+        return performance.now();
+      }
+
+      return Date.now();
+    };
+
     const attemptSignal = async () => {
       if (!sdk || cancelled || hasSignaledReady.current) {
         return;
       }
 
-      try {
-        const isMiniApp =
-          typeof sdk.isInMiniApp === "function" ? await sdk.isInMiniApp() : true;
+      if (startTime.current === null) {
+        startTime.current = getTimestamp();
+      }
 
-        if (!isMiniApp) {
+      attemptCount.current += 1;
+
+      const now = getTimestamp();
+      const elapsed = now - startTime.current;
+      const limitReached =
+        attemptCount.current >= MAX_ATTEMPTS || elapsed >= MAX_DURATION_MS;
+
+      let isMiniApp: boolean | null = null;
+      if (typeof sdk.isInMiniApp === "function") {
+        try {
+          isMiniApp = await sdk.isInMiniApp();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (lastLoggedError.current !== message) {
+            console.warn("Mini app readiness detection failed:", error);
+            lastLoggedError.current = message;
+          }
+          isMiniApp = null;
+        }
+      }
+
+      let shouldAttemptReady = true;
+      let usedFallback = false;
+
+      if (isMiniApp === false) {
+        if (!fallbackAttempted.current) {
+          if (elapsed >= FALLBACK_DELAY_MS || limitReached) {
+            usedFallback = true;
+          } else {
+            shouldAttemptReady = false;
+          }
+        } else if (limitReached) {
+          markComplete();
+          return;
+        } else {
+          shouldAttemptReady = false;
+        }
+      }
+
+      if (!shouldAttemptReady) {
+        if (limitReached) {
+          markComplete();
+        } else {
+          scheduleAttempt();
+        }
+        return;
+      }
+
+      if (usedFallback) {
+        fallbackAttempted.current = true;
+      }
+
+      try {
+        await sdk.actions.ready();
+        markComplete();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (lastLoggedError.current !== message) {
+          console.error("Error signaling mini app ready:", error);
+          lastLoggedError.current = message;
+        }
+
+        if (limitReached) {
           markComplete();
           return;
         }
 
-        await sdk.actions.ready();
-        markComplete();
-      } catch (error) {
-        console.error("Error signaling mini app ready:", error);
         scheduleAttempt();
       }
     };

--- a/src/common/components/utilities/MiniAppReady.tsx
+++ b/src/common/components/utilities/MiniAppReady.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useMiniAppSdk } from "@/common/lib/hooks/useMiniAppSdk";
+import useMiniApp from "@/common/utils/useMiniApp";
+
+const MiniAppReady = () => {
+  const { sdk } = useMiniAppSdk();
+  const { isInMiniApp } = useMiniApp();
+  const hasSignaledReady = useRef(false);
+
+  useEffect(() => {
+    if (hasSignaledReady.current) {
+      return;
+    }
+
+    if (!sdk || isInMiniApp !== true) {
+      return;
+    }
+
+    let animationFrameId: number | null = null;
+    let readyCompleted = false;
+
+    hasSignaledReady.current = true;
+
+    const signalReady = async () => {
+      try {
+        await sdk.actions.ready();
+        readyCompleted = true;
+      } catch (error) {
+        console.error("Error signaling mini app ready:", error);
+        hasSignaledReady.current = false;
+      }
+    };
+
+    if (typeof window === "undefined") {
+      signalReady();
+    } else {
+      animationFrameId = window.requestAnimationFrame(signalReady);
+    }
+
+    return () => {
+      if (!readyCompleted) {
+        hasSignaledReady.current = false;
+      }
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+    };
+  }, [sdk, isInMiniApp]);
+
+  return null;
+};
+
+export default MiniAppReady;

--- a/src/common/providers/MiniAppSdkProvider.tsx
+++ b/src/common/providers/MiniAppSdkProvider.tsx
@@ -58,22 +58,23 @@ export const MiniAppSdkProvider: React.FC<{ children: React.ReactNode }> = ({
 
     const initializeSdk = async () => {
       try {
-        // Initialize the frame SDK
-        await frameSdk.actions.ready();
-
-        // Store the sdk reference
-        // Get initial frame context - it's a Promise
-        const initialFrameContext = await frameSdk.context;
-
-        // console.log("Frame SDK initialized successfully.", initialFrameContext);
-
         setState((prev) => ({
           ...prev,
           sdk: frameSdk,
-          frameContext: initialFrameContext,
           isInitializing: false,
-          isReady: true,
         }));
+
+        try {
+          const initialFrameContext = await frameSdk.context;
+
+          setState((prev) => ({
+            ...prev,
+            frameContext: initialFrameContext,
+            isReady: true,
+          }));
+        } catch (contextError) {
+          console.error("Failed to fetch mini app context:", contextError);
+        }
       } catch (err) {
         console.error("Failed to initialize Frame SDK:", err);
         setState((prev) => ({

--- a/src/common/providers/index.tsx
+++ b/src/common/providers/index.tsx
@@ -12,6 +12,7 @@ import VersionCheckProivder from "./VersionCheckProvider";
 import { SidebarContextProvider } from "@/common/components/organisms/Sidebar";
 import AnalyticsProvider from "./AnalyticsProvider";
 import { ToastProvider } from "../components/atoms/Toast";
+import MiniAppReady from "../components/utilities/MiniAppReady";
 import MiniAppSdkProvider from "./MiniAppSdkProvider";
 import MobilePreviewProvider from "./MobilePreviewProvider";
 import { SharedDataProvider } from "./SharedDataProvider";
@@ -28,7 +29,10 @@ const RarelyUpdatedProviders = React.memo(
         <AnalyticsProvider>
           <MiniAppSdkProvider>
             <SharedDataProvider>
-              <ToastProvider>{children}</ToastProvider>
+              <ToastProvider>
+                <MiniAppReady />
+                {children}
+              </ToastProvider>
             </SharedDataProvider>
           </MiniAppSdkProvider>
         </AnalyticsProvider>


### PR DESCRIPTION
## Summary
- stop calling the Farcaster frame SDK `ready` action during provider bootstrap and fetch the initial context separately
- add a `MiniAppReady` client utility that signals `ready` on the next frame after the UI mounts when running inside a mini app
- render the new readiness utility alongside the global providers so mini app shells hide their splash screens promptly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3e5321b608325aee40f2f77405f99