### PR TITLE
Refine mini app SDK initialization handshake

### DIFF
--- a/src/common/components/utilities/MiniAppReady.tsx
+++ b/src/common/components/utilities/MiniAppReady.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useContext, useEffect, useRef } from "react";
+import { MiniAppSdkContext } from "../../providers/MiniAppSdkProvider";
+
+const MiniAppReady = () => {
+  const { sdk, isReady, setContextState } = useContext(MiniAppSdkContext);
+  const hasLoggedErrorRef = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (!sdk || isReady) {
+      return;
+    }
+
+    let rafId: number | null = null;
+    let cancelled = false;
+
+    hasLoggedErrorRef.current = false;
+
+    const attemptReady = () => {
+      if (!sdk || cancelled) {
+        return;
+      }
+
+      sdk.actions
+        .ready()
+        .then(() => {
+          if (cancelled) {
+            return;
+          }
+
+          setContextState((prev) => ({
+            ...prev,
+            isReady: true,
+            isInitializing: false,
+            error: null,
+          }));
+          hasLoggedErrorRef.current = false;
+        })
+        .catch((err) => {
+          if (cancelled) {
+            return;
+          }
+
+          if (!hasLoggedErrorRef.current) {
+            console.error("Mini App ready handshake failed:", err);
+            hasLoggedErrorRef.current = true;
+          }
+
+          setContextState((prev) => ({
+            ...prev,
+            error: err instanceof Error ? err : new Error(String(err)),
+          }));
+
+          rafId = window.requestAnimationFrame(attemptReady);
+        });
+    };
+
+    rafId = window.requestAnimationFrame(attemptReady);
+
+    return () => {
+      cancelled = true;
+      if (rafId !== null) {
+        window.cancelAnimationFrame(rafId);
+      }
+    };
+  }, [sdk, isReady, setContextState]);
+
+  return null;
+};
+
+export default MiniAppReady;


### PR DESCRIPTION
## Summary
- expose the Frame SDK from MiniAppSdkProvider immediately and store the initial context without awaiting the ready handshake
- extend the provider context with a setter so a dedicated MiniAppReady helper component can manage the readiness lifecycle
- mount a MiniAppReady effect that retries sdk.actions.ready() with requestAnimationFrame until the handshake succeeds

## Testing
- npm run lint
- npm run check-types

------
https://chatgpt.com/codex/tasks/task_e_68e4089f46c8832593603777ea23818d