### PR TITLE
Fix profile space tab selection using cached channel config

### DIFF
--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -146,6 +146,23 @@ export default function PublicSpace({
 
   const requestedTabName =
     currentTabNameValue || providedTabName || spacePageData.defaultTab;
+
+  const currentConfig = getCurrentSpaceConfig();
+  if (!currentConfig) {
+    console.error("Current space config is undefined");
+  }
+
+  const resolvedTabName = useMemo(() => {
+    if (hasMatchingSpace && currentConfig?.tabs?.[requestedTabName]) {
+      return requestedTabName;
+    }
+
+    return spacePageData.defaultTab;
+  }, [currentConfig?.tabs, hasMatchingSpace, requestedTabName, spacePageData.defaultTab]);
+
+  const activeSpaceId = hasMatchingSpace
+    ? currentSpaceIdValue ?? undefined
+    : undefined;
   // Clear cache only when switching to a different space
   useEffect(() => {
     const currentSpaceId = getCurrentSpaceId();
@@ -367,23 +384,6 @@ export default function PublicSpace({
       }
     });
   }, [isSignedIntoFarcaster, authManagerLastUpdatedAt]);
-
-  const currentConfig = getCurrentSpaceConfig();
-  if (!currentConfig) {
-    console.error("Current space config is undefined");
-  }
-
-  const resolvedTabName = useMemo(() => {
-    if (hasMatchingSpace && currentConfig?.tabs?.[requestedTabName]) {
-      return requestedTabName;
-    }
-
-    return spacePageData.defaultTab;
-  }, [currentConfig?.tabs, hasMatchingSpace, requestedTabName, spacePageData.defaultTab]);
-
-  const activeSpaceId = hasMatchingSpace
-    ? currentSpaceIdValue ?? undefined
-    : undefined;
 
   const config = {
     ...(hasMatchingSpace && currentConfig?.tabs?.[resolvedTabName]

--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -10,6 +10,7 @@ import type {
   UpdatableDatabaseWritableSpaceSaveConfig,
   UpdatableSpaceConfig,
 } from "@/common/data/stores/app/space/spaceStore";
+import { sanitizeTabConfig as sanitizeTabConfigShape } from "@/common/utils/sanitizeTabConfig";
 import { EtherScanChainName } from "@/constants/etherscanChainIds";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialSpaceConfig";
 import Profile from "@/fidgets/ui/profile";
@@ -550,64 +551,13 @@ export default function PublicSpace({
   const sanitizeTabConfig = useCallback(
     (
       candidate?: SanitizableTabConfig,
-    ): ServerTabConfig | undefined => {
-      if (!candidate) {
-        return undefined;
-      }
-
-      if (!isPlainObject(candidate)) {
-        console.warn(
-          "Ignoring cached tab config because it is not a plain object",
-          resolvedTabName,
-        );
-        return undefined;
-      }
-
-      const { fidgetInstanceDatums, layoutDetails, theme } = candidate as {
-        fidgetInstanceDatums?: unknown;
-        layoutDetails?: unknown;
-        theme?: unknown;
-      };
-
-      if (
-        (fidgetInstanceDatums != null && !isPlainObject(fidgetInstanceDatums)) ||
-        (layoutDetails != null && !isPlainObject(layoutDetails)) ||
-        (theme != null && !isPlainObject(theme))
-      ) {
-        console.warn(
-          "Ignoring cached tab config because it is missing required plain-object fields",
-          resolvedTabName,
-        );
-        return undefined;
-      }
-
-      if (isPlainObject(fidgetInstanceDatums)) {
-        for (const [key, datum] of Object.entries(
-          fidgetInstanceDatums as Record<string, unknown>,
-        )) {
-          if (!isPlainObject(datum)) {
-            console.warn(
-              "Ignoring cached tab config because fidget datum is not a plain object",
-              resolvedTabName,
-              key,
-            );
-            return undefined;
-          }
-
-          const configValue = (datum as { config?: unknown }).config;
-          if (configValue != null && !isPlainObject(configValue)) {
-            console.warn(
-              "Ignoring cached tab config because fidget config is not a plain object",
-              resolvedTabName,
-              key,
-            );
-            return undefined;
-          }
-        }
-      }
-
-      return cloneDeep(candidate) as ServerTabConfig;
-    },
+    ): ServerTabConfig | undefined =>
+      sanitizeTabConfigShape<SanitizableTabConfig>(candidate, {
+        tabName: resolvedTabName,
+        defaultIsPrivate: false,
+        log: (message, ...details) =>
+          console.warn("Ignoring cached tab config:", message, ...details),
+      }) as ServerTabConfig | undefined,
     [resolvedTabName],
   );
 

--- a/src/app/(spaces)/PublicSpace.tsx
+++ b/src/app/(spaces)/PublicSpace.tsx
@@ -6,6 +6,7 @@ import { useSidebarContext } from "@/common/components/organisms/Sidebar";
 import TabBar from "@/common/components/organisms/TabBar";
 import TabBarSkeleton from "@/common/components/organisms/TabBarSkeleton";
 import { useAppStore } from "@/common/data/stores/app";
+import type { UpdatableSpaceConfig } from "@/common/data/stores/app/space/spaceStore";
 import { EtherScanChainName } from "@/constants/etherscanChainIds";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialSpaceConfig";
 import Profile from "@/fidgets/ui/profile";
@@ -25,7 +26,7 @@ import {
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Address } from "viem";
-import { SpaceConfigSaveDetails } from "./Space";
+import type { SpaceConfig, SpaceConfigSaveDetails } from "./Space";
 import SpaceLoading from "./SpaceLoading";
 import SpacePage from "./SpacePage";
 import {
@@ -536,10 +537,17 @@ export default function PublicSpace({
     });
   }, [isSignedIntoFarcaster, authManagerLastUpdatedAt]);
 
+  type SanitizableTabConfig =
+    | (Omit<SpaceConfig, "isEditable"> & {
+        isEditable?: boolean;
+        isPrivate?: boolean;
+      })
+    | UpdatableSpaceConfig;
+
   const sanitizeTabConfig = useCallback(
     (
-      candidate?: (typeof currentConfig)["tabs"][string],
-    ): (typeof currentConfig)["tabs"][string] | undefined => {
+      candidate?: SanitizableTabConfig,
+    ): SanitizableTabConfig | undefined => {
       if (!candidate) {
         return undefined;
       }

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -7,6 +7,7 @@ import { SignedFile, signSignable } from "@/common/lib/signedFiles";
 import { EtherScanChainName } from "@/constants/etherscanChainIds";
 import { SPACE_TYPES } from "@/common/types/spaceData";
 import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialSpaceConfig";
+import { sanitizeTabConfig } from "@/common/utils/sanitizeTabConfig";
 import createIntialProfileSpaceConfigForFid from "@/constants/initialProfileSpace";
 import createInitialChannelSpaceConfig from "@/constants/initialChannelSpace";
 import {
@@ -309,6 +310,20 @@ export const createSpaceStoreFunc = (
       localCopy.timestamp = newTimestamp;
       // console.log("localCopy", localCopy);
     }
+
+    const sanitizedCopy = sanitizeTabConfig(localCopy, {
+      tabName,
+      requireIsPrivate: true,
+      defaultIsPrivate: false,
+      log: (message, ...details) =>
+        console.warn("Skipping saveLocalSpaceTab due to invalid config:", message, ...details),
+    });
+
+    if (!sanitizedCopy) {
+      return;
+    }
+
+    localCopy = sanitizedCopy;
 
     set((draft) => {
       // Create space entry if it doesn't exist

--- a/src/common/utils/sanitizeTabConfig.ts
+++ b/src/common/utils/sanitizeTabConfig.ts
@@ -1,0 +1,102 @@
+import { cloneDeep, isArray, isPlainObject } from "lodash";
+
+interface TabConfigSanitizerOptions {
+  tabName?: string;
+  log?: (message: string, ...details: unknown[]) => void;
+  defaultIsPrivate?: boolean;
+  requireIsPrivate?: boolean;
+}
+
+type TabConfigLike = Record<string, unknown> & {
+  fidgetInstanceDatums?: Record<string, unknown> | undefined;
+  layoutDetails?: Record<string, unknown> | undefined;
+  theme?: Record<string, unknown> | undefined;
+  fidgetTrayContents?: unknown;
+  isPrivate?: unknown;
+};
+
+const warn = (
+  options: TabConfigSanitizerOptions,
+  reason: string,
+  ...details: unknown[]
+) => {
+  if (options.log) {
+    if (options.tabName) {
+      options.log(reason, options.tabName, ...details);
+    } else {
+      options.log(reason, ...details);
+    }
+  }
+};
+
+export function sanitizeTabConfig<T extends Record<string, unknown>>(
+  candidate: T | undefined,
+  options: TabConfigSanitizerOptions = {},
+): (T & { isPrivate?: boolean }) | undefined {
+  if (!candidate) {
+    return undefined;
+  }
+
+  if (!isPlainObject(candidate)) {
+    warn(options, "tab config is not a plain object");
+    return undefined;
+  }
+
+  const {
+    fidgetInstanceDatums,
+    layoutDetails,
+    theme,
+    fidgetTrayContents,
+  } = candidate as TabConfigLike;
+
+  if (fidgetTrayContents != null && !isArray(fidgetTrayContents)) {
+    warn(options, "tab config fidget tray is not an array");
+    return undefined;
+  }
+
+  if (layoutDetails != null && !isPlainObject(layoutDetails)) {
+    warn(options, "tab config layout details is not a plain object");
+    return undefined;
+  }
+
+  if (theme != null && !isPlainObject(theme)) {
+    warn(options, "tab config theme is not a plain object");
+    return undefined;
+  }
+
+  if (fidgetInstanceDatums != null && !isPlainObject(fidgetInstanceDatums)) {
+    warn(options, "tab config fidget datums is not a plain object");
+    return undefined;
+  }
+
+  if (isPlainObject(fidgetInstanceDatums)) {
+    for (const [datumId, datum] of Object.entries(fidgetInstanceDatums)) {
+      if (!isPlainObject(datum)) {
+        warn(options, "tab config datum is not a plain object", datumId);
+        return undefined;
+      }
+
+      const configValue = (datum as { config?: unknown }).config;
+      if (configValue != null && !isPlainObject(configValue)) {
+        warn(
+          options,
+          "tab config datum config is not a plain object",
+          datumId,
+        );
+        return undefined;
+      }
+    }
+  }
+
+  const sanitized = cloneDeep(candidate) as T & { isPrivate?: boolean };
+
+  if (options.requireIsPrivate || sanitized.isPrivate !== undefined) {
+    sanitized.isPrivate = Boolean(sanitized.isPrivate);
+  } else if (options.defaultIsPrivate !== undefined) {
+    sanitized.isPrivate = options.defaultIsPrivate;
+  }
+
+  return sanitized;
+}
+
+export type { TabConfigSanitizerOptions };

--- a/src/common/utils/sanitizeTabConfig.ts
+++ b/src/common/utils/sanitizeTabConfig.ts
@@ -70,7 +70,11 @@ export function sanitizeTabConfig<T extends Record<string, unknown>>(
   }
 
   if (isPlainObject(fidgetInstanceDatums)) {
-    for (const [datumId, datum] of Object.entries(fidgetInstanceDatums)) {
+    const datumEntries = Object.entries(
+      fidgetInstanceDatums as Record<string, unknown>,
+    );
+
+    for (const [datumId, datum] of datumEntries) {
       if (!isPlainObject(datum)) {
         warn(options, "tab config datum is not a plain object", datumId);
         return undefined;

--- a/tests/spaceSanitization.test.ts
+++ b/tests/spaceSanitization.test.ts
@@ -1,0 +1,135 @@
+import { cloneDeep } from "lodash";
+import { vi } from "vitest";
+import { sanitizeTabConfig } from "@/common/utils/sanitizeTabConfig";
+import { createAppStore } from "@/common/data/stores/app";
+import { INITIAL_SPACE_CONFIG_EMPTY } from "@/constants/initialSpaceConfig";
+
+const createMockLocalStorage = () => {
+  let storage = new Map<string, string>();
+  return {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+    clear: () => {
+      storage.clear();
+    },
+  } as Storage;
+};
+
+describe("sanitizeTabConfig", () => {
+  it("rejects non-plain objects", () => {
+    expect(
+      sanitizeTabConfig(undefined, {
+        log: vi.fn(),
+      }),
+    ).toBeUndefined();
+    expect(
+      sanitizeTabConfig(5 as unknown as Record<string, unknown>, {
+        log: vi.fn(),
+      }),
+    ).toBeUndefined();
+  });
+
+  it("coerces isPrivate to a boolean when present", () => {
+    const candidate = {
+      ...INITIAL_SPACE_CONFIG_EMPTY,
+      isPrivate: 1 as unknown as boolean,
+    };
+
+    const result = sanitizeTabConfig(candidate, { requireIsPrivate: true });
+
+    expect(result?.isPrivate).toBe(true);
+  });
+
+  it("deep clones the candidate to avoid external mutation", () => {
+    const candidate = {
+      ...INITIAL_SPACE_CONFIG_EMPTY,
+      theme: { ...INITIAL_SPACE_CONFIG_EMPTY.theme },
+      isPrivate: false,
+    };
+
+    const result = sanitizeTabConfig(candidate, { requireIsPrivate: true });
+
+    expect(result).not.toBe(candidate);
+    result!.theme.primary = "updated" as any;
+    expect((candidate.theme as any).primary).not.toBe("updated");
+  });
+});
+
+describe("space store sanitization", () => {
+  beforeEach(() => {
+    (globalThis as any).localStorage = createMockLocalStorage();
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).localStorage;
+  });
+
+  it("prevents invalid configs from being saved locally", async () => {
+    const store = createAppStore();
+    const invalidConfig = {
+      ...INITIAL_SPACE_CONFIG_EMPTY,
+      layoutDetails: { ...INITIAL_SPACE_CONFIG_EMPTY.layoutDetails },
+      theme: { ...INITIAL_SPACE_CONFIG_EMPTY.theme },
+      isPrivate: false,
+      fidgetInstanceDatums: {
+        broken: 42 as any,
+      },
+    };
+
+    await store.getState().space.saveLocalSpaceTab(
+      "space-1",
+      "Profile",
+      invalidConfig as any,
+    );
+
+    expect(store.getState().space.localSpaces["space-1"]).toBeUndefined();
+  });
+
+  it("filters corrupted tabs when reading current space config", () => {
+    const store = createAppStore();
+    const timestamp = new Date().toISOString();
+    const validTab = {
+      ...cloneDeep(INITIAL_SPACE_CONFIG_EMPTY),
+      isPrivate: false,
+      timestamp,
+    } as any;
+    const invalidTab = {
+      ...cloneDeep(INITIAL_SPACE_CONFIG_EMPTY),
+      isPrivate: false,
+      fidgetInstanceDatums: {
+        broken: 42 as any,
+      },
+    } as any;
+
+    store.setState((state) => ({
+      ...state,
+      space: {
+        ...state.space,
+        localSpaces: {
+          "space-1": {
+            id: "space-1",
+            updatedAt: timestamp,
+            tabs: {
+              Profile: validTab,
+              Bad: invalidTab,
+            },
+            order: ["Profile", "Bad"],
+            changedNames: {},
+          },
+        },
+      },
+    }));
+
+    store.getState().currentSpace.setCurrentSpaceId("space-1");
+
+    const config = store.getState().currentSpace.getCurrentSpaceConfig();
+
+    expect(config?.tabs.Profile).toBeDefined();
+    expect(config?.tabs.Bad).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add guards to ensure a space's cached config matches the page being rendered before using it
- resolve the active tab from the validated space instead of stale store values and gate tab actions accordingly
- prevent loading or mutating tabs when the cached space metadata does not match the requested profile space

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e532a097b88325877b26dc7e8f955a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Improvements
  - More consistent tab selection/navigation with resolved space and tab identity.
  - Safer tab configuration handling via a new sanitization step and stable in-memory config derivation.
  - Smarter local caching and clearer cache fallbacks when switching spaces.
  - Async flows guarded to avoid state updates after leaving a page.

- Bug Fixes
  - Prevents actions targeting wrong space/tab and reduces mismatched active states.
  - Fewer errors/warnings during async saves/loads; invalid configs are rejected early.

- Tests
  - Added tests for tab/space sanitization and preventing saving of invalid configs.

- Chores
  - New exported sanitizeTabConfig utility; removed one previously exported config accessor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->