### PR TITLE
Enhance Farcaster embed handling and validation

### DIFF
--- a/src/common/components/molecules/Modal.tsx
+++ b/src/common/components/molecules/Modal.tsx
@@ -56,7 +56,7 @@ const Modal = ({
               "w-[100vw] max-w-[600px] rounded-[10px] p-[25px]",
               "max-h-[90vh] overflow-y-auto",
               "shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none",
-              "relative overflow-visible",
+              "relative",
             )}
             // Fixes issue causing grid items to remain draggable behind open modal
             onMouseDown={(e) => e.stopPropagation()}

--- a/src/common/components/molecules/Modal.tsx
+++ b/src/common/components/molecules/Modal.tsx
@@ -54,6 +54,7 @@ const Modal = ({
             className={mergeClasses(
               "pointer-events-auto data-[state=open]:animate-contentShow bg-background",
               "w-[100vw] max-w-[600px] rounded-[10px] p-[25px]",
+              "max-h-[90vh] overflow-y-auto",
               "shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] focus:outline-none",
               "relative overflow-visible",
             )}

--- a/src/common/providers/SharedDataProvider.tsx
+++ b/src/common/providers/SharedDataProvider.tsx
@@ -7,8 +7,17 @@ import React, {
   useCallback,
   useMemo,
 } from "react";
-import { Channel, FarcasterEmbed } from '@mod-protocol/farcaster';
-import { useQueryClient } from '@tanstack/react-query';
+import { Channel } from "@mod-protocol/farcaster";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  EmbedMetadata,
+  FarcasterEmbed,
+} from "@/fidgets/farcaster/types";
+
+export type RecentEmbedEntry = {
+  embed: FarcasterEmbed;
+  metadata?: EmbedMetadata | null;
+};
 
 // Define the types of data that will be shared
 interface SharedDataContextType {
@@ -17,9 +26,9 @@ interface SharedDataContextType {
   addRecentChannel: (channel: Channel) => void;
   
   // Cache of recently processed embeds
-  recentEmbeds: Record<string, FarcasterEmbed>;
-  addRecentEmbed: (url: string, embed: FarcasterEmbed) => void;
-  getRecentEmbed: (url: string) => FarcasterEmbed | undefined;
+  recentEmbeds: Record<string, RecentEmbedEntry>;
+  addRecentEmbed: (url: string, embed: RecentEmbedEntry) => void;
+  getRecentEmbed: (url: string) => RecentEmbedEntry | undefined;
   
   // Method to invalidate specific caches
   invalidateCache: (cacheKey: string) => void;
@@ -39,7 +48,7 @@ export const SharedDataProvider: React.FC<{ children: React.ReactNode }> = ({ ch
   const [recentChannels, setRecentChannels] = useState<Channel[]>([]);
   
   // Internal state for recent embeds
-  const [recentEmbeds, setRecentEmbeds] = useState<Record<string, FarcasterEmbed>>({});
+  const [recentEmbeds, setRecentEmbeds] = useState<Record<string, RecentEmbedEntry>>({});
   
   // Adds a channel to recent ones, avoiding duplicates
   const addRecentChannel = useCallback((channel: Channel) => {
@@ -51,7 +60,7 @@ export const SharedDataProvider: React.FC<{ children: React.ReactNode }> = ({ ch
   }, []);
   
   // Adds an embed to the recent embeds cache
-  const addRecentEmbed = useCallback((url: string, embed: FarcasterEmbed) => {
+  const addRecentEmbed = useCallback((url: string, embed: RecentEmbedEntry) => {
     setRecentEmbeds((prev) => ({
       ...prev,
       [url]: embed,

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -1046,7 +1046,6 @@ const CreateCast: React.FC<CreateCastProps> = ({
                       setPreviewUrl(null);
                       setPreviewMetadata(null);
                       setPreviewError(null);
-                      setEmbedLookupMessage(null);
                     }}
                   >
                     ✕

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -1010,11 +1010,10 @@ const CreateCast: React.FC<CreateCastProps> = ({
                           (embed) => isUrlEmbed(embed) && embed.url === previewUrl,
                         )
                       ) {
-                        setEmbeds((existing) =>
-                          existing.filter(
-                            (embed) => !(isUrlEmbed(embed) && embed.url === previewUrl),
-                          ),
+                        const nextEmbeds = getEmbeds().filter(
+                          (embed) => !(isUrlEmbed(embed) && embed.url === previewUrl),
                         );
+                        setEmbeds(nextEmbeds);
                         setDraft((prev) => ({
                           ...prev,
                           embeds: (prev.embeds || []).filter(

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -999,14 +999,16 @@ const CreateCast: React.FC<CreateCastProps> = ({
         {previewUrl && (
           <div className="mt-3 w-full rounded-md border border-slate-200 bg-white p-3 shadow-sm">
             <div className="flex items-start justify-between gap-2">
-              <div>
+              <div className="flex-1">
                 <p className="font-semibold text-slate-900 break-all">
                   {previewMetadata?.frame?.title ||
                     previewMetadata?.html?.ogTitle ||
                     previewUrl}
                 </p>
                 <p className="text-sm text-slate-600 line-clamp-2">
-                  {previewMetadata?.frame?.url ||
+                  {previewMetadata?.frame?.manifest?.miniapp?.description ||
+                    previewMetadata?.frame?.manifest?.frame?.description ||
+                    previewMetadata?.frame?.manifest?.frame?.name ||
                     (!previewMetadata?.frame && previewMetadata?.html?.ogDescription) ||
                     previewError ||
                     (!previewLoading && "Preview from Neynar embed crawl")}
@@ -1053,17 +1055,35 @@ const CreateCast: React.FC<CreateCastProps> = ({
                 )}
               </div>
             </div>
-            {previewMetadata?.frame?.image && (
-              <div className="mt-2 overflow-hidden rounded-md">
+            {previewMetadata?.frame ? (
+              <div className="mt-2 overflow-hidden rounded-md border border-slate-200">
                 <img
-                  src={previewMetadata.frame.image}
-                  alt={previewMetadata.frame.title || "Frame preview"}
-                  className="h-40 w-full object-cover"
+                  src={
+                    previewMetadata.frame.image ||
+                    previewMetadata.frame.manifest?.miniapp?.splash_image_url ||
+                    previewMetadata.frame.manifest?.frame?.hero_image_url ||
+                    previewMetadata.frame.manifest?.miniapp?.hero_image_url ||
+                    previewMetadata.frame.manifest?.frame?.og_image_url ||
+                    previewMetadata.frame.image
+                  }
+                  alt={previewMetadata.frame.title || "Mini app preview"}
+                  className="w-full object-cover"
+                  style={{ maxHeight: 280 }}
                 />
+                {previewMetadata.frame.manifest?.miniapp?.name && (
+                  <div className="px-3 py-2">
+                    <p className="text-sm font-semibold">
+                      {previewMetadata.frame.manifest.miniapp.name}
+                    </p>
+                    {previewMetadata.frame.manifest.miniapp.description && (
+                      <p className="text-xs text-slate-600 line-clamp-2">
+                        {previewMetadata.frame.manifest.miniapp.description}
+                      </p>
+                    )}
+                  </div>
+                )}
               </div>
-            )}
-            {!previewMetadata?.frame?.image &&
-              !previewMetadata?.frame &&
+            ) : (
               (previewMetadata?.html?.ogImage?.[0]?.url ||
                 previewMetadata?.image?.url) && (
                 <div className="mt-2 overflow-hidden rounded-md">
@@ -1077,7 +1097,8 @@ const CreateCast: React.FC<CreateCastProps> = ({
                     className="h-40 w-full object-cover"
                   />
                 </div>
-              )}
+              )
+            )}
           </div>
         )}
 

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -1006,7 +1006,9 @@ const CreateCast: React.FC<CreateCastProps> = ({
                     previewUrl}
                 </p>
                 <p className="text-sm text-slate-600 line-clamp-2">
-                  {previewMetadata?.frame?.html?.ogDescription ||
+                  {previewMetadata?.frame
+                    ? undefined
+                    : previewMetadata?.html?.ogDescription ||
                     (!previewMetadata?.frame && previewMetadata?.html?.ogDescription) ||
                     previewError ||
                     (!previewLoading && "Preview from Neynar embed crawl")}

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -1064,7 +1064,7 @@ const CreateCast: React.FC<CreateCastProps> = ({
                     previewMetadata.frame.manifest?.frame?.hero_image_url ||
                     previewMetadata.frame.manifest?.miniapp?.hero_image_url ||
                     previewMetadata.frame.manifest?.frame?.og_image_url ||
-                    previewMetadata.frame.image
+                    undefined
                   }
                   alt={previewMetadata.frame.title || "Mini app preview"}
                   className="w-full object-cover"

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -429,35 +429,6 @@ const CreateCast: React.FC<CreateCastProps> = ({
     fetchInitialChannels();
   }, [fid]);
 
-  useEffect(() => {
-    const inspectEmbeds = async () => {
-      const allEmbeds = initialEmbeds ? [...embeds, ...initialEmbeds] : embeds;
-      const urls = allEmbeds
-        .filter((embed) => isUrlEmbed(embed))
-        .map((embed) => embed.url);
-
-      if (!urls.length) {
-        setEmbedInspections([]);
-        return;
-      }
-
-      try {
-        const params = new URLSearchParams();
-        urls.forEach((url) => params.append("url", url));
-        const response = await fetch(`/api/farcaster/neynar/embeds?${params.toString()}`);
-        if (!response.ok) throw new Error("Failed to inspect embeds");
-        const data = await response.json();
-        if (Array.isArray(data?.embeds)) {
-          setEmbedInspections(data.embeds as EmbedInspection[]);
-        }
-      } catch (error) {
-        console.error("Failed to inspect embeds", error);
-      }
-    };
-
-    inspectEmbeds();
-  }, [embeds, initialEmbeds]);
-
   const debouncedGetChannels = useCallback(
     debounce(
       async (query: string) => {
@@ -596,6 +567,36 @@ const CreateCast: React.FC<CreateCastProps> = ({
   const text = getText();
   const embeds = getEmbeds();
   const channel = getChannel();
+
+  useEffect(() => {
+    const inspectEmbeds = async () => {
+      const allEmbeds = initialEmbeds ? [...embeds, ...initialEmbeds] : embeds;
+      const urls = allEmbeds
+        .filter((embed) => isUrlEmbed(embed))
+        .map((embed) => embed.url);
+
+      if (!urls.length) {
+        setEmbedInspections([]);
+        return;
+      }
+
+      try {
+        const params = new URLSearchParams();
+        urls.forEach((url) => params.append("url", url));
+        const response = await fetch(`/api/farcaster/neynar/embeds?${params.toString()}`);
+        if (!response.ok) throw new Error("Failed to inspect embeds");
+        const data = await response.json();
+        if (Array.isArray(data?.embeds)) {
+          setEmbedInspections(data.embeds as EmbedInspection[]);
+        }
+      } catch (error) {
+        console.error("Failed to inspect embeds", error);
+      }
+    };
+
+    inspectEmbeds();
+  }, [embeds, initialEmbeds]);
+
   useEffect(() => {
     const detectedUrl = extractLastUrl(text);
 

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -985,13 +985,13 @@ const CreateCast: React.FC<CreateCastProps> = ({
             <div className="flex items-start justify-between gap-2">
               <div>
                 <p className="font-semibold text-slate-900 break-all">
-                  {previewMetadata?.html?.ogTitle ||
-                    previewMetadata?.frame?.title ||
+                  {previewMetadata?.frame?.title ||
+                    previewMetadata?.html?.ogTitle ||
                     previewUrl}
                 </p>
                 <p className="text-sm text-slate-600 line-clamp-2">
-                  {previewMetadata?.html?.ogDescription ||
-                    previewMetadata?.frame?.url ||
+                  {previewMetadata?.frame?.url ||
+                    (!previewMetadata?.frame && previewMetadata?.html?.ogDescription) ||
                     previewError ||
                     (!previewLoading && "Preview from Neynar embed crawl")}
                 </p>
@@ -1006,7 +1006,7 @@ const CreateCast: React.FC<CreateCastProps> = ({
                 {previewLoading && (
                   <Spinner style={{ width: "24px", height: "24px" }} />
                 )}
-                {embeds.some((embed) => isUrlEmbed(embed) && embed.url === previewUrl) && (
+                {previewUrl && (
                   <Button
                     size="icon"
                     type="button"
@@ -1030,6 +1030,10 @@ const CreateCast: React.FC<CreateCastProps> = ({
                         updated.add(previewUrl);
                         return updated;
                       });
+                      setPreviewUrl(null);
+                      setPreviewMetadata(null);
+                      setPreviewError(null);
+                      setEmbedLookupMessage(null);
                     }}
                   >
                     ✕
@@ -1047,6 +1051,7 @@ const CreateCast: React.FC<CreateCastProps> = ({
               </div>
             )}
             {!previewMetadata?.frame?.image &&
+              !previewMetadata?.frame &&
               (previewMetadata?.html?.ogImage?.[0]?.url ||
                 previewMetadata?.image?.url) && (
                 <div className="mt-2 overflow-hidden rounded-md">

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -1006,9 +1006,7 @@ const CreateCast: React.FC<CreateCastProps> = ({
                     previewUrl}
                 </p>
                 <p className="text-sm text-slate-600 line-clamp-2">
-                  {previewMetadata?.frame?.manifest?.miniapp?.description ||
-                    previewMetadata?.frame?.manifest?.frame?.description ||
-                    previewMetadata?.frame?.manifest?.frame?.name ||
+                  {previewMetadata?.frame?.html?.ogDescription ||
                     (!previewMetadata?.frame && previewMetadata?.html?.ogDescription) ||
                     previewError ||
                     (!previewLoading && "Preview from Neynar embed crawl")}

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -1295,7 +1295,7 @@ const CreateCast: React.FC<CreateCastProps> = ({
       )}
 
       {hasEmbeds && (() => {
-        const visibleEmbeds = previewUrl && previewMetadata
+        const visibleEmbeds = previewUrl
           ? (draft.embeds || []).filter(
               (embed) => !(isUrlEmbed(embed) && embed.url === previewUrl),
             )

--- a/src/fidgets/farcaster/embedLookup.ts
+++ b/src/fidgets/farcaster/embedLookup.ts
@@ -1,0 +1,19 @@
+import axiosBackend from "@/common/data/api/backend";
+
+export type EmbedLookupResult = {
+  casts: any[];
+};
+
+export const fetchCastsByEmbed = async (
+  url: string,
+): Promise<EmbedLookupResult | null> => {
+  try {
+    const { data } = await axiosBackend.get(
+      `/api/farcaster/neynar/castsByEmbed?url=${encodeURIComponent(url)}`,
+    );
+    return data as EmbedLookupResult;
+  } catch (error) {
+    console.warn("Failed to fetch casts by embed", error);
+    return null;
+  }
+};

--- a/src/fidgets/farcaster/embedNormalization.ts
+++ b/src/fidgets/farcaster/embedNormalization.ts
@@ -90,10 +90,15 @@ export const normalizeToFarcasterEmbeds = (
     if (typeof candidate.url === "string") {
       const inspection = findInspectionForUrl(candidate.url, inspections);
       if (inspection?.castId) {
-        const castEmbed = normaliseCastId({
-          fid: inspection.castId.fid,
-          hash: inspection.castId.hash,
-        });
+        const hash = toUint8Array(inspection.castId.hash);
+        const castEmbed = normaliseCastId(
+          hash
+            ? {
+                fid: inspection.castId.fid,
+                hash,
+              }
+            : undefined,
+        );
         if (castEmbed) {
           normalized.push(castEmbed);
           return;

--- a/src/fidgets/farcaster/embedNormalization.ts
+++ b/src/fidgets/farcaster/embedNormalization.ts
@@ -1,0 +1,131 @@
+import { isNil } from "lodash";
+import { CastIdEmbed, EmbedInspection, FarcasterEmbed, UrlEmbed } from "./types";
+
+const toUint8Array = (
+  value: string | Uint8Array | number[] | { type?: string; data?: number[] },
+): Uint8Array | null => {
+  if (!value) return null;
+
+  if (value instanceof Uint8Array) return value;
+
+  if (Array.isArray(value)) {
+    return new Uint8Array(value);
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.startsWith("0x") ? value.slice(2) : value;
+    if (!normalized || normalized.length % 2 !== 0) return null;
+    const pairs = normalized.match(/.{1,2}/g);
+    if (!pairs) return null;
+    const bytes = pairs.map((pair) => parseInt(pair, 16));
+    return Uint8Array.from(bytes);
+  }
+
+  if (typeof value === "object" && Array.isArray(value.data)) {
+    return new Uint8Array(value.data);
+  }
+
+  return null;
+};
+
+const isValidCastId = (embed: CastIdEmbed): boolean => {
+  const fidValid = typeof embed.castId?.fid === "number";
+  const hashValid =
+    embed.castId?.hash instanceof Uint8Array ||
+    typeof embed.castId?.hash === "string" ||
+    Array.isArray(embed.castId?.hash) ||
+    (!!embed.castId?.hash && typeof embed.castId?.hash === "object");
+
+  return fidValid && hashValid;
+};
+
+const normaliseCastId = (
+  castId?: CastIdEmbed["castId"],
+): CastIdEmbed | null => {
+  if (!castId || typeof castId.fid !== "number") return null;
+  const hash = toUint8Array(castId.hash);
+  if (!hash) return null;
+
+  return {
+    castId: {
+      fid: castId.fid,
+      hash,
+    },
+  };
+};
+
+const findInspectionForUrl = (
+  url: string,
+  inspections?: EmbedInspection[],
+): EmbedInspection | undefined => {
+  if (!inspections) return undefined;
+  return inspections.find((inspection) => inspection.url === url);
+};
+
+/**
+ * Normalize the editor's embed output into Farcaster-compliant embed objects.
+ */
+export const normalizeToFarcasterEmbeds = (
+  rawEmbeds: unknown[],
+  inspections?: EmbedInspection[],
+): FarcasterEmbed[] => {
+  if (!Array.isArray(rawEmbeds)) return [];
+
+  const normalized: FarcasterEmbed[] = [];
+
+  rawEmbeds.forEach((raw) => {
+    if (!raw || typeof raw !== "object") return;
+    const candidate = raw as Record<string, unknown>;
+
+    // Highest priority: explicit castId
+    if (candidate.castId) {
+      const castEmbed = normaliseCastId(candidate.castId as any);
+      if (castEmbed) {
+        normalized.push(castEmbed);
+        return;
+      }
+    }
+
+    // URL embeds
+    if (typeof candidate.url === "string") {
+      const inspection = findInspectionForUrl(candidate.url, inspections);
+      if (inspection?.castId) {
+        const castEmbed = normaliseCastId({
+          fid: inspection.castId.fid,
+          hash: inspection.castId.hash,
+        });
+        if (castEmbed) {
+          normalized.push(castEmbed);
+          return;
+        }
+      }
+
+      normalized.push({ url: candidate.url });
+      return;
+    }
+  });
+
+  return normalized;
+};
+
+export const isValidEmbed = (embed: unknown): embed is FarcasterEmbed => {
+  if (!embed || typeof embed !== "object") return false;
+
+  if ("url" in (embed as UrlEmbed)) {
+    return typeof (embed as UrlEmbed).url === "string";
+  }
+
+  if ("castId" in (embed as CastIdEmbed)) {
+    return isValidCastId(embed as CastIdEmbed);
+  }
+
+  return false;
+};
+
+export const validateEmbedPayload = (
+  embeds: unknown,
+): embeds is FarcasterEmbed[] => {
+  if (isNil(embeds)) return true;
+  if (!Array.isArray(embeds)) return false;
+  return embeds.every((embed) => isValidEmbed(embed));
+};

--- a/src/fidgets/farcaster/types.ts
+++ b/src/fidgets/farcaster/types.ts
@@ -44,6 +44,14 @@ export type EmbedInspection = {
   error?: string;
 };
 
+export enum CastReactionType {
+  likes = "likes",
+  recasts = "recasts",
+  replies = "replies",
+  quote = "quote",
+  links = "links",
+}
+
 export const isUrlEmbed = (embed: FarcasterEmbed): embed is UrlEmbed =>
   "url" in embed && typeof (embed as UrlEmbed).url === "string";
 

--- a/src/fidgets/farcaster/types.ts
+++ b/src/fidgets/farcaster/types.ts
@@ -1,7 +1,51 @@
-export enum CastReactionType {
-  likes = "likes",
-  recasts = "recasts",
-  replies = "replies",
-  quote = "quote",
-  links = "links",
-}
+export type CastIdEmbed = {
+  castId: {
+    fid: number;
+    hash: Uint8Array | string | { type?: string; data?: number[] } | number[];
+  };
+};
+
+export type UrlEmbed = {
+  url: string;
+};
+
+export type FarcasterEmbed = CastIdEmbed | UrlEmbed;
+
+export type EmbedMetadata = {
+  content_type?: string | null;
+  image?: { url?: string } | null;
+  video?: { url?: string } | null;
+  frame?: {
+    url?: string | null;
+    version?: string | null;
+    title?: string | null;
+    image?: string | null;
+  } | null;
+  html?: {
+    ogTitle?: string | null;
+    ogDescription?: string | null;
+    ogUrl?: string | null;
+    ogImage?: Array<{ url?: string | null }>;
+    ogSiteName?: string | null;
+    title?: string | null;
+    description?: string | null;
+    url?: string | null;
+  } | null;
+};
+
+export type EmbedInspection = {
+  url: string;
+  type?: string;
+  castId?: {
+    fid: number;
+    hash: string | Uint8Array | { type?: string; data?: number[] } | number[];
+  };
+  metadata?: EmbedMetadata | null;
+  error?: string;
+};
+
+export const isUrlEmbed = (embed: FarcasterEmbed): embed is UrlEmbed =>
+  "url" in embed && typeof (embed as UrlEmbed).url === "string";
+
+export const isCastIdEmbed = (embed: FarcasterEmbed): embed is CastIdEmbed =>
+  "castId" in embed && typeof (embed as CastIdEmbed).castId === "object";

--- a/src/fidgets/farcaster/types.ts
+++ b/src/fidgets/farcaster/types.ts
@@ -1,7 +1,7 @@
 export type CastIdEmbed = {
   castId: {
     fid: number;
-    hash: Uint8Array | string | { type?: string; data?: number[] } | number[];
+    hash: Uint8Array;
   };
 };
 

--- a/src/fidgets/farcaster/types.ts
+++ b/src/fidgets/farcaster/types.ts
@@ -20,6 +20,20 @@ export type EmbedMetadata = {
     version?: string | null;
     title?: string | null;
     image?: string | null;
+    manifest?: {
+      miniapp?: {
+        splash_image_url?: string | null;
+        hero_image_url?: string | null;
+        description?: string | null;
+        name?: string | null;
+      } | null;
+      frame?: {
+        hero_image_url?: string | null;
+        og_image_url?: string | null;
+        description?: string | null;
+        name?: string | null;
+      } | null;
+    } | null;
   } | null;
   html?: {
     ogTitle?: string | null;

--- a/src/fidgets/farcaster/utils.ts
+++ b/src/fidgets/farcaster/utils.ts
@@ -26,22 +26,8 @@ import { Address, encodeAbiParameters } from "viem";
 import { mnemonicToAccount } from "viem/accounts";
 import { optimismChaninClient } from "@/constants/optimismChainClient";
 import axiosBackend from "@/common/data/api/backend";
-// import { ModProtocolCastAddBody } from "./components/CreateCast";
 import { type Channel } from "@mod-protocol/farcaster";
-
-type FarcasterUrlEmbed = {
-  url: string;
-};
-type FarcasterCastIdEmbed = {
-  castId: {
-    fid: number;
-    hash: Uint8Array;
-  };
-};
-export type FarcasterEmbed = FarcasterCastIdEmbed | FarcasterUrlEmbed;
-export function isFarcasterUrlEmbed(embed: FarcasterEmbed): embed is FarcasterUrlEmbed {
-  return (embed as FarcasterUrlEmbed).url !== undefined;
-}
+import { FarcasterEmbed, isUrlEmbed as isFarcasterUrlEmbed } from "./types";
 
 export const WARPCAST_RECOVERY_PROXY: `0x${string}` =
   "0x00000000FcB080a4D6c39a9354dA9EB9bC104cd7";
@@ -447,3 +433,5 @@ export async function fetchChannelsByName(
     return [] as Channel[];
   }
 }
+
+export type { FarcasterEmbed };

--- a/src/pages/api/farcaster/neynar/castsByEmbed.ts
+++ b/src/pages/api/farcaster/neynar/castsByEmbed.ts
@@ -1,0 +1,49 @@
+import requestHandler from "@/common/data/api/requestHandler";
+import axios, { AxiosRequestConfig, isAxiosError } from "axios";
+import { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const querySchema = z.object({
+  url: z.string().url(),
+  limit: z.string().optional(),
+});
+
+async function fetchCastsByEmbed(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const parsed = querySchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({ message: "url query param is required" });
+      return;
+    }
+
+    const { url, limit } = parsed.data;
+
+    const options: AxiosRequestConfig = {
+      method: "GET",
+      url: "https://api.neynar.com/v2/farcaster/casts",
+      headers: {
+        accept: "application/json",
+        api_key: process.env.NEYNAR_API_KEY!,
+      },
+      params: {
+        "embeds[]": url,
+        limit: limit ? Number(limit) : undefined,
+      },
+    };
+
+    const { data } = await axios.request(options);
+    res.status(200).json(data);
+  } catch (e) {
+    if (isAxiosError(e)) {
+      res
+        .status(e.response?.status || 500)
+        .json(e.response?.data || "An unknown error occurred");
+    } else {
+      res.status(500).json("An unknown error occurred");
+    }
+  }
+}
+
+export default requestHandler({
+  get: fetchCastsByEmbed,
+});

--- a/src/pages/api/farcaster/neynar/castsByEmbed.ts
+++ b/src/pages/api/farcaster/neynar/castsByEmbed.ts
@@ -31,6 +31,19 @@ async function fetchCastsByEmbed(req: NextApiRequest, res: NextApiResponse) {
         "embeds[]": url,
         limit: limit ? Number(limit) : undefined,
       },
+      paramsSerializer: {
+        encode: (params) => {
+          const searchParams = new URLSearchParams();
+          const values = Array.isArray(params["embeds[]"])
+            ? (params["embeds[]"] as string[])
+            : [params["embeds[]"] as string];
+          values.forEach((value) => searchParams.append("embeds[]", value));
+          if (params.limit) {
+            searchParams.append("limit", String(params.limit));
+          }
+          return searchParams.toString();
+        },
+      },
     };
 
     const { data } = await axios.request(options);

--- a/src/pages/api/farcaster/neynar/castsByEmbed.ts
+++ b/src/pages/api/farcaster/neynar/castsByEmbed.ts
@@ -35,10 +35,12 @@ async function fetchCastsByEmbed(req: NextApiRequest, res: NextApiResponse) {
 
     const { data } = await axios.request(options);
     res.status(200).json(data);
-  } catch (e) {
-    const status = isAxiosError(e) ? e.response?.status || 500 : 500;
-    // Best-effort: avoid bubbling API errors to the client UI
-    console.warn("Failed to fetch casts by embed", e?.response?.data || e);
+  } catch (e: unknown) {
+    if (isAxiosError(e)) {
+      console.warn("Failed to fetch casts by embed", e.response?.data || e.message);
+    } else {
+      console.warn("Failed to fetch casts by embed", e);
+    }
     res.status(200).json({ casts: [] });
   }
 }

--- a/src/pages/api/farcaster/neynar/embedMetadata.ts
+++ b/src/pages/api/farcaster/neynar/embedMetadata.ts
@@ -1,0 +1,43 @@
+import requestHandler from "@/common/data/api/requestHandler";
+import axios, { AxiosRequestConfig, isAxiosError } from "axios";
+import { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const querySchema = z.object({
+  url: z.string().url(),
+});
+
+async function fetchEmbedMetadata(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const parsed = querySchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({ message: "url query param is required" });
+      return;
+    }
+
+    const options: AxiosRequestConfig = {
+      method: "GET",
+      url: "https://api.neynar.com/v2/farcaster/cast/embed/crawl",
+      headers: {
+        accept: "application/json",
+        api_key: process.env.NEYNAR_API_KEY!,
+      },
+      params: { url: parsed.data.url },
+    };
+
+    const { data } = await axios.request(options);
+    res.status(200).json(data);
+  } catch (e) {
+    if (isAxiosError(e)) {
+      res
+        .status(e.response?.status || 500)
+        .json(e.response?.data || "An unknown error occurred");
+    } else {
+      res.status(500).json("An unknown error occurred");
+    }
+  }
+}
+
+export default requestHandler({
+  get: fetchEmbedMetadata,
+});

--- a/src/pages/api/farcaster/neynar/embeds.ts
+++ b/src/pages/api/farcaster/neynar/embeds.ts
@@ -1,0 +1,56 @@
+import requestHandler from "@/common/data/api/requestHandler";
+import axios, { AxiosRequestConfig, isAxiosError } from "axios";
+import { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+const querySchema = z.object({
+  url: z.union([z.string().url(), z.array(z.string().url())]).optional(),
+});
+
+async function fetchEmbeds(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const parsed = querySchema.safeParse(req.query);
+    if (!parsed.success || !parsed.data.url) {
+      res.status(400).json({ message: "url query param is required" });
+      return;
+    }
+
+    const urls = Array.isArray(parsed.data.url)
+      ? parsed.data.url
+      : [parsed.data.url];
+
+    const options: AxiosRequestConfig = {
+      method: "GET",
+      url: "https://api.neynar.com/v2/farcaster/embeds",
+      headers: {
+        accept: "application/json",
+        api_key: process.env.NEYNAR_API_KEY!,
+      },
+      params: { url: urls },
+      paramsSerializer: {
+        encode: (params) => {
+          const searchParams = new URLSearchParams();
+          (params.url as string[]).forEach((value) => {
+            searchParams.append("url", value);
+          });
+          return searchParams.toString();
+        },
+      },
+    };
+
+    const { data } = await axios.request(options);
+    res.status(200).json(data);
+  } catch (e) {
+    if (isAxiosError(e)) {
+      res
+        .status(e.response?.status || 500)
+        .json(e.response?.data || "An unknown error occurred");
+    } else {
+      res.status(500).json("An unknown error occurred");
+    }
+  }
+}
+
+export default requestHandler({
+  get: fetchEmbeds,
+});

--- a/src/pages/api/farcaster/neynar/publishMessage.ts
+++ b/src/pages/api/farcaster/neynar/publishMessage.ts
@@ -1,19 +1,28 @@
 import neynar from "@/common/data/api/neynar";
 import requestHandler from "@/common/data/api/requestHandler";
+import { validateEmbedPayload } from "@/fidgets/farcaster/embedNormalization";
 import { isAxiosError } from "axios";
 import { NextApiRequest, NextApiResponse } from "next";
 
-
-async function publishMessage(req: NextApiRequest, res: NextApiResponse) {
+export async function publishMessageHandler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
   try {
-    const message = {
-      ...req.body
-    };
-    const response = await neynar.publishMessageToFarcaster({body: message});
+    const body = { ...req.body };
+    const { embeds } = body || {};
+
+    if (!validateEmbedPayload(embeds)) {
+      console.error("Invalid embed payload", embeds);
+      res.status(400).json({ message: "Invalid embed payload" });
+      return;
+    }
+
+    const response = await neynar.publishMessageToFarcaster({ body });
     res.status(200).json(response);
   } catch (e: any) {
     if (e.response?.data) {
-      console.error("response.data")
+      console.error("response.data");
       console.dir(e.response.data, { depth: null });
     }
     if (isAxiosError(e)) {
@@ -25,5 +34,5 @@ async function publishMessage(req: NextApiRequest, res: NextApiResponse) {
 }
 
 export default requestHandler({
-  post: publishMessage,
+  post: publishMessageHandler,
 });

--- a/tests/farcasterEmbeds.test.ts
+++ b/tests/farcasterEmbeds.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  normalizeToFarcasterEmbeds,
+  validateEmbedPayload,
+} from "@/fidgets/farcaster/embedNormalization";
+import { publishMessageHandler } from "@/pages/api/farcaster/neynar/publishMessage";
+import { submitCast } from "@/fidgets/farcaster/utils";
+import axiosBackend from "@/common/data/api/backend";
+import { Message } from "@farcaster/core";
+
+vi.mock("@/common/data/api/backend", () => ({
+  __esModule: true,
+  default: { post: vi.fn().mockResolvedValue({}) },
+}));
+
+vi.mock("@/common/data/api/neynar", () => ({
+  __esModule: true,
+  default: {
+    publishMessageToFarcaster: vi
+      .fn()
+      .mockResolvedValue({ result: "ok" }),
+  },
+}));
+
+vi.mock("@farcaster/hub-web", () => ({
+  __esModule: true,
+  ID_REGISTRY_ADDRESS: "",
+  KEY_GATEWAY_ADDRESS: "",
+  SIGNED_KEY_REQUEST_TYPE: [],
+  SIGNED_KEY_REQUEST_VALIDATOR_ADDRESS: "",
+  SIGNED_KEY_REQUEST_VALIDATOR_EIP_712_DOMAIN: {},
+  Signer: class {},
+  UserDataType: {},
+  idRegistryABI: [],
+  keyGatewayABI: [],
+  makeUserDataAdd: vi.fn(),
+  signedKeyRequestValidatorABI: [],
+  FarcasterNetwork: { MAINNET: 1 },
+}));
+
+vi.mock("@farcaster/core", async () => {
+  const actual = await vi.importActual<any>("@farcaster/core");
+  return {
+    ...actual,
+    Message: {
+      toJSON: vi.fn((msg) => msg),
+    },
+    makeReactionAdd: vi.fn(),
+    makeReactionRemove: vi.fn(),
+    makeLinkAdd: vi.fn(),
+    makeLinkRemove: vi.fn(),
+  };
+});
+
+describe("embed normalization", () => {
+  it("filters invalid embeds and normalizes castId hashes", () => {
+    const raw = [
+      { url: "https://example.com/image.png", status: "loaded" },
+      { castId: { fid: 2, hash: "0x001122" } },
+      { malformed: true },
+    ];
+
+    const inspections = [
+      { url: "https://example.com/image.png", type: "image" },
+    ];
+
+    const result = normalizeToFarcasterEmbeds(raw as any[], inspections as any);
+    expect(result).toEqual([
+      { url: "https://example.com/image.png" },
+      { castId: { fid: 2, hash: new Uint8Array([0, 17, 34]) } },
+    ]);
+  });
+
+  it("validates payloads", () => {
+    expect(validateEmbedPayload([{ url: "https://site.com" }])).toBe(true);
+    expect(
+      validateEmbedPayload([{ castId: { fid: 1, hash: new Uint8Array([1, 2]) } }]),
+    ).toBe(true);
+    expect(validateEmbedPayload([{ url: 123 } as any])).toBe(false);
+    expect(validateEmbedPayload("bad" as any)).toBe(false);
+  });
+});
+
+describe("publishMessageHandler embed validation", () => {
+  const createResponse = () => {
+    const json = vi.fn();
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json,
+    } as any;
+    return { res, json };
+  };
+
+  it("rejects invalid embed payloads", async () => {
+    const { res, json } = createResponse();
+    const req = {
+      body: { embeds: [{ invalid: true }] },
+    } as any;
+
+    await publishMessageHandler(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalled();
+  });
+
+  it("passes through valid embeds", async () => {
+    const { res, json } = createResponse();
+    const req = {
+      body: { embeds: [{ url: "https://example.com" }], text: "hello" },
+    } as any;
+
+    await publishMessageHandler(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({ result: "ok" });
+  });
+});
+
+describe("submitCast pipeline", () => {
+  beforeEach(() => {
+    axiosBackend.post.mockClear();
+    Message.toJSON.mockClear();
+  });
+
+  it("sends signed messages with embeds unchanged", async () => {
+    const signedMessage = { data: { embeds: [{ url: "https://video.com" }] } };
+
+    const result = await submitCast(signedMessage as any, 1, {} as any);
+
+    expect(result).toBe(true);
+    expect(Message.toJSON).toHaveBeenCalledWith(signedMessage);
+    expect(axiosBackend.post).toHaveBeenCalledWith(
+      "/api/farcaster/neynar/publishMessage",
+      signedMessage,
+    );
+  });
+
+  it("returns false when backend rejects", async () => {
+    axiosBackend.post.mockRejectedValueOnce(new Error("fail"));
+    const result = await submitCast({ data: {} } as any, 1, {} as any);
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize client embeds to Farcaster’s {url}|{castId} schema using Neynar inspection data and add Neynar-backed preview/attach/detach flows with cached metadata in the cast composer.
- Add backend Neynar proxy endpoints for embed inspection, URL metadata, and related-cast lookup plus stricter embed validation before publish.
- Cache enriched embeds via the shared data provider and add tests covering normalization and the submit/publish pipeline.

## Testing
- yarn test farcasterEmbeds.test.ts
- yarn lint *(fails: yarn berry could not find lockfile entry; requires install in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953019a0f0c83258f7e107b42cd4526)