### PR TITLE
Remove jsdom from opengraph endpoint and resolve relative OG image URLs

### DIFF
--- a/src/common/lib/utils/resolveBaseUrlFromHeaders.ts
+++ b/src/common/lib/utils/resolveBaseUrlFromHeaders.ts
@@ -52,7 +52,11 @@ function parseHostCandidate(value: string): ParsedHost | undefined {
 }
 
 function isVercelDotCom(host: string): boolean {
-  return host === "vercel.com" || host.endsWith(".vercel.com");
+  return (
+    host === "vercel.com" ||
+    host.endsWith(".vercel.com") ||
+    host.endsWith(".vercel.app")
+  );
 }
 
 function normalizeBaseUrl(rawUrl: string): string {


### PR DESCRIPTION
### Motivation
- The `/api/opengraph` endpoint was failing with an ESM `require()` error from `jsdom` causing 500 responses in serverless environments. 
- Using `jsdom` creates compatibility issues in the deployed Node runtime, so a lighter parsing approach is needed for robustness. 
- Open Graph images were sometimes returned as relative paths or endpoint URLs instead of absolute image URLs, causing incorrect image links in metadata. 

### Description
- Removed the `jsdom` dependency from `src/app/api/opengraph/route.ts` and replaced DOM parsing with a small regex-based `getMetaContent` helper to extract meta tag `content` values. 
- Added `resolveMaybeRelativeUrl` to normalize `og:image` (and `twitter:image`) values by resolving relative paths against the requested page URL. 
- Extracted `title`, `description`, `image`, and `siteName` from the raw HTML using the new helpers while keeping existing fetch headers, timeout, and error handling intact. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696acf92233483258f60067140f50545)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenGraph metadata extraction reliability with better error handling for failed requests.
  * Enhanced security by requiring HTTPS URLs for metadata retrieval.
  * Extended support for additional Vercel hosting domains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->