### PR TITLE
Add tags to Farcaster mini app manifest

### DIFF
--- a/src/app/.well-known/farcaster.json/route.ts
+++ b/src/app/.well-known/farcaster.json/route.ts
@@ -28,7 +28,9 @@ export async function GET() {
       homeUrl: URL,
       webhookUrl: `${URL}/api/webhook`,
       primaryCategory: metadata.APP_PRIMARY_CATEGORY || process.env.NEXT_PUBLIC_APP_PRIMARY_CATEGORY,
-      tags: [],
+      tags:
+        metadata.APP_TAGS ||
+        process.env.NEXT_PUBLIC_APP_TAGS?.split(',').map((tag) => tag.trim()).filter(Boolean),
       heroImageUrl: metadata.APP_HERO_IMAGE || process.env.NEXT_PUBLIC_APP_HERO_IMAGE,
       tagline: metadata.APP_TAGLINE || process.env.NEXT_PUBLIC_APP_TAGLINE,
       ogTitle: metadata.APP_OG_TITLE || process.env.NEXT_PUBLIC_APP_OG_TITLE,

--- a/src/constants/metadata.ts
+++ b/src/constants/metadata.ts
@@ -29,4 +29,5 @@ export const metadata = {
   APP_OG_TITLE: 'Nouns',
   APP_OG_DESCRIPTION: 'The social hub for Nouns',
   APP_OG_IMAGE: 'https://www.nounspace.com/images/icon-192x192.png',
+  APP_TAGS: ['nouns', 'client', 'customizable', 'social', 'link'],
 }


### PR DESCRIPTION
## Summary
- add default Farcaster mini app tags to the metadata constants
- include the default tags array when generating the Farcaster manifest

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5465e7d288325acb2b6ee6de2b588

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Miniapp tags are now dynamically generated from configuration, allowing customizable, comma-separated tags that are trimmed and validated.
- Improvements
  - Default tags provided to enhance app discovery and categorization out-of-the-box.
- Configuration
  - Supports tags via environment variables, with sensible fallbacks to predefined defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->