### PR TITLE
Apply ui config styling to cancel cast prompt

### DIFF
--- a/src/common/components/molecules/CastModalHelpers.tsx
+++ b/src/common/components/molecules/CastModalHelpers.tsx
@@ -5,6 +5,8 @@ import {
   CastModalPortalProvider,
   CAST_MODAL_INTERACTIVE_ATTR,
 } from "@/common/lib/utils/castModalInteractivity";
+import { useUIColors } from "@/common/lib/hooks/useUIColors";
+import { SystemConfig } from "@/config";
 
 export { CAST_MODAL_INTERACTIVE_ATTR };
 
@@ -33,8 +35,28 @@ export const CastDiscardPrompt: React.FC<{
   open: boolean;
   onClose: () => void;
   onDiscard: () => void;
-}> = ({ open, onClose, onDiscard }) => {
+  systemConfig?: SystemConfig;
+}> = ({ open, onClose, onDiscard, systemConfig }) => {
   const cancelRef = React.useRef<HTMLButtonElement | null>(null);
+  const uiColors = useUIColors({ systemConfig });
+
+  const dialogStyles: React.CSSProperties = {
+    backgroundColor: uiColors.backgroundColor,
+    color: uiColors.fontColor,
+    fontFamily: uiColors.fontFamily,
+  };
+
+  const cancelButtonStyles: React.CSSProperties = {
+    backgroundColor: "rgba(128, 128, 128, 0.2)",
+    borderColor: "rgba(128, 128, 128, 0.2)",
+    color: uiColors.fontColor,
+    fontFamily: uiColors.fontFamily,
+  };
+
+  const discardButtonStyles: React.CSSProperties = {
+    color: "#ffffff",
+    fontFamily: uiColors.fontFamily,
+  };
 
   React.useEffect(() => {
     if (open) {
@@ -53,13 +75,14 @@ export const CastDiscardPrompt: React.FC<{
       <Dialog.Portal container={undefined}>
         <Dialog.Overlay className="fixed inset-0 z-[9999] bg-black/40" />
         <Dialog.Content
-          className="fixed left-1/2 top-1/2 z-[10000] w-[min(560px,90vw)] -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-6 shadow-lg focus:outline-none"
+          className="fixed left-1/2 top-1/2 z-[10000] w-[min(560px,90vw)] -translate-x-1/2 -translate-y-1/2 rounded-lg p-6 shadow-lg focus:outline-none"
+          style={dialogStyles}
           aria-labelledby="cast-discard-title"
         >
-          <h2 id="cast-discard-title" className="text-lg font-semibold text-gray-900">
+          <h2 id="cast-discard-title" className="text-lg font-semibold">
             Cancel Cast
           </h2>
-          <p className="mt-2 text-sm text-gray-600">
+          <p className="mt-2 text-sm">
             Are you sure you want to discard this draft?
           </p>
 
@@ -68,6 +91,7 @@ export const CastDiscardPrompt: React.FC<{
               ref={cancelRef}
               type="button"
               className="inline-flex items-center justify-center rounded-md border px-3 py-1.5 text-sm"
+              style={cancelButtonStyles}
               onClick={onClose}
             >
               Cancel
@@ -75,6 +99,7 @@ export const CastDiscardPrompt: React.FC<{
             <button
               type="button"
               className="inline-flex items-center justify-center rounded-md bg-red-600 px-3 py-1.5 text-sm text-white"
+              style={discardButtonStyles}
               onClick={() => {
                 onDiscard();
                 onClose();

--- a/src/common/components/organisms/MobileHeader.tsx
+++ b/src/common/components/organisms/MobileHeader.tsx
@@ -312,6 +312,7 @@ const MobileHeader = ({ systemConfig }: MobileHeaderProps) => {
               open={showCastDiscardPrompt}
               onClose={handleCancelDiscard}
               onDiscard={handleDiscardCast}
+              systemConfig={systemConfig}
             />
           </>
         </CastModalPortalBoundary>

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -396,6 +396,7 @@ const Navigation = React.memo(
               open={showCastDiscardPrompt}
               onClose={handleCancelDiscard}
               onDiscard={handleDiscardCast}
+              systemConfig={systemConfig}
             />
           </>
         </CastModalPortalBoundary>


### PR DESCRIPTION
## Summary
- apply ui_config-driven font, font color, and background color to the cancel cast confirmation dialog
- ensure discard and cancel buttons inherit configured font while keeping red discard background and semi-transparent gray cancel background
- pass systemConfig into discard prompt from navigation and mobile headers for consistent styling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955b78be9c8832589c6a58c4aad3992)