### PR TITLE
Adjust nav border thickness

### DIFF
--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -365,7 +365,7 @@ const Navigation = React.memo(
     <nav
       id="logo-sidebar"
       className={mergeClasses(
-        "border-r-2",
+        "border-r",
         mobile
           ? "w-[270px]"
           : "w-full transition-transform -translate-x-full sm:translate-x-0"

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -66,6 +66,8 @@ type NavProps = {
   onNavigate?: () => void;
 };
 
+const NAV_BORDER_COLOR = "rgba(128, 128, 128, 0.5)";
+
 const NavIconBadge: React.FC<{
   children: React.ReactNode;
   systemConfig: SystemConfig;
@@ -116,7 +118,6 @@ const Navigation = React.memo(
     activeColor: uiColors.castButton.activeColor,
     fontColor: uiColors.castButtonFontColor,
   };
-  const NAV_BORDER_COLOR = "rgba(128, 128, 128, 0.5)";
   const navTextStyle: React.CSSProperties = {
     color: uiColors.fontColor,
     fontFamily: uiColors.fontFamily,

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -73,8 +73,11 @@ const NavIconBadge: React.FC<{
   const uiColors = useUIColors({ systemConfig });
   return (
     <Badge
-      className="justify-center text-[11px]/[12px] min-w-[18px] min-h-[18px] font-medium shadow-md px-[3px] rounded-full absolute left-[19px] top-[4px] border-white text-white"
-      style={{ backgroundColor: uiColors.primaryColor }}
+      className="justify-center text-[11px]/[12px] min-w-[18px] min-h-[18px] font-medium shadow-md px-[3px] rounded-full absolute left-[19px] top-[4px] border text-white"
+      style={{
+        backgroundColor: uiColors.primaryColor,
+        borderColor: NAV_BORDER_COLOR,
+      }}
     >
       {children}
     </Badge>
@@ -113,7 +116,7 @@ const Navigation = React.memo(
     activeColor: uiColors.castButton.activeColor,
     fontColor: uiColors.castButtonFontColor,
   };
-  const NAV_BORDER_COLOR = "rgba(128, 128, 128, 0.2)";
+  const NAV_BORDER_COLOR = "rgba(128, 128, 128, 0.5)";
   const navTextStyle: React.CSSProperties = {
     color: uiColors.fontColor,
     fontFamily: uiColors.fontFamily,
@@ -511,6 +514,9 @@ const Navigation = React.memo(
                   shrunk={shrunk}
                   fontColor={uiColors.fontColor}
                   fontFamily={uiColors.fontFamily}
+                  borderColor={NAV_BORDER_COLOR}
+                  accentColor={castButtonColors.backgroundColor}
+                  accentIconColor={castButtonColors.fontColor}
                 />
               </div>
             )}

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -516,8 +516,6 @@ const Navigation = React.memo(
                   fontColor={uiColors.fontColor}
                   fontFamily={uiColors.fontFamily}
                   borderColor={NAV_BORDER_COLOR}
-                  accentColor={castButtonColors.backgroundColor}
-                  accentIconColor={castButtonColors.fontColor}
                 />
               </div>
             )}

--- a/src/common/components/organisms/Player.tsx
+++ b/src/common/components/organisms/Player.tsx
@@ -205,13 +205,13 @@ export const Player: React.FC<PlayerProps> = ({
                   <FaPause
                     className="drop-shadow-md"
                     size={24}
-                    style={{ color: "rgba(128, 128, 128, 0.5)" }}
+                    style={{ color: "rgba(128, 128, 128, 0.8)" }}
                   />
                 ) : (
                   <FaPlay
                     className="drop-shadow-md"
                     size={24}
-                    style={{ color: "rgba(128, 128, 128, 0.5)" }}
+                    style={{ color: "rgba(255, 255, 255, 0.5)" }}
                   />
                 )}
               </div>

--- a/src/common/components/organisms/Player.tsx
+++ b/src/common/components/organisms/Player.tsx
@@ -39,18 +39,12 @@ export type PlayerProps = {
   fontColor?: string;
   fontFamily?: string;
   borderColor?: string;
-  accentColor?: string;
-  accentIconColor?: string;
-  collapsedAccentColor?: string;
-  collapsedIconColor?: string;
 };
 
 const DEFAULT_UI_FONT_COLOR = "var(--ns-nav-font-color, #0f172a)";
 const DEFAULT_UI_FONT_FAMILY =
   "var(--ns-nav-font, var(--font-sans, Inter, system-ui, -apple-system, sans-serif))";
 const DEFAULT_BORDER_COLOR = "rgba(128, 128, 128, 0.5)";
-const DEFAULT_ACCENT_COLOR = "var(--ns-cast-button-background-color, rgb(37, 99, 235))";
-const DEFAULT_ACCENT_ICON_COLOR = "var(--ns-cast-button-font-color, #ffffff)";
 
 const getToggleIcon = ({ playing, started, ready }): [IconType, string] => {
   if ((playing && !started) || !ready) {
@@ -68,10 +62,6 @@ export const Player: React.FC<PlayerProps> = ({
   fontColor = DEFAULT_UI_FONT_COLOR,
   fontFamily = DEFAULT_UI_FONT_FAMILY,
   borderColor = DEFAULT_BORDER_COLOR,
-  accentColor = DEFAULT_ACCENT_COLOR,
-  accentIconColor = DEFAULT_ACCENT_ICON_COLOR,
-  collapsedAccentColor,
-  collapsedIconColor,
 }) => {
   const hasWindow = useHasWindow();
   const playerRef = useRef<ReactPlayer | null>(null);
@@ -177,11 +167,6 @@ export const Player: React.FC<PlayerProps> = ({
     fontFamily,
   };
 
-  const collapsedButtonStyles: React.CSSProperties = {
-    backgroundColor: collapsedAccentColor || accentColor,
-    color: collapsedIconColor || accentIconColor,
-  };
-
   if (shrunk) {
     return (
       <>
@@ -212,15 +197,22 @@ export const Player: React.FC<PlayerProps> = ({
             ) : (
               <div
                 className={mergeClasses(
-                  "transition-transform duration-200 flex items-center justify-center w-10 h-10 rounded-full drop-shadow-md",
+                  "transition-transform duration-200",
                   isHovering ? "scale-110" : "scale-100"
                 )}
-                style={collapsedButtonStyles}
               >
                 {playing ? (
-                  <FaPause size={20} />
+                  <FaPause
+                    className="drop-shadow-md"
+                    size={24}
+                    style={{ color: "rgba(128, 128, 128, 0.5)" }}
+                  />
                 ) : (
-                  <FaPlay size={20} />
+                  <FaPlay
+                    className="drop-shadow-md"
+                    size={24}
+                    style={{ color: "rgba(128, 128, 128, 0.5)" }}
+                  />
                 )}
               </div>
             )}
@@ -282,8 +274,8 @@ export const Player: React.FC<PlayerProps> = ({
             variant="secondary"
             style={{
               ...baseTextStyles,
-              backgroundColor: accentColor,
-              color: accentIconColor,
+              backgroundColor: "rgba(128, 128, 128, 0.5)",
+              color: "rgba(128, 128, 128, 0.5)",
             }}
           >
             <ToggleIcon className={iconClassNames} size={20} />

--- a/src/common/components/organisms/Player.tsx
+++ b/src/common/components/organisms/Player.tsx
@@ -38,11 +38,19 @@ export type PlayerProps = {
   shrunk?: boolean;
   fontColor?: string;
   fontFamily?: string;
+  borderColor?: string;
+  accentColor?: string;
+  accentIconColor?: string;
+  collapsedAccentColor?: string;
+  collapsedIconColor?: string;
 };
 
 const DEFAULT_UI_FONT_COLOR = "var(--ns-nav-font-color, #0f172a)";
 const DEFAULT_UI_FONT_FAMILY =
   "var(--ns-nav-font, var(--font-sans, Inter, system-ui, -apple-system, sans-serif))";
+const DEFAULT_BORDER_COLOR = "rgba(128, 128, 128, 0.5)";
+const DEFAULT_ACCENT_COLOR = "var(--ns-cast-button-background-color, rgb(37, 99, 235))";
+const DEFAULT_ACCENT_ICON_COLOR = "var(--ns-cast-button-font-color, #ffffff)";
 
 const getToggleIcon = ({ playing, started, ready }): [IconType, string] => {
   if ((playing && !started) || !ready) {
@@ -59,6 +67,11 @@ export const Player: React.FC<PlayerProps> = ({
   shrunk = false,
   fontColor = DEFAULT_UI_FONT_COLOR,
   fontFamily = DEFAULT_UI_FONT_FAMILY,
+  borderColor = DEFAULT_BORDER_COLOR,
+  accentColor = DEFAULT_ACCENT_COLOR,
+  accentIconColor = DEFAULT_ACCENT_ICON_COLOR,
+  collapsedAccentColor,
+  collapsedIconColor,
 }) => {
   const hasWindow = useHasWindow();
   const playerRef = useRef<ReactPlayer | null>(null);
@@ -164,6 +177,11 @@ export const Player: React.FC<PlayerProps> = ({
     fontFamily,
   };
 
+  const collapsedButtonStyles: React.CSSProperties = {
+    backgroundColor: collapsedAccentColor || accentColor,
+    color: collapsedIconColor || accentIconColor,
+  };
+
   if (shrunk) {
     return (
       <>
@@ -194,14 +212,15 @@ export const Player: React.FC<PlayerProps> = ({
             ) : (
               <div
                 className={mergeClasses(
-                  "transition-transform duration-200",
+                  "transition-transform duration-200 flex items-center justify-center w-10 h-10 rounded-full drop-shadow-md",
                   isHovering ? "scale-110" : "scale-100"
                 )}
+                style={collapsedButtonStyles}
               >
                 {playing ? (
-                  <FaPause className="text-white drop-shadow-md" size={24} />
+                  <FaPause size={20} />
                 ) : (
-                  <FaPlay className="text-white drop-shadow-md" size={24} />
+                  <FaPlay size={20} />
                 )}
               </div>
             )}
@@ -232,8 +251,8 @@ export const Player: React.FC<PlayerProps> = ({
   return (
     <>
       <div
-        className="flex items-center border border-gray-200 rounded-full md:rounded-lg overflow-hidden"
-        style={{ fontFamily }}
+        className="flex items-center border rounded-full md:rounded-lg overflow-hidden"
+        style={{ fontFamily, borderColor }}
       >
         <div className="overflow-hidden relative w-8 h-8 md:w-16 md:h-auto ml-2 md:ml-auto flex-shrink-0 self-center md:self-stretch rounded-lg md:rounded-none">
           {metadata?.thumbnail && (
@@ -258,10 +277,14 @@ export const Player: React.FC<PlayerProps> = ({
           <Button
             onClick={playing ? onPause : onPlay}
             aria-label="Play/Pause"
-            className="flex items-center justify-center flex-none rounded-full h-9 w-9 md:h-7 md:w-7 p-0 bg-gray-300"
+            className="flex items-center justify-center flex-none rounded-full h-9 w-9 md:h-7 md:w-7 p-0"
             disabled={!ready}
             variant="secondary"
-            style={baseTextStyles}
+            style={{
+              ...baseTextStyles,
+              backgroundColor: accentColor,
+              color: accentIconColor,
+            }}
           >
             <ToggleIcon className={iconClassNames} size={20} />
           </Button>


### PR DESCRIPTION
## Summary
- Align the sidebar’s vertical border width with the horizontal nav border for consistent line thickness.
- Keep nav control styling consistent with the surrounding border treatment.

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695565687ea88325b4ca3822b42936ec)