### PR TITLE
Add Builder Score Talent Protocol fidget

### DIFF
--- a/src/common/data/services/fidgetOptionsService.ts
+++ b/src/common/data/services/fidgetOptionsService.ts
@@ -98,8 +98,12 @@ export class FidgetOptionsService {
           case 'frame':
           case 'chat':
           case 'profile':
+          case 'BuilderScore':
             primaryCategory = 'social';
             specificTags.push('farcaster');
+            if (key === 'BuilderScore') {
+              specificTags.push('talent protocol', 'builder score');
+            }
             break;
             
           // DeFi

--- a/src/constants/mobileFidgetIcons.ts
+++ b/src/constants/mobileFidgetIcons.ts
@@ -11,6 +11,7 @@ export const DEFAULT_FIDGET_ICON_MAP: Record<string, string> = {
   Market: 'BsBarChart',
   Portfolio: 'GiTwoCoins',
   Chat: 'BsChatDots',
+  BuilderScore: 'BsTools',
   profile: 'BsPerson',
 };
 

--- a/src/fidgets/farcaster/BuilderScore.tsx
+++ b/src/fidgets/farcaster/BuilderScore.tsx
@@ -1,0 +1,122 @@
+import React, { useMemo } from "react";
+import TextInput from "@/common/components/molecules/TextInput";
+import SwitchButton from "@/common/components/molecules/SwitchButton";
+import {
+  FidgetArgs,
+  FidgetModule,
+  FidgetProperties,
+  type FidgetSettingsStyle,
+} from "@/common/fidgets";
+import { defaultStyleFields, ErrorWrapper, WithMargin } from "@/fidgets/helpers";
+import { BsTools } from "react-icons/bs";
+
+export type BuilderScoreFidgetSettings = {
+  fid: string;
+  darkMode: boolean;
+} & FidgetSettingsStyle;
+
+const BASE_URL = "https://farcaster-talent-sco-tlzb.bolt.host";
+
+const builderScoreProperties: FidgetProperties = {
+  fidgetName: "Builder Score",
+  icon: 0x1f528, // 🔨
+  mobileIcon: <BsTools size={20} />,
+  fields: [
+    {
+      fieldName: "fid",
+      displayName: "FID",
+      displayNameHint: "Enter the Farcaster ID whose Builder Score you want to display.",
+      default: "230941",
+      required: true,
+      inputSelector: (props) => (
+        <WithMargin>
+          <TextInput {...props} />
+        </WithMargin>
+      ),
+      group: "settings",
+    },
+    {
+      fieldName: "darkMode",
+      displayName: "Dark Mode",
+      displayNameHint: "Enable the dark theme for the Builder Score view.",
+      default: false,
+      required: false,
+      inputSelector: (props) => (
+        <WithMargin>
+          <SwitchButton {...props} />
+        </WithMargin>
+      ),
+      group: "settings",
+    },
+    ...defaultStyleFields,
+  ],
+  size: {
+    minHeight: 3,
+    maxHeight: 36,
+    minWidth: 3,
+    maxWidth: 36,
+  },
+};
+
+const BuilderScore: React.FC<FidgetArgs<BuilderScoreFidgetSettings>> = ({
+  settings,
+}) => {
+  const {
+    fid = "230941",
+    darkMode = false,
+    background,
+    fidgetBorderColor,
+    fidgetBorderWidth,
+    fidgetShadow,
+  } = settings;
+
+  const normalizedFid = fid?.toString().trim();
+
+  const url = useMemo(() => {
+    if (!normalizedFid) {
+      return null;
+    }
+
+    const encodedFid = encodeURIComponent(normalizedFid);
+    const query = darkMode ? "?dark=true" : "";
+
+    return `${BASE_URL}/${encodedFid}${query}`;
+  }, [normalizedFid, darkMode]);
+
+  if (!normalizedFid || !url) {
+    return (
+      <ErrorWrapper
+        icon="🔍"
+        message="Provide a Farcaster FID to load the Builder Score."
+      />
+    );
+  }
+
+  return (
+    <div
+      style={{
+        overflow: "hidden",
+        width: "100%",
+        background,
+        borderColor: fidgetBorderColor,
+        borderWidth: fidgetBorderWidth,
+        boxShadow: fidgetShadow,
+      }}
+      className="h-[calc(100dvh-220px)] md:h-full"
+    >
+      <iframe
+        key={`${normalizedFid}-${darkMode}`}
+        src={url}
+        title="Builder Score"
+        className="size-full"
+        frameBorder="0"
+        sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-top-navigation allow-forms allow-modals allow-cursor-lock allow-orientation-lock allow-pointer-lock"
+      />
+    </div>
+  );
+};
+
+export default {
+  fidget: BuilderScore,
+  properties: builderScoreProperties,
+} as FidgetModule<FidgetArgs<BuilderScoreFidgetSettings>>;

--- a/src/fidgets/farcaster/BuilderScore.tsx
+++ b/src/fidgets/farcaster/BuilderScore.tsx
@@ -51,7 +51,7 @@ const builderScoreProperties: FidgetProperties = {
     ...defaultStyleFields,
   ],
   size: {
-    minHeight: 3,
+    minHeight: 2,
     maxHeight: 36,
     minWidth: 3,
     maxWidth: 36,

--- a/src/fidgets/farcaster/BuilderScore.tsx
+++ b/src/fidgets/farcaster/BuilderScore.tsx
@@ -15,7 +15,7 @@ export type BuilderScoreFidgetSettings = {
   darkMode: boolean;
 } & FidgetSettingsStyle;
 
-const BASE_URL = "https://farcaster-talent-sco-tlzb.bolt.host";
+const BASE_URL = "https://talent-score-eight.vercel.app";
 
 const builderScoreProperties: FidgetProperties = {
   fidgetName: "Builder Score",

--- a/src/fidgets/index.ts
+++ b/src/fidgets/index.ts
@@ -19,6 +19,7 @@ import VideoFidget from "./ui/Video";
 import marketData from "./token/marketData";
 import Portfolio from "./token/Portfolio";
 import chat from "./ui/chat";
+import BuilderScore from "./farcaster/BuilderScore";
 import MobileStack from "./layout/tabFullScreen";
 import FramesFidget from "./framesV2/components/FramesFidget";
 import NounsHome from "./nouns-home";
@@ -53,6 +54,7 @@ export const CompleteFidgets = {
   Market: marketData,
   Portfolio: Portfolio,
   Chat: chat,
+  BuilderScore: BuilderScore,
   FramesV2: FramesFidget,
 };
 


### PR DESCRIPTION
## Summary
- add a Builder Score fidget that iframes Talent Protocol profiles with configurable FID and optional dark mode support
- register the new fidget with the picker catalog and mobile icon map so it can be discovered in nounspace

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e573e283888325931aeabaefa94235

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Builder Score fidget with configurable Farcaster FID and dark mode, rendering an embedded view with customizable styling.
  - Made Builder Score available in the fidget picker/library.
  - Assigned a default mobile icon for Builder Score.
  - Improved discovery by categorizing Builder Score under Social and adding relevant tags (e.g., Farcaster, Talent Protocol, Builder Score).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->