### PR TITLE
feat: add dynamic sitemap generation

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,67 @@
+import type { MetadataRoute } from "next";
+import { loadSystemConfig } from "@/config";
+import { resolveBaseUrl } from "@/common/lib/utils/resolveBaseUrl";
+import { createSupabaseServerClient } from "@/common/data/database/supabase/clients/server";
+
+export const dynamic = "force-dynamic";
+
+type TabOrderFile = {
+  tabOrder?: string[];
+};
+
+const resolveTabOrder = async (spaceId: string): Promise<string[]> => {
+  try {
+    const { data, error } = await createSupabaseServerClient()
+      .storage
+      .from("spaces")
+      .download(`${spaceId}/tabOrder`);
+
+    if (error || !data) {
+      return [];
+    }
+
+    const text = await data.text();
+    const parsed = JSON.parse(text) as TabOrderFile;
+    const tabs = parsed.tabOrder ?? [];
+    return Array.isArray(tabs) ? tabs.filter((tab) => typeof tab === "string" && tab.length > 0) : [];
+  } catch (error) {
+    console.warn(`Failed to load tabOrder for space ${spaceId}:`, error);
+    return [];
+  }
+};
+
+const buildNavUrls = async (
+  baseUrl: string,
+  navSlug: "home" | "explore",
+  spaceId?: string,
+): Promise<string[]> => {
+  const urls = [`${baseUrl}/${navSlug}`];
+  if (!spaceId) {
+    return urls;
+  }
+  const tabs = await resolveTabOrder(spaceId);
+  for (const tab of tabs) {
+    urls.push(`${baseUrl}/${navSlug}/${encodeURIComponent(tab)}`);
+  }
+  return urls;
+};
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const systemConfig = await loadSystemConfig();
+  const baseUrl = await resolveBaseUrl({ systemConfig });
+  const navItems = systemConfig.navigation?.items ?? [];
+
+  const homeItem = navItems.find((item) => item.href === "/home" || item.id === "home");
+  const exploreItem = navItems.find((item) => item.href === "/explore" || item.id === "explore");
+
+  const [homeUrls, exploreUrls] = await Promise.all([
+    buildNavUrls(baseUrl, "home", homeItem?.spaceId),
+    buildNavUrls(baseUrl, "explore", exploreItem?.spaceId),
+  ]);
+
+  const lastModified = new Date();
+  return [...homeUrls, ...exploreUrls].map((url) => ({
+    url,
+    lastModified,
+  }));
+}


### PR DESCRIPTION
## Overview

This PR adds dynamic sitemap generation that supports multi-community space systems. The sitemap is generated based on the system configuration and includes navigation items (home and explore) with their associated tabs.

## Changes

- **New file**: `src/app/sitemap.ts` - Dynamic sitemap generator
  - Generates sitemap entries based on system config navigation items
  - Supports home and explore navigation with dynamic tab discovery
  - Resolves tab order from Supabase storage for each space
  - Uses `force-dynamic` to ensure fresh sitemap generation on each request

## Technical Details

- The sitemap dynamically resolves:
  - Base URL from system config
  - Navigation items (home/explore) from system config
  - Tab order for each space from Supabase storage
  - Generates URLs for base navigation items and their tabs

- Uses Next.js `MetadataRoute.Sitemap` type for proper sitemap generation
- Includes lastModified timestamp for all entries

## Benefits

- Improves SEO for multi-community space systems
- Ensures search engines can discover all navigation tabs
- Automatically updates when navigation or tab configurations change
- Works with the existing dynamic metadata infrastructure

---

**Note**: This PR only includes the sitemap.ts file changes, without any other branch dependencies.