### PR TITLE
Improve Farcaster embed validation and caching

### DIFF
--- a/src/common/providers/SharedDataProvider.tsx
+++ b/src/common/providers/SharedDataProvider.tsx
@@ -13,6 +13,8 @@ import type { EmbedUrlMetadata } from "@neynar/nodejs-sdk/build/api/models/embed
 import type { Channel } from "@mod-protocol/farcaster";
 import type { FarcasterEmbed } from "@/fidgets/farcaster/utils/embedTypes";
 
+const MAX_RECENT_EMBEDS = 50;
+
 // Define the types of data that will be shared
 interface SharedDataContextType {
   // Cache of recently accessed channels
@@ -58,10 +60,17 @@ export const SharedDataProvider: React.FC<{ children: React.ReactNode }> = ({ ch
   // Adds an embed to the recent embeds cache
   const addRecentEmbed = useCallback(
     (url: string, embed: FarcasterEmbed, metadata?: EmbedUrlMetadata) => {
-      setRecentEmbeds((prev) => ({
-        ...prev,
-        [url]: { embed, metadata },
-      }));
+      setRecentEmbeds((prev) => {
+        const updated = { ...prev, [url]: { embed, metadata } };
+        const keys = Object.keys(updated);
+
+        if (keys.length > MAX_RECENT_EMBEDS) {
+          const [oldestKey] = keys;
+          delete updated[oldestKey];
+        }
+
+        return updated;
+      });
     },
     [],
   );

--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -194,8 +194,13 @@ const CreateCast: React.FC<CreateCastProps> = ({
   const [embedPreviews, setEmbedPreviews] = useState<Record<string, EmbedPreview>>({});
   const [removedEmbeds, setRemovedEmbeds] = useState<Set<string>>(new Set());
   const [loadingEmbeds, setLoadingEmbeds] = useState<Set<string>>(new Set());
+  const loadingEmbedsRef = useRef<Set<string>>(loadingEmbeds);
   const [embedErrors, setEmbedErrors] = useState<Record<string, string>>({});
   const { addRecentEmbed, getRecentEmbed } = useSharedData();
+
+  useEffect(() => {
+    loadingEmbedsRef.current = loadingEmbeds;
+  }, [loadingEmbeds]);
 
   const isTargetInsideEmojiPicker = useCallback(
     (event?: Event | CustomEvent<{ originalEvent?: Event }>, fallbackTarget?: EventTarget | null) => {
@@ -721,7 +726,7 @@ const CreateCast: React.FC<CreateCastProps> = ({
         return;
       }
 
-      if (loadingEmbeds.has(normalizedUrl)) {
+      if (loadingEmbedsRef.current.has(normalizedUrl)) {
         return;
       }
 
@@ -771,7 +776,7 @@ const CreateCast: React.FC<CreateCastProps> = ({
     return () => {
       timers.forEach((timer) => clearTimeout(timer));
     };
-  }, [text, embedPreviews, addRecentEmbed, getRecentEmbed, removedEmbeds, loadingEmbeds]);
+  }, [text, embedPreviews, addRecentEmbed, getRecentEmbed, removedEmbeds]);
 
   useEffect(() => {
     if (!editor) return;

--- a/src/fidgets/farcaster/utils/embedNormalization.ts
+++ b/src/fidgets/farcaster/utils/embedNormalization.ts
@@ -104,11 +104,17 @@ export const validateFarcasterEmbeds = (embeds: unknown[]) => {
   };
 };
 
+type SanitizeOptions = {
+  removedKeys?: Set<string>;
+  limit?: number;
+  normalized?: FarcasterEmbed[];
+};
+
 export const sanitizeFarcasterEmbeds = (
   embeds: unknown[],
-  options?: { removedKeys?: Set<string>; limit?: number },
+  options?: SanitizeOptions,
 ) => {
-  const { normalized } = validateFarcasterEmbeds(embeds);
+  const normalized = options?.normalized ?? validateFarcasterEmbeds(embeds).normalized;
   const limit = options?.limit ?? FARCASTER_EMBED_LIMIT;
   const removedKeys = options?.removedKeys ?? new Set<string>();
 

--- a/src/pages/api/farcaster/neynar/embedMetadata.ts
+++ b/src/pages/api/farcaster/neynar/embedMetadata.ts
@@ -4,10 +4,6 @@ import { isAxiosError } from "axios";
 import { NextApiRequest, NextApiResponse } from "next";
 
 const embedMetadata = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (req.method !== "GET") {
-    return res.status(405).json({ message: "Method not allowed" });
-  }
-
   const url = typeof req.query.url === "string" ? req.query.url : "";
   if (!url) {
     return res.status(400).json({ message: "Missing url" });

--- a/src/pages/api/farcaster/neynar/publishMessage.ts
+++ b/src/pages/api/farcaster/neynar/publishMessage.ts
@@ -30,10 +30,10 @@ async function publishMessage(req: NextApiRequest, res: NextApiResponse) {
         });
       }
 
-      message.embeds = sanitizeFarcasterEmbeds(message.embeds);
+      message.embeds = sanitizeFarcasterEmbeds(message.embeds, { normalized });
     }
 
-    const response = await neynar.publishMessageToFarcaster({body: message});
+    const response = await neynar.publishMessageToFarcaster({ body: message });
     res.status(200).json(response);
   } catch (e: any) {
     if (e.response?.data) {


### PR DESCRIPTION
## Summary
- remove redundant GET guard in the embed metadata handler and rely on the shared request wrapper
- reuse normalized embed validation results to avoid duplicate processing while sanitizing embeds
- cap the recent embed cache size and avoid stale loading checks while fetching embed previews

## Testing
- npx vitest tests/farcasterEmbeds.test.ts --run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954419443b0832580784c133282127a)