### PR TITLE
Apply ui-config background color across UI surfaces

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -120,6 +120,7 @@ export default async function RootLayout({
       : "var(--font-sans, Inter, system-ui, -apple-system, sans-serif)";
   const navFontColor = systemConfig.ui?.fontColor || "#0f172a";
   const castButtonFontColor = systemConfig.ui?.castButtonFontColor || "#ffffff";
+  const navBackgroundColor = systemConfig.ui?.backgroundColor || "#ffffff";
   
   return (
     <html lang="en" suppressHydrationWarning>
@@ -134,6 +135,7 @@ export default async function RootLayout({
             ["--ns-nav-font" as string]: navFontStack,
             ["--ns-nav-font-color" as string]: navFontColor,
             ["--ns-cast-button-font-color" as string]: castButtonFontColor,
+            ["--ns-background-color" as string]: navBackgroundColor,
           } as React.CSSProperties
         }
       >

--- a/src/common/components/molecules/Modal.tsx
+++ b/src/common/components/molecules/Modal.tsx
@@ -41,6 +41,7 @@ const Modal = ({
     fontFamily:
       "var(--ns-nav-font, var(--font-sans, Inter, system-ui, -apple-system, sans-serif))",
     color: "var(--ns-nav-font-color, #0f172a)",
+    backgroundColor: "var(--ns-background-color, #ffffff)",
   };
 
   const handleContentRef = React.useCallback((node: HTMLDivElement | null) => {

--- a/src/common/components/organisms/MobileHeader.tsx
+++ b/src/common/components/organisms/MobileHeader.tsx
@@ -266,7 +266,14 @@ const MobileHeader = ({ systemConfig }: MobileHeaderProps) => {
   }, [shouldConfirmCastClose]);
 
   return (
-    <header className="z-30 flex items-center justify-between h-14 px-4 bg-white overflow-hidden sticky top-0">
+    <header
+      className="z-30 flex items-center justify-between h-14 px-4 overflow-hidden sticky top-0"
+      style={{
+        backgroundColor: uiColors.backgroundColor,
+        color: uiColors.fontColor,
+        fontFamily: uiColors.fontFamily,
+      }}
+    >
       <div className="flex items-center gap-2">{isLoggedIn ? userAvatar : menuButton}</div>
       <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
         <BrandHeader systemConfig={systemConfig} />

--- a/src/common/components/organisms/MobileNavbar.tsx
+++ b/src/common/components/organisms/MobileNavbar.tsx
@@ -5,6 +5,7 @@ import { UserTheme } from "@/common/lib/theme";
 import { MdGridView } from "react-icons/md";
 import { BsImage, BsImageFill, BsFillPinFill, BsPin } from "react-icons/bs";
 import { CompleteFidgets } from "@/fidgets";
+import { useUIColors } from "@/common/lib/hooks/useUIColors";
 
 export interface TabItem {
   id: string;
@@ -311,17 +312,19 @@ const MobileNavbar: React.FC<MobileNavbarProps> = ({
   // Get theme colors for active tab indicators
   const navFontColor = "var(--ns-nav-font-color, #0f172a)";
   const navFontFamily = "var(--ns-nav-font, var(--font-sans, Inter, system-ui, -apple-system, sans-serif))";
+  const uiColors = useUIColors();
+  const backgroundColor = uiColors.backgroundColor || theme?.properties?.background || "white";
 
   return (
     <Tabs
       value={selected}
       onValueChange={onSelect}
       className={mergeClasses(
-        "fixed bottom-0 left-0 right-0 w-full h-[72px] bg-white border-t border-gray-200 z-30",
+        "fixed bottom-0 left-0 right-0 w-full h-[72px] border-t border-gray-200 z-30",
         className
       )}
       style={{
-          backgroundColor: theme?.properties?.background || "white",
+          backgroundColor,
           borderColor: theme?.properties?.fidgetBorderColor || "rgb(229 231 235)",
       }}
     >
@@ -333,7 +336,7 @@ const MobileNavbar: React.FC<MobileNavbarProps> = ({
         <div 
           className="absolute left-0 top-0 bottom-0 w-8 h-full z-10 pointer-events-none"
           style={{
-              background: `linear-gradient(to right, ${theme?.properties?.background || "white"}, transparent)`,
+              background: `linear-gradient(to right, ${backgroundColor}, transparent)`,
             opacity: scrollState.leftGradientOpacity,
             transition: 'opacity 0.3s ease'
           }}
@@ -367,7 +370,7 @@ const MobileNavbar: React.FC<MobileNavbarProps> = ({
         <div 
           className="absolute right-0 top-0 bottom-0 w-8 h-full z-10 pointer-events-none"
           style={{
-              background: `linear-gradient(to left, ${theme?.properties?.background || "white"}, transparent)`,
+              background: `linear-gradient(to left, ${backgroundColor}, transparent)`,
             opacity: scrollState.rightGradientOpacity,
             transition: 'opacity 0.3s ease'
           }}

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -116,6 +116,7 @@ const Navigation = React.memo(
   const navTextStyle: React.CSSProperties = {
     color: uiColors.fontColor,
     fontFamily: uiColors.fontFamily,
+    backgroundColor: uiColors.backgroundColor,
   };
 
   const [shrunk, setShrunk] = useState(mobile ? false : true);
@@ -363,7 +364,7 @@ const Navigation = React.memo(
     <nav
       id="logo-sidebar"
       className={mergeClasses(
-        "border-r-2 bg-white",
+        "border-r-2",
         mobile
           ? "w-[270px]"
           : "w-full transition-transform -translate-x-full sm:translate-x-0"
@@ -414,7 +415,8 @@ const Navigation = React.memo(
           {!mobile && (
             <button
               onClick={toggleSidebar}
-              className="absolute right-0 top-4 transform translate-x-1/2 bg-white rounded-full border border-gray-200 shadow-sm p-2 hover:bg-gray-50 sidebar-expand-button z-50"
+              className="absolute right-0 top-4 transform translate-x-1/2 rounded-full border border-gray-200 shadow-sm p-2 sidebar-expand-button z-50"
+              style={{ backgroundColor: uiColors.backgroundColor }}
               aria-label={shrunk ? "Expand sidebar" : "Collapse sidebar"}
             >
               {shrunk ? (

--- a/src/common/components/organisms/TabBar.tsx
+++ b/src/common/components/organisms/TabBar.tsx
@@ -14,6 +14,7 @@ import ClaimButtonWithModal from "../molecules/ClaimButtonWithModal";
 import { useSidebarContext } from "./Sidebar";
 import TokenDataHeader from "./TokenDataHeader";
 import { validateTabName } from "@/common/utils/tabUtils";
+import { useUIColors } from "@/common/lib/hooks/useUIColors";
 
 interface TabBarProps {
   inHomebase: boolean;
@@ -55,6 +56,7 @@ function TabBar({
 }: TabBarProps) {
   const isMobile = useIsMobile();
   const { setEditMode } = useSidebarContext();
+  const uiColors = useUIColors();
 
   const { getIsLoggedIn, getIsInitializing, homebaseLoadTab, setCurrentTabName } = useAppStore((state) => ({
     setModalOpen: state.setup.setModalOpen,
@@ -243,13 +245,22 @@ function TabBar({
 
   return (
     <TooltipProvider>
-      <div className="flex flex-col md:flex-row justify-start md:h-16 z-30 bg-white w-full"> 
+      <div
+        className="flex flex-col md:flex-row justify-start md:h-16 z-30 w-full"
+        style={{ backgroundColor: uiColors.backgroundColor }}
+      > 
         {isTokenPage && contractAddress && (
-          <div className="flex flex-row justify-start h-16 w-full md:w-fit z-20 bg-white">
+          <div
+            className="flex flex-row justify-start h-16 w-full md:w-fit z-20"
+            style={{ backgroundColor: uiColors.backgroundColor }}
+          >
             <TokenDataHeader />
           </div>
         )}
-        <div className="flex w-full h-16 bg-white items-center justify-between"> 
+        <div
+          className="flex w-full h-16 items-center justify-between"
+          style={{ backgroundColor: uiColors.backgroundColor }}
+        > 
           {/* Tabs Section - grows until it hits buttons */}
           <div className="flex-1 min-w-0 overflow-hidden">
             <div className="overflow-x-auto scrollbar-hide" style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}>

--- a/src/common/lib/hooks/useUIColors.ts
+++ b/src/common/lib/hooks/useUIColors.ts
@@ -18,6 +18,7 @@ export const useUIColors = ({ systemConfig }: UseUIColorsProps = {}) => {
     let cssFontColor: string | undefined;
     let cssFontFamily: string | undefined;
     let cssCastButtonFontColor: string | undefined;
+    let cssBackgroundColor: string | undefined;
 
     if (typeof document !== "undefined") {
       const styles = getComputedStyle(document.body);
@@ -25,6 +26,8 @@ export const useUIColors = ({ systemConfig }: UseUIColorsProps = {}) => {
       cssFontFamily = styles.getPropertyValue("--ns-nav-font")?.trim() || undefined;
       cssCastButtonFontColor =
         styles.getPropertyValue("--ns-cast-button-font-color")?.trim() || undefined;
+      cssBackgroundColor =
+        styles.getPropertyValue("--ns-background-color")?.trim() || undefined;
     }
 
     const parsedFontFamily = extractFontFamilyFromUrl(ui?.url);
@@ -36,6 +39,7 @@ export const useUIColors = ({ systemConfig }: UseUIColorsProps = {}) => {
         ? `${parsedFontFamily}, var(--font-sans, sans-serif)`
         : cssFontFamily || "var(--font-sans, Inter, system-ui, -apple-system, sans-serif)",
       fontUrl: ui?.url,
+      backgroundColor: ui?.backgroundColor || cssBackgroundColor || "#ffffff",
       primaryColor: ui?.primaryColor || "rgb(37, 99, 235)",
       primaryHoverColor: ui?.primaryHoverColor || "rgb(29, 78, 216)",
       primaryActiveColor: ui?.primaryActiveColor || "rgb(30, 64, 175)",

--- a/src/fidgets/ui/profile.tsx
+++ b/src/fidgets/ui/profile.tsx
@@ -14,7 +14,6 @@ import { followUser, unfollowUser } from "../farcaster/utils";
 import { useIsMobile } from "@/common/lib/hooks/useIsMobile";
 import { BsPerson, BsPersonFill } from "react-icons/bs";
 import { IoLocationOutline } from "react-icons/io5";
-import { useUIColors } from "@/common/lib/hooks/useUIColors";
 
 export type ProfileFidgetSettings = {
   fid: number;
@@ -134,14 +133,13 @@ const Profile: React.FC<FidgetArgs<ProfileFidgetSettings>> = ({
   const bioText = user.profile?.bio?.text || "";
   const uiFontFamily =
     "var(--ns-nav-font, var(--font-sans, Inter, system-ui, -apple-system, sans-serif))";
-  const { backgroundColor: uiBackgroundColor } = useUIColors();
   
   return (
     <div
       className={`flex flex-col h-full overflow-auto ${isMobile ? 'px-3 py-3' : 'px-4 py-4'}`}
       style={{
         fontFamily: uiFontFamily,
-        backgroundColor: uiBackgroundColor,
+        backgroundColor: "var(--ns-background-color, #ffffff)",
       }}
     >
       <div className="flex flex-row items-center mb-4">

--- a/src/fidgets/ui/profile.tsx
+++ b/src/fidgets/ui/profile.tsx
@@ -133,12 +133,14 @@ const Profile: React.FC<FidgetArgs<ProfileFidgetSettings>> = ({
   const bioText = user.profile?.bio?.text || "";
   const uiFontFamily =
     "var(--ns-nav-font, var(--font-sans, Inter, system-ui, -apple-system, sans-serif))";
+  const uiFontColor = "var(--ns-nav-font-color, #0f172a)";
   
   return (
     <div
       className={`flex flex-col h-full overflow-auto ${isMobile ? 'px-3 py-3' : 'px-4 py-4'}`}
       style={{
         fontFamily: uiFontFamily,
+        color: uiFontColor,
         backgroundColor: "var(--ns-background-color, #ffffff)",
       }}
     >

--- a/src/fidgets/ui/profile.tsx
+++ b/src/fidgets/ui/profile.tsx
@@ -14,6 +14,7 @@ import { followUser, unfollowUser } from "../farcaster/utils";
 import { useIsMobile } from "@/common/lib/hooks/useIsMobile";
 import { BsPerson, BsPersonFill } from "react-icons/bs";
 import { IoLocationOutline } from "react-icons/io5";
+import { useUIColors } from "@/common/lib/hooks/useUIColors";
 
 export type ProfileFidgetSettings = {
   fid: number;
@@ -133,11 +134,15 @@ const Profile: React.FC<FidgetArgs<ProfileFidgetSettings>> = ({
   const bioText = user.profile?.bio?.text || "";
   const uiFontFamily =
     "var(--ns-nav-font, var(--font-sans, Inter, system-ui, -apple-system, sans-serif))";
+  const { backgroundColor: uiBackgroundColor } = useUIColors();
   
   return (
     <div
       className={`flex flex-col h-full overflow-auto ${isMobile ? 'px-3 py-3' : 'px-4 py-4'}`}
-      style={{ fontFamily: uiFontFamily }}
+      style={{
+        fontFamily: uiFontFamily,
+        backgroundColor: uiBackgroundColor,
+      }}
     >
       <div className="flex flex-row items-center mb-4">
         <div className={`${isMobile ? 'h-12 w-12' : 'h-14 w-14'} mr-4`}>


### PR DESCRIPTION
## Summary
- expose the community ui_config backgroundColor as a global CSS variable and surface it through the shared UI color hook
- apply the configured background color to navigation (desktop and mobile), tab bars, profile fidget, and shared modals for consistent theming

## Testing
- yarn lint *(fails: Yarn immutable install prevented dependency resolution)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695452bfd58c8325a17849bcbbbe2bfb)