### PR TITLE
Add dynamic mini app manifests

### DIFF
--- a/src/app/(spaces)/c/[channelId]/layout.tsx
+++ b/src/app/(spaces)/c/[channelId]/layout.tsx
@@ -4,7 +4,7 @@ import { getChannelMetadata } from "./utils";
 import { loadSystemConfig, type SystemConfig } from "@/config";
 import { resolveBaseUrl } from "@/common/lib/utils/resolveBaseUrl";
 import { resolveAssetUrl } from "@/common/lib/utils/resolveAssetUrl";
-import { buildMiniAppEmbed, truncateMiniAppButtonTitle } from "@/common/lib/utils/miniAppEmbed";
+import { buildMiniAppEmbed } from "@/common/lib/utils/miniAppEmbed";
 import { resolveMiniAppDomain } from "@/common/lib/utils/miniAppDomain";
 
 async function buildDefaultMetadata(
@@ -109,7 +109,7 @@ export async function generateMetadata({
     ? `${baseUrl}/c/${channel.id}/${encodeURIComponent(decodedTabName)}`
     : `${baseUrl}/c/${channel.id}`;
 
-  const buttonTitle = truncateMiniAppButtonTitle(`Visit ${name}`);
+  const buttonTitle = `Visit ${name}`;
   const frameName = `${name} on ${brandName}`;
   const splashImageUrl = defaultSplashImage;
 

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -9,12 +9,30 @@ import { loadSystemConfig, type SystemConfig } from "@/config";
 import { resolveBaseUrl } from "@/common/lib/utils/resolveBaseUrl";
 import { resolveAssetUrl } from "@/common/lib/utils/resolveAssetUrl";
 import type { Embed } from "@neynar/nodejs-sdk/build/api";
+import { buildMiniAppEmbed } from "@/common/lib/utils/miniAppEmbed";
+import { resolveMiniAppDomain } from "@/common/lib/utils/miniAppDomain";
 
 async function buildDefaultMetadata(systemConfig: SystemConfig, baseUrl: string): Promise<Metadata> {
   const defaultFrame = await getDefaultFrame({ systemConfig, baseUrl });
+  const brandName = systemConfig.brand.displayName;
+  const defaultImage =
+    resolveAssetUrl(systemConfig.assets.logos.og, baseUrl) ?? systemConfig.assets.logos.og;
+  const splashImageUrl =
+    resolveAssetUrl(systemConfig.assets.logos.splash, baseUrl) ??
+    systemConfig.assets.logos.splash;
+  const miniAppDomain = resolveMiniAppDomain(baseUrl);
+  const defaultMiniApp = buildMiniAppEmbed({
+    imageUrl: defaultImage,
+    buttonTitle: `Open ${brandName}`,
+    actionUrl: baseUrl,
+    actionName: brandName,
+    splashImageUrl,
+  });
   return {
     other: {
       "fc:frame": JSON.stringify(defaultFrame),
+      "fc:miniapp": JSON.stringify(defaultMiniApp),
+      "fc:miniapp:domain": miniAppDomain,
     },
   };
 }
@@ -48,6 +66,7 @@ export async function generateMetadata({
   const systemConfig = await loadSystemConfig();
   const baseUrl = await resolveBaseUrl({ systemConfig });
   const brandName = systemConfig.brand.displayName;
+  const miniAppDomain = resolveMiniAppDomain(baseUrl);
   const twitterHandle = systemConfig.community.social?.x;
   const splashImageUrl =
     resolveAssetUrl(systemConfig.assets.logos.splash, baseUrl) ??
@@ -105,9 +124,21 @@ export async function generateMetadata({
       },
     };
 
+    const castMiniApp = buildMiniAppEmbed({
+      imageUrl: ogImageUrl,
+      buttonTitle: `View @${cast.author.username}'s Cast`,
+      actionUrl: castUrl,
+      actionName: `Cast by @${cast.author.username} on ${brandName}`,
+      splashImageUrl,
+    });
+
     return {
       ...baseMetadata,
-      other: { "fc:frame": JSON.stringify(castFrame) },
+      other: {
+        "fc:frame": JSON.stringify(castFrame),
+        "fc:miniapp": JSON.stringify(castMiniApp),
+        "fc:miniapp:domain": miniAppDomain,
+      },
     };
   } catch (error) {
     console.error("Error generating cast metadata:", error);
@@ -131,7 +162,21 @@ export async function generateMetadata({
         },
       },
     };
-    return { ...baseMetadata, other: { "fc:frame": JSON.stringify(castFrame) } };
+    const castMiniApp = buildMiniAppEmbed({
+      imageUrl: ogImageUrl,
+      buttonTitle: "View Cast",
+      actionUrl: castUrl ?? baseUrl,
+      actionName: `Farcaster Cast on ${brandName}`,
+      splashImageUrl,
+    });
+    return {
+      ...baseMetadata,
+      other: {
+        "fc:frame": JSON.stringify(castFrame),
+        "fc:miniapp": JSON.stringify(castMiniApp),
+        "fc:miniapp:domain": miniAppDomain,
+      },
+    };
   }
 }
 

--- a/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
+++ b/src/app/(spaces)/homebase/[[...slug]]/layout.tsx
@@ -15,11 +15,8 @@ import { resolveMiniAppDomain } from "@/common/lib/utils/miniAppDomain";
 async function buildDefaultMetadata(systemConfig: SystemConfig, baseUrl: string): Promise<Metadata> {
   const defaultFrame = await getDefaultFrame({ systemConfig, baseUrl });
   const brandName = systemConfig.brand.displayName;
-  const defaultImage =
-    resolveAssetUrl(systemConfig.assets.logos.og, baseUrl) ?? systemConfig.assets.logos.og;
-  const splashImageUrl =
-    resolveAssetUrl(systemConfig.assets.logos.splash, baseUrl) ??
-    systemConfig.assets.logos.splash;
+  const defaultImage = defaultFrame.imageUrl;
+  const splashImageUrl = defaultFrame.button.action.splashImageUrl;
   const miniAppDomain = resolveMiniAppDomain(baseUrl);
   const defaultMiniApp = buildMiniAppEmbed({
     imageUrl: defaultImage,

--- a/src/app/.well-known/farcaster.json/route.ts
+++ b/src/app/.well-known/farcaster.json/route.ts
@@ -4,20 +4,19 @@ import { buildMiniAppManifest } from "@/common/lib/utils/miniAppManifest";
 import { resolveMiniAppDomain } from "@/common/lib/utils/miniAppDomain";
 
 function withValidProperties<T extends Record<string, unknown>>(properties: T): Partial<T> {
-  return Object.fromEntries(
-    Object.entries(properties).filter(([_, value]) => {
-      if (value === undefined || value === null) {
-        return false;
-      }
-      if (Array.isArray(value)) {
-        return value.length > 0;
-      }
-      if (typeof value === "string") {
-        return value.trim().length > 0;
-      }
-      return true;
-    })
-  );
+  return Object.entries(properties).reduce<Partial<T>>((acc, [key, value]) => {
+    if (value === undefined || value === null) {
+      return acc;
+    }
+    if (Array.isArray(value) && value.length === 0) {
+      return acc;
+    }
+    if (typeof value === "string" && value.trim().length === 0) {
+      return acc;
+    }
+    acc[key as keyof T] = value as T[keyof T];
+    return acc;
+  }, {});
 }
 
 const resolveEnvAccountAssociation = (): MiniAppAccountAssociation | undefined => {

--- a/src/app/.well-known/farcaster.json/route.ts
+++ b/src/app/.well-known/farcaster.json/route.ts
@@ -1,53 +1,96 @@
-import { getMetadata } from '../../../constants/metadata';
-import { loadSystemConfig } from "@/config";
+import { loadSystemConfig, type MiniAppConfig, type MiniAppAccountAssociation, type MiniAppManifestOverrides } from "@/config";
 import { resolveBaseUrl } from "@/common/lib/utils/resolveBaseUrl";
+import { buildMiniAppManifest } from "@/common/lib/utils/miniAppManifest";
+import { resolveMiniAppDomain } from "@/common/lib/utils/miniAppDomain";
 
-function withValidProperties(properties: Record<string, undefined | string | string[]>) {
+function withValidProperties<T extends Record<string, unknown>>(properties: T): Partial<T> {
   return Object.fromEntries(
-    Object.entries(properties).filter(([_, value]) => (Array.isArray(value) ? value.length > 0 : !!value))
+    Object.entries(properties).filter(([_, value]) => {
+      if (value === undefined || value === null) {
+        return false;
+      }
+      if (Array.isArray(value)) {
+        return value.length > 0;
+      }
+      if (typeof value === "string") {
+        return value.trim().length > 0;
+      }
+      return true;
+    })
   );
 }
+
+const resolveEnvAccountAssociation = (): MiniAppAccountAssociation | undefined => {
+  const header = process.env.FARCASTER_HEADER;
+  const payload = process.env.FARCASTER_PAYLOAD;
+  const signature = process.env.FARCASTER_SIGNATURE;
+  if (!header || !payload || !signature) {
+    return undefined;
+  }
+  return { header, payload, signature };
+};
+
+const isAccountAssociationComplete = (association?: MiniAppAccountAssociation) =>
+  Boolean(association?.header && association?.payload && association?.signature);
+
+const resolveAccountAssociation = (
+  miniappConfig: MiniAppConfig | undefined,
+  domain: string,
+): MiniAppAccountAssociation | undefined => {
+  if (!miniappConfig) {
+    return undefined;
+  }
+  const normalizedDomain = domain.trim().toLowerCase();
+  const associations = miniappConfig.accountAssociations;
+  if (associations && normalizedDomain) {
+    const directMatch = associations[normalizedDomain] ?? associations[domain];
+    if (isAccountAssociationComplete(directMatch)) {
+      return directMatch;
+    }
+    const withoutWww = normalizedDomain.replace(/^www\./, "");
+    const fallbackMatch = associations[withoutWww];
+    if (isAccountAssociationComplete(fallbackMatch)) {
+      return fallbackMatch;
+    }
+  }
+  if (isAccountAssociationComplete(miniappConfig.accountAssociation)) {
+    return miniappConfig.accountAssociation;
+  }
+  return undefined;
+};
 
 export async function GET() {
   const systemConfig = await loadSystemConfig();
   const baseUrl = await resolveBaseUrl({ systemConfig });
-  const metadata = await getMetadata({ systemConfig, baseUrl });
-  const URL = baseUrl || (process.env.NEXT_PUBLIC_URL as string);
+  const miniAppDomain = resolveMiniAppDomain(baseUrl);
   const envTags = process.env.NEXT_PUBLIC_APP_TAGS
-    ?.split(',')
-    .map(tag => tag.trim())
-    .filter(tag => tag.length > 0);
+    ?.split(",")
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0);
+
+  const manifestOverrides: MiniAppManifestOverrides = {
+    ...(systemConfig.community.miniapp?.manifest ?? {}),
+  };
+
+  if ((!manifestOverrides.tags || manifestOverrides.tags.length === 0) && envTags) {
+    manifestOverrides.tags = envTags;
+  }
+
+  const miniapp = buildMiniAppManifest({
+    systemConfig,
+    baseUrl,
+    overrides: manifestOverrides,
+  });
+
+  const accountAssociation =
+    resolveAccountAssociation(systemConfig.community.miniapp, miniAppDomain) ??
+    resolveEnvAccountAssociation();
+
   return Response.json({
-    accountAssociation: {
-      header: process.env.FARCASTER_HEADER,
-      payload: process.env.FARCASTER_PAYLOAD,
-      signature: process.env.FARCASTER_SIGNATURE,
-    },
-    miniapp: withValidProperties({
-      version: '1',
-      imageUrl: metadata.APP_OG_IMAGE || process.env.NEXT_PUBLIC_APP_OG_IMAGE,
-      buttonTitle: metadata.APP_NAME || process.env.NEXT_PUBLIC_ONCHAINKIT_PROJECT_NAME,
-      name: metadata.APP_NAME || process.env.NEXT_PUBLIC_ONCHAINKIT_PROJECT_NAME,
-      subtitle: metadata.APP_SUBTITLE || process.env.NEXT_PUBLIC_APP_SUBTITLE,
-      description: metadata.APP_DESCRIPTION || process.env.NEXT_PUBLIC_APP_DESCRIPTION,
-      screenshotUrls: [],
-      iconUrl: metadata.APP_ICON || process.env.NEXT_PUBLIC_APP_ICON,
-      splashImageUrl: metadata.APP_SPLASH_IMAGE || process.env.NEXT_PUBLIC_APP_SPLASH_IMAGE,
-      splashBackgroundColor: metadata.SPLASH_BACKGROUND_COLOR || process.env.NEXT_PUBLIC_SPLASH_BACKGROUND_COLOR,
-      homeUrl: URL,
-      webhookUrl: `${URL}/api/webhook`,
-      primaryCategory: metadata.APP_PRIMARY_CATEGORY || process.env.NEXT_PUBLIC_APP_PRIMARY_CATEGORY,
-      tags: metadata.APP_TAGS && metadata.APP_TAGS.length > 0 ? metadata.APP_TAGS : envTags,
-      heroImageUrl: metadata.APP_HERO_IMAGE || process.env.NEXT_PUBLIC_APP_HERO_IMAGE,
-      tagline: metadata.APP_TAGLINE || process.env.NEXT_PUBLIC_APP_TAGLINE,
-      ogTitle: metadata.APP_OG_TITLE || process.env.NEXT_PUBLIC_APP_OG_TITLE,
-      ogDescription: metadata.APP_OG_DESCRIPTION || process.env.NEXT_PUBLIC_APP_OG_DESCRIPTION,
-      ogImageUrl: metadata.APP_OG_IMAGE || process.env.NEXT_PUBLIC_APP_OG_IMAGE,
-      // use only while testing
-      // noindex: 'true',
-    }),
+    ...(accountAssociation ? { accountAssociation } : {}),
+    miniapp: withValidProperties(miniapp),
     baseBuilder: {
-      allowedAddresses: ["0x857Ba87e094BF962D0B933bBf2C706893e14d3bE"]
-    }
+      allowedAddresses: ["0x857Ba87e094BF962D0B933bBf2C706893e14d3bE"],
+    },
   });
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,8 @@ import type { Metadata } from 'next' // Migrating next/head
 import { extractFontFamilyFromUrl } from "@/common/lib/utils/fontUtils";
 import { resolveBaseUrl } from "@/common/lib/utils/resolveBaseUrl";
 import { resolveAssetUrl } from "@/common/lib/utils/resolveAssetUrl";
+import { buildMiniAppEmbed } from "@/common/lib/utils/miniAppEmbed";
+import { resolveMiniAppDomain } from "@/common/lib/utils/miniAppDomain";
 
 const TRUSTED_STYLESHEET_HOSTS = new Set(["fonts.googleapis.com"]);
 
@@ -53,6 +55,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const splashImageUrl =
     resolveAssetUrl(config.assets.logos.splash, baseUrl) ?? config.assets.logos.splash;
   const communityOgUrl = `${baseUrl}/api/metadata/community`;
+  const miniAppDomain = resolveMiniAppDomain(baseUrl);
   
   const defaultFrame = {
     version: "next",
@@ -68,6 +71,14 @@ export async function generateMetadata(): Promise<Metadata> {
       }
     }
   };
+
+  const defaultMiniApp = buildMiniAppEmbed({
+    imageUrl: communityOgUrl,
+    buttonTitle: `Open ${config.brand.displayName}`,
+    actionUrl: baseUrl,
+    actionName: config.brand.displayName,
+    splashImageUrl,
+  });
 
   return {
     title: config.brand.displayName,
@@ -113,6 +124,8 @@ export async function generateMetadata(): Promise<Metadata> {
     },
     other: {
       "fc:frame": JSON.stringify(defaultFrame),
+      "fc:miniapp": JSON.stringify(defaultMiniApp),
+      "fc:miniapp:domain": miniAppDomain,
     },
   };
 }

--- a/src/common/lib/utils/miniAppDomain.ts
+++ b/src/common/lib/utils/miniAppDomain.ts
@@ -1,0 +1,8 @@
+export const resolveMiniAppDomain = (url: string): string => {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    const trimmed = url.replace(/^https?:\/\//i, "");
+    return trimmed.split("/")[0]?.split(":")[0] ?? "";
+  }
+};

--- a/src/common/lib/utils/miniAppEmbed.ts
+++ b/src/common/lib/utils/miniAppEmbed.ts
@@ -1,0 +1,58 @@
+type MiniAppEmbedAction = {
+  type: "launch_miniapp";
+  name: string;
+  url: string;
+  splashImageUrl: string;
+  splashBackgroundColor?: string;
+};
+
+export type MiniAppEmbed = {
+  version: "1";
+  imageUrl: string;
+  button: {
+    title: string;
+    action: MiniAppEmbedAction;
+  };
+};
+
+const MAX_BUTTON_TITLE_LENGTH = 32;
+
+export const truncateMiniAppButtonTitle = (title: string) => {
+  if (title.length <= MAX_BUTTON_TITLE_LENGTH) {
+    return title;
+  }
+  const ellipsis = "...";
+  const sliceLimit = Math.max(0, MAX_BUTTON_TITLE_LENGTH - ellipsis.length);
+  return `${title.slice(0, sliceLimit)}${ellipsis}`;
+};
+
+type BuildMiniAppEmbedOptions = {
+  imageUrl: string;
+  buttonTitle: string;
+  actionUrl: string;
+  actionName: string;
+  splashImageUrl: string;
+  splashBackgroundColor?: string;
+};
+
+export const buildMiniAppEmbed = ({
+  imageUrl,
+  buttonTitle,
+  actionUrl,
+  actionName,
+  splashImageUrl,
+  splashBackgroundColor = "#FFFFFF",
+}: BuildMiniAppEmbedOptions): MiniAppEmbed => ({
+  version: "1",
+  imageUrl,
+  button: {
+    title: truncateMiniAppButtonTitle(buttonTitle),
+    action: {
+      type: "launch_miniapp",
+      name: actionName,
+      url: actionUrl,
+      splashImageUrl,
+      splashBackgroundColor,
+    },
+  },
+});

--- a/src/common/lib/utils/miniAppManifest.ts
+++ b/src/common/lib/utils/miniAppManifest.ts
@@ -1,0 +1,185 @@
+import type { SystemConfig, MiniAppManifestOverrides } from "@/config";
+import { resolveAssetUrl } from "@/common/lib/utils/resolveAssetUrl";
+
+export type MiniAppManifest = {
+  version: "1";
+  name: string;
+  homeUrl: string;
+  iconUrl: string;
+  splashImageUrl?: string;
+  splashBackgroundColor?: string;
+  subtitle?: string;
+  description?: string;
+  screenshotUrls?: string[];
+  primaryCategory?: string;
+  tags?: string[];
+  heroImageUrl?: string;
+  tagline?: string;
+  ogTitle?: string;
+  ogDescription?: string;
+  ogImageUrl?: string;
+  noindex?: boolean;
+  requiredChains?: string[];
+  requiredCapabilities?: string[];
+  canonicalDomain?: string;
+};
+
+const MINIAPP_PRIMARY_CATEGORIES = new Set([
+  "games",
+  "social",
+  "finance",
+  "utility",
+  "productivity",
+  "health-fitness",
+  "news-media",
+  "music",
+  "shopping",
+  "education",
+  "developer-tools",
+  "entertainment",
+  "art-creativity",
+]);
+
+const MAX_NAME_LENGTH = 32;
+const MAX_SUBTITLE_LENGTH = 30;
+const MAX_DESCRIPTION_LENGTH = 170;
+const MAX_TAGLINE_LENGTH = 30;
+const MAX_OG_TITLE_LENGTH = 30;
+const MAX_OG_DESCRIPTION_LENGTH = 100;
+const MAX_URL_LENGTH = 1024;
+const MAX_TAG_LENGTH = 20;
+const MAX_TAGS = 5;
+const MAX_SCREENSHOTS = 3;
+
+const truncate = (value: string, maxLength: number) =>
+  value.length > maxLength ? value.slice(0, maxLength) : value;
+
+const sanitizeManifestText = (value?: string, maxLength?: number) => {
+  if (!value) return undefined;
+  const ascii = value.replace(/[^\x20-\x7E]/g, "");
+  const normalized = ascii.replace(/\s+/g, " ").trim();
+  if (!normalized) return undefined;
+  return maxLength ? truncate(normalized, maxLength) : normalized;
+};
+
+const normalizeUrl = (value?: string) => {
+  if (!value) return undefined;
+  return truncate(value.trim(), MAX_URL_LENGTH);
+};
+
+const normalizePrimaryCategory = (value?: string) => {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase();
+  return MINIAPP_PRIMARY_CATEGORIES.has(normalized) ? normalized : undefined;
+};
+
+const normalizeTags = (tags?: string[]) => {
+  if (!tags || tags.length === 0) return undefined;
+  const normalized = tags
+    .map((tag) => tag.toLowerCase().replace(/[^a-z0-9-]/g, ""))
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0)
+    .map((tag) => truncate(tag, MAX_TAG_LENGTH))
+    .slice(0, MAX_TAGS);
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+const normalizeScreenshots = (urls?: string[]) => {
+  if (!urls || urls.length === 0) return undefined;
+  const normalized = urls
+    .map((url) => url?.trim())
+    .filter((url): url is string => !!url)
+    .slice(0, MAX_SCREENSHOTS);
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+const normalizeCanonicalDomain = (value?: string) => {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  const withoutScheme = trimmed.replace(/^https?:\/\//i, "");
+  return withoutScheme.split("/")[0]?.split(":")[0] ?? undefined;
+};
+
+type BuildMiniAppManifestOptions = {
+  systemConfig: SystemConfig;
+  baseUrl: string;
+  overrides?: MiniAppManifestOverrides;
+};
+
+export const buildMiniAppManifest = ({
+  systemConfig,
+  baseUrl,
+  overrides,
+}: BuildMiniAppManifestOptions): MiniAppManifest => {
+  const resolvedIconUrl =
+    resolveAssetUrl(systemConfig.assets.logos.icon, baseUrl) ?? systemConfig.assets.logos.icon;
+  const resolvedSplashUrl =
+    resolveAssetUrl(systemConfig.assets.logos.splash, baseUrl) ?? systemConfig.assets.logos.splash;
+  const resolvedOgUrl =
+    resolveAssetUrl(systemConfig.assets.logos.og, baseUrl) ?? systemConfig.assets.logos.og;
+
+  const name = truncate(overrides?.name ?? systemConfig.brand.displayName, MAX_NAME_LENGTH);
+  const homeUrl = normalizeUrl(overrides?.homeUrl ?? baseUrl) ?? baseUrl;
+  const iconUrl = normalizeUrl(overrides?.iconUrl ?? resolvedIconUrl) ?? resolvedIconUrl;
+
+  const subtitle = sanitizeManifestText(
+    overrides?.subtitle ?? systemConfig.brand.description,
+    MAX_SUBTITLE_LENGTH,
+  );
+  const description = sanitizeManifestText(
+    overrides?.description ?? systemConfig.brand.description,
+    MAX_DESCRIPTION_LENGTH,
+  );
+  const screenshotUrls = normalizeScreenshots(overrides?.screenshotUrls);
+  const primaryCategory = normalizePrimaryCategory(overrides?.primaryCategory);
+  const tags = normalizeTags(overrides?.tags ?? systemConfig.brand.miniAppTags);
+  const heroImageUrl = normalizeUrl(overrides?.heroImageUrl ?? resolvedOgUrl);
+  const tagline = sanitizeManifestText(
+    overrides?.tagline ?? systemConfig.brand.description,
+    MAX_TAGLINE_LENGTH,
+  );
+  const ogTitle = sanitizeManifestText(
+    overrides?.ogTitle ?? systemConfig.brand.displayName,
+    MAX_OG_TITLE_LENGTH,
+  );
+  const ogDescription = sanitizeManifestText(
+    overrides?.ogDescription ?? systemConfig.brand.description,
+    MAX_OG_DESCRIPTION_LENGTH,
+  );
+  const ogImageUrl = normalizeUrl(overrides?.ogImageUrl ?? resolvedOgUrl);
+  const canonicalDomain = normalizeCanonicalDomain(overrides?.canonicalDomain);
+
+  const manifest: MiniAppManifest = {
+    version: "1",
+    name,
+    homeUrl,
+    iconUrl,
+    ...(overrides?.splashImageUrl || resolvedSplashUrl
+      ? { splashImageUrl: normalizeUrl(overrides?.splashImageUrl ?? resolvedSplashUrl) }
+      : {}),
+    ...(overrides?.splashBackgroundColor
+      ? { splashBackgroundColor: overrides.splashBackgroundColor }
+      : { splashBackgroundColor: "#FFFFFF" }),
+    ...(subtitle ? { subtitle } : {}),
+    ...(description ? { description } : {}),
+    ...(screenshotUrls ? { screenshotUrls } : {}),
+    ...(primaryCategory ? { primaryCategory } : {}),
+    ...(tags ? { tags } : {}),
+    ...(heroImageUrl ? { heroImageUrl } : {}),
+    ...(tagline ? { tagline } : {}),
+    ...(ogTitle ? { ogTitle } : {}),
+    ...(ogDescription ? { ogDescription } : {}),
+    ...(ogImageUrl ? { ogImageUrl } : {}),
+    ...(typeof overrides?.noindex === "boolean" ? { noindex: overrides.noindex } : {}),
+    ...(overrides?.requiredChains && overrides.requiredChains.length > 0
+      ? { requiredChains: overrides.requiredChains }
+      : {}),
+    ...(overrides?.requiredCapabilities && overrides.requiredCapabilities.length > 0
+      ? { requiredCapabilities: overrides.requiredCapabilities }
+      : {}),
+    ...(canonicalDomain ? { canonicalDomain } : {}),
+  };
+
+  return manifest;
+};

--- a/src/common/lib/utils/miniAppManifest.ts
+++ b/src/common/lib/utils/miniAppManifest.ts
@@ -6,6 +6,8 @@ export type MiniAppManifest = {
   name: string;
   homeUrl: string;
   iconUrl: string;
+  imageUrl?: string;
+  buttonTitle?: string;
   splashImageUrl?: string;
   splashBackgroundColor?: string;
   subtitle?: string;
@@ -46,6 +48,7 @@ const MAX_DESCRIPTION_LENGTH = 170;
 const MAX_TAGLINE_LENGTH = 30;
 const MAX_OG_TITLE_LENGTH = 30;
 const MAX_OG_DESCRIPTION_LENGTH = 100;
+const MAX_BUTTON_TITLE_LENGTH = 32;
 const MAX_URL_LENGTH = 1024;
 const MAX_TAG_LENGTH = 20;
 const MAX_TAGS = 5;
@@ -65,6 +68,13 @@ const sanitizeManifestText = (value?: string, maxLength?: number) => {
 const normalizeUrl = (value?: string) => {
   if (!value) return undefined;
   return truncate(value.trim(), MAX_URL_LENGTH);
+};
+
+const normalizeButtonTitle = (value?: string) => {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return truncate(trimmed, MAX_BUTTON_TITLE_LENGTH);
 };
 
 const normalizePrimaryCategory = (value?: string) => {
@@ -148,6 +158,8 @@ export const buildMiniAppManifest = ({
     MAX_OG_DESCRIPTION_LENGTH,
   );
   const ogImageUrl = normalizeUrl(overrides?.ogImageUrl ?? resolvedOgUrl);
+  const imageUrl = normalizeUrl(overrides?.imageUrl);
+  const buttonTitle = normalizeButtonTitle(overrides?.buttonTitle);
   const canonicalDomain = normalizeCanonicalDomain(overrides?.canonicalDomain);
 
   const manifest: MiniAppManifest = {
@@ -171,6 +183,8 @@ export const buildMiniAppManifest = ({
     ...(ogTitle ? { ogTitle } : {}),
     ...(ogDescription ? { ogDescription } : {}),
     ...(ogImageUrl ? { ogImageUrl } : {}),
+    ...(imageUrl ? { imageUrl } : {}),
+    ...(buttonTitle ? { buttonTitle } : {}),
     ...(typeof overrides?.noindex === "boolean" ? { noindex: overrides.noindex } : {}),
     ...(overrides?.requiredChains && overrides.requiredChains.length > 0
       ? { requiredChains: overrides.requiredChains }

--- a/src/common/lib/utils/miniAppManifest.ts
+++ b/src/common/lib/utils/miniAppManifest.ts
@@ -87,7 +87,6 @@ const normalizeTags = (tags?: string[]) => {
   if (!tags || tags.length === 0) return undefined;
   const normalized = tags
     .map((tag) => tag.toLowerCase().replace(/[^a-z0-9-]/g, ""))
-    .map((tag) => tag.trim())
     .filter((tag) => tag.length > 0)
     .map((tag) => truncate(tag, MAX_TAG_LENGTH))
     .slice(0, MAX_TAGS);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -101,6 +101,9 @@ export type {
   CommunityNftToken,
   CommunityTokenNetwork,
   CommunityTokensConfig,
+  MiniAppAccountAssociation,
+  MiniAppManifestOverrides,
+  MiniAppConfig,
 };
 
 // Space creators - re-export directly from Nouns implementations

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,6 +4,9 @@ import {
   type CommunityNftToken,
   type CommunityTokenNetwork,
   type CommunityTokensConfig,
+  type MiniAppAccountAssociation,
+  type MiniAppManifestOverrides,
+  type MiniAppConfig,
 } from './systemConfig';
 import { 
   ConfigLoadContext,

--- a/src/config/systemConfig.ts
+++ b/src/config/systemConfig.ts
@@ -137,6 +137,8 @@ export interface MiniAppManifestOverrides {
   ogTitle?: string;
   ogDescription?: string;
   ogImageUrl?: string;
+  imageUrl?: string;
+  buttonTitle?: string;
   homeUrl?: string;
   iconUrl?: string;
   splashImageUrl?: string;

--- a/src/config/systemConfig.ts
+++ b/src/config/systemConfig.ts
@@ -111,11 +111,46 @@ export interface CommunityConfig {
     farcaster?: string;
     x?: string;
   };
+  miniapp?: MiniAppConfig;
   governance?: {
     snapshotSpace?: string;
     nounishGov?: string;
   };
   tokens?: CommunityTokensConfig;
+}
+
+export interface MiniAppAccountAssociation {
+  header: string;
+  payload: string;
+  signature: string;
+}
+
+export interface MiniAppManifestOverrides {
+  name?: string;
+  subtitle?: string;
+  description?: string;
+  screenshotUrls?: string[];
+  primaryCategory?: string;
+  tags?: string[];
+  heroImageUrl?: string;
+  tagline?: string;
+  ogTitle?: string;
+  ogDescription?: string;
+  ogImageUrl?: string;
+  homeUrl?: string;
+  iconUrl?: string;
+  splashImageUrl?: string;
+  splashBackgroundColor?: string;
+  noindex?: boolean;
+  requiredChains?: string[];
+  requiredCapabilities?: string[];
+  canonicalDomain?: string;
+}
+
+export interface MiniAppConfig {
+  accountAssociation?: MiniAppAccountAssociation;
+  accountAssociations?: Record<string, MiniAppAccountAssociation>;
+  manifest?: MiniAppManifestOverrides;
 }
 
 export interface FidgetConfig {


### PR DESCRIPTION
Fixes prod issues with Nouns' mini app manifest while making manifests dynamic and paving the way for community admins to be able to register/sign the mini app version of their space system (with the goal of enabling community admins to upload their account association signature from blank.space launchpad).

Summary:
- Implemented dynamic miniapp manifests + embed metadata end‑to‑end, wiring per‑community config (including per‑domain signatures) and adding fc:miniapp tags across all shareable pages.
- Manifest building + config: added shared utilities in miniAppManifest.ts, miniAppEmbed.ts, and miniAppDomain.ts, plus new community.miniapp config types in systemConfig.ts and exports in index.ts.
- Manifest route: route.ts now builds a full manifest from config, uses per‑domain accountAssociation (or env fallback), and omits webhookUrl as requested.
- Embeds everywhere: added fc:miniapp + fc:miniapp:domain metadata alongside frames in layout.tsx, layout.tsx, layout.tsx, layout.tsx, layout.tsx, and layout.tsx.

Testing:
example of an updated community_config (for nounspace.com):
{
  "type": "erc20-token",
  "urls": {
    "discord": "https://discord.gg/TAqsDAp3XW",
    "website": "https://nouns.wtf"
  },
  "domain": "nounspace.com",
  "social": {
    "x": "nounsdao",
    "farcaster": "nouns"
  },
  "tokens": {
    "erc20Tokens": [
      {
        "name": "Nounspace (v2)",
        "symbol": "$SPACE",
        "address": "0xbf63463eE6F105EDC5AdeAa28A0fE8c297aD0b07",
        "network": "base",
        "decimals": 18
      }
    ]
  },
  "miniapp": {
    "manifest": {
      "name": "Nouns",
      "tags": [
        "nouns",
        "social",
        "client",
        "customizable",
        "dao"
      ],
      "homeUrl": "https://nounspace.com",
      "iconUrl": "https://www.nounspace.com/_next/static/media/noggles.23179b3f.svg",
      "noindex": false,
      "ogTitle": "Nouns",
      "imageUrl": "https://undbyaytxgmhhbuxjbty.supabase.co/storage/v1/object/public/images/community/nounspace.com/og.jpg",
      "subtitle": "Explore Nouns",
      "ogImageUrl": "https://undbyaytxgmhhbuxjbty.supabase.co/storage/v1/object/public/images/community/nounspace.com/og.jpg",
      "buttonTitle": "Explore Nouns",
      "description": "A space for Nouns. Create, customize, and explore the Nouns universe.",
      "heroImageUrl": "https://undbyaytxgmhhbuxjbty.supabase.co/storage/v1/object/public/images/community/nounspace.com/og.jpg",
      "ogDescription": "A space for Nouns.",
      "requiredChains": [
        "eip155:8453"
      ],
      "screenshotUrls": [
        "https://your-cdn.example.com/miniapp/screen-1-1284x2778.png"
      ],
      "splashImageUrl": "https://www.nounspace.com/_next/static/media/noggles.23179b3f.svg",
      "canonicalDomain": "https://nounspace.com",
      "primaryCategory": "social",
      "requiredCapabilities": [],
      "splashBackgroundColor": "#FFFFFF"
    },
    "accountAssociations": {
      "empirebuilder.blank.space": {
        "header": "eyJmaWQiOjQ4ODgsInR5cGUiOiJjdXN0b2R5Iiwia2V5IjoiMHhhQWIwQzY2Qjc2QzA0ZUEzMTRDMjQ4Y0U1NzA0YTY1NzcxNzNFQzZjIn0",
        "payload": "eyJkb21haW4iOiJ3d3cubm91bnNwYWNlLmNvbSJ9",
        "signature": "MHhlM2IyZjIzNjhmOGU0ZTk1NmU1ZmY4ZGQ1YzI1ZGQwZWQ2ZmFhOTdjYmFjMjllZDdiMTY0NzI0MWQyZjUzNTBkNjcxZjU1MjYxMDg5Y2RjNTJmZTQwNGMzNDNmMzdjZjEwNmY0ZGI0YmU2YjRjYTAwYmQxNmFjNGJkYWZkMGEyOTFi"
      }
    }
  },
  "governance": {},
  "admin_address": "0x05A1ff0a32bc24265BCB39499d0c5D9A6cb2011c"
}


Test this branch in farcaster's mini app manifest testing tool:
https://farcaster.xyz/~/developers/mini-apps/manifest?domain=space-system-b3gvhc7rj-blankdotspace.vercel.app


<img width="3044" height="5228" alt="image" src="https://github.com/user-attachments/assets/cbef727f-560d-4206-8166-91df3f109c94" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mini app embedding support across pages, enabling enhanced metadata for Farcaster integration
  * Introduced mini app manifest generation and domain resolution capabilities
  * Added configurable mini app settings for customization of branding, images, and button titles
  * Enhanced Farcaster integration with mini app account association and manifest overrides

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->