### PR TITLE
Enable dynamic rendering for proposal space pages

### DIFF
--- a/src/app/(spaces)/p/[proposalId]/page.tsx
+++ b/src/app/(spaces)/p/[proposalId]/page.tsx
@@ -1,6 +1,3 @@
-export const dynamic = "force-static";
-export const revalidate = 60;
-
 import React from "react";
 import { loadProposalSpaceData } from "./utils";
 import SpaceNotFound from "@/app/(spaces)/SpaceNotFound";


### PR DESCRIPTION
### Motivation
- Proposal spaces at `/p/[proposalId]` were failing with a Next.js `DYNAMIC_SERVER_USAGE` error because the page was forced to be statically rendered.
- Token, profile, and channel space pages render dynamically and the proposal page needs the same dynamic behavior to load live proposal data.

### Description
- Removed `export const dynamic = "force-static"` and `export const revalidate = 60` from `src/app/(spaces)/p/[proposalId]/page.tsx` so the page can be rendered dynamically.
- The page continues to use `loadProposalSpaceData`, decode the `tabname` param, and render `ProposalProvider` and `ProposalSpace` as before.
- This change prevents the `DYNAMIC_SERVER_USAGE` error and allows server-side data fetching for proposal pages.

### Testing
- No automated tests were run as part of this change.
- The change is limited to removing static rendering hints and does not modify existing data-loading or rendering logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ffc7d2b18832589162c19cd0c728c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed rendering configuration from proposal details page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->