### PR TITLE
Map admin identity keys into system config

### DIFF
--- a/src/config/loaders/registry.ts
+++ b/src/config/loaders/registry.ts
@@ -88,6 +88,7 @@ function transformRowToSystemConfig(row: CommunityConfigRow): SystemConfig {
     fidgets: row.fidgets_config as unknown as SystemConfig['fidgets'],
     navigation: (row.navigation_config ?? null) as unknown as SystemConfig['navigation'],
     ui: (row.ui_config ?? null) as unknown as SystemConfig['ui'],
+    adminIdentityPublicKeys: row.admin_identity_public_keys ?? [],
     theme: themes, // Themes come from shared file, not database
   };
 }
@@ -259,4 +260,3 @@ export async function loadSystemConfigById(
   
   return config;
 }
-


### PR DESCRIPTION
## Summary
- map admin_identity_public_keys from community_configs into SystemConfig when loading configs
- default to an empty array so nav page admin checks receive populated keys

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695449cb55e48325947280f8fcf2c2a4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring admin identity public keys in system settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->