### PR TITLE
Update $SPACE navigation link to new token space address

### DIFF
--- a/src/config/nouns/nouns.navigation.ts
+++ b/src/config/nouns/nouns.navigation.ts
@@ -5,9 +5,8 @@ export const nounsNavigation: NavigationConfig = {
     { id: 'home', label: 'Home', href: '/home', icon: 'home' },
     { id: 'explore', label: 'Explore', href: '/explore', icon: 'explore' },
     { id: 'notifications', label: 'Notifications', href: '/notifications', icon: 'notifications', requiresAuth: true },
-    { id: 'space-token', label: '$SPACE', href: '/t/base/0x48C6740BcF807d6C47C864FaEEA15Ed4dA3910Ab/Profile', icon: 'space' },
+    { id: 'space-token', label: '$SPACE', href: '/t/base/0xbf63463eE6F105EDC5AdeAa28A0fE8c297aD0b07/Token', icon: 'space' },
   ]
 };
 
 export default nounsNavigation;
-


### PR DESCRIPTION
Note: I created this branch on top of main in order to publish a quick fix. this branch is currently promoted to prod

### Motivation
- Point the `$SPACE` navigation entry at the new token space contract address on Nounspace.
- Use the canonical token route for the new contract so the nav target matches the current token UI path.

### Description
- Updated `src/config/nouns/nouns.navigation.ts` to replace `0x48C6740BcF807d6C47C864FaEEA15Ed4dA3910Ab` with `0xbf63463eE6F105EDC5AdeAa28A0fE8c297aD0b07` and changed the nav href from `/Profile` to `/Token`.
- Only the `nounsNavigation` config item for the `$SPACE` nav entry was modified.

### Testing
- No automated tests were run for this change.
- Quick repository search and file inspection were used to locate and verify the updated nav entry.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ebdd1578083259b8ab86a6918e548)