### PR TITLE
Add Matcha referral tracking with dynamic community config

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -186,7 +186,7 @@ export default async function RootLayout({
         }
       >
         <SpeedInsights />
-        <Providers>{sidebarLayout(children, systemConfig)}</Providers>
+        <Providers systemConfig={systemConfig}>{sidebarLayout(children, systemConfig)}</Providers>
       </body>
     </html>
   );

--- a/src/common/lib/utils/links.ts
+++ b/src/common/lib/utils/links.ts
@@ -13,9 +13,9 @@ export function getGeckoIframe(address: Address, network: EtherScanChainName) {
   return `https://www.geckoterminal.com/${getGeckoNetwork(network)}/pools/${address}?embed=1&info=0&swaps=0&grayscale=0&light_chart=1`;
 }
 
-export function getMatchaUrl(address: Address, network: EtherScanChainName) {
+export function getMatchaUrl(address: Address, network: EtherScanChainName, ref?: string) {
   const ethAddress = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
-  const matchaRef = process.env.NEXT_PUBLIC_MATCHA_REF || "nounspace";
+  const matchaRef = ref || "nounspace";
   return `https://matcha.xyz/trade?sellAddress=${ethAddress}&buyAddress=${address}&sellChain=${network}&buyChain=${EtherScanChains[network]}&ref=${matchaRef}`;
 }
 

--- a/src/common/lib/utils/links.ts
+++ b/src/common/lib/utils/links.ts
@@ -15,7 +15,8 @@ export function getGeckoIframe(address: Address, network: EtherScanChainName) {
 
 export function getMatchaUrl(address: Address, network: EtherScanChainName) {
   const ethAddress = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
-  return `https://matcha.xyz/trade?sellAddress=${ethAddress}&buyAddress=${address}&sellChain=${network}&buyChain=${EtherScanChains[network]}`;
+  const matchaRef = process.env.NEXT_PUBLIC_MATCHA_REF || "nounspace";
+  return `https://matcha.xyz/trade?sellAddress=${ethAddress}&buyAddress=${address}&sellChain=${network}&buyChain=${EtherScanChains[network]}&ref=${matchaRef}`;
 }
 
 export function getDexScreenerUrl(

--- a/src/common/providers/SystemConfigProvider.tsx
+++ b/src/common/providers/SystemConfigProvider.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import React, { createContext, useContext } from "react";
+import { SystemConfig } from "@/config";
+
+const SystemConfigContext = createContext<SystemConfig | null>(null);
+
+export const SystemConfigProvider: React.FC<{
+  children: React.ReactNode;
+  systemConfig: SystemConfig;
+}> = ({ children, systemConfig }) => {
+  return (
+    <SystemConfigContext.Provider value={systemConfig}>
+      {children}
+    </SystemConfigContext.Provider>
+  );
+};
+
+export const useSystemConfig = (): SystemConfig => {
+  const context = useContext(SystemConfigContext);
+  if (!context) {
+    throw new Error("useSystemConfig must be used within SystemConfigProvider");
+  }
+  return context;
+};
+
+export default SystemConfigProvider;

--- a/src/common/providers/index.tsx
+++ b/src/common/providers/index.tsx
@@ -17,6 +17,8 @@ import MobilePreviewProvider from "./MobilePreviewProvider";
 import { SharedDataProvider } from "./SharedDataProvider";
 import { MiniKitContextProvider } from "./MiniKitProvider";
 import { GlobalErrorHandler } from "./GlobalErrorHandler";
+import { SystemConfigProvider } from "./SystemConfigProvider";
+import { SystemConfig } from "@/config";
 
 const RarelyUpdatedProviders = React.memo(
   function RarelyUpdatedProviders({
@@ -38,33 +40,41 @@ const RarelyUpdatedProviders = React.memo(
   },
 );
 
-export default function Providers({ children }: { children: React.ReactNode }) {
+export default function Providers({
+  children,
+  systemConfig,
+}: {
+  children: React.ReactNode;
+  systemConfig: SystemConfig;
+}) {
   return (
     <>
       <GlobalErrorHandler />
-      <VersionCheckProivder>
-        <Privy>
-          <Query>
-            <Wagmi>
-              <MiniKitContextProvider>
-                <Theme>
-                  <AppStoreProvider>
-                    <UserThemeProvider>
-                      <AuthenticatorProvider>
-                        <LoggedInStateProvider>
-                          <SidebarContextProvider>
-                            <RarelyUpdatedProviders>{children}</RarelyUpdatedProviders>
-                          </SidebarContextProvider>
-                        </LoggedInStateProvider>
-                      </AuthenticatorProvider>
-                    </UserThemeProvider>
-                  </AppStoreProvider>
-                </Theme>
-              </MiniKitContextProvider>
-            </Wagmi>
-          </Query>
-        </Privy>
-      </VersionCheckProivder>
+      <SystemConfigProvider systemConfig={systemConfig}>
+        <VersionCheckProivder>
+          <Privy>
+            <Query>
+              <Wagmi>
+                <MiniKitContextProvider>
+                  <Theme>
+                    <AppStoreProvider>
+                      <UserThemeProvider>
+                        <AuthenticatorProvider>
+                          <LoggedInStateProvider>
+                            <SidebarContextProvider>
+                              <RarelyUpdatedProviders>{children}</RarelyUpdatedProviders>
+                            </SidebarContextProvider>
+                          </LoggedInStateProvider>
+                        </AuthenticatorProvider>
+                      </UserThemeProvider>
+                    </AppStoreProvider>
+                  </Theme>
+                </MiniKitContextProvider>
+              </Wagmi>
+            </Query>
+          </Privy>
+        </VersionCheckProivder>
+      </SystemConfigProvider>
     </>
   );
 }

--- a/src/fidgets/swap/Swap.tsx
+++ b/src/fidgets/swap/Swap.tsx
@@ -146,6 +146,8 @@ const Swap: React.FC<FidgetArgs<MatchaFidgetSettings>> = ({
     }
     if (optionalFeeRecipient)
       params.append("feeRecipient", optionalFeeRecipient);
+    const matchaRef = process.env.NEXT_PUBLIC_MATCHA_REF || "nounspace";
+    params.append("ref", matchaRef);
     return `${matchaBaseUrl}?${params.toString()}`;
   };
 

--- a/src/fidgets/swap/Swap.tsx
+++ b/src/fidgets/swap/Swap.tsx
@@ -11,6 +11,7 @@ import {
 import { BsArrowRepeat } from "react-icons/bs";
 import { mobileStyleSettings, WithMargin } from "../helpers";
 import ShadowSelector from "@/common/components/molecules/ShadowSelector";
+import { useSystemConfig } from "@/common/providers/SystemConfigProvider";
 
 type MatchaFidgetSettings = {
   defaultSellToken: string;
@@ -131,10 +132,12 @@ const Swap: React.FC<FidgetArgs<MatchaFidgetSettings>> = ({
     size = 0.8,
   },
 }) => {
+  const systemConfig = useSystemConfig();
+  const matchaRef = systemConfig.brand.displayName;
   const matchaBaseUrl = "https://matcha.xyz/trade";
   const [url, setUrl] = React.useState("");
 
-  const buildMatchaUrl = () => {
+  const buildMatchaUrl = React.useCallback(() => {
     const params = new URLSearchParams();
     if (defaultSellToken) params.append("sellAddress", defaultSellToken);
     if (defaultBuyToken) params.append("buyAddress", defaultBuyToken);
@@ -146,20 +149,13 @@ const Swap: React.FC<FidgetArgs<MatchaFidgetSettings>> = ({
     }
     if (optionalFeeRecipient)
       params.append("feeRecipient", optionalFeeRecipient);
-    const matchaRef = process.env.NEXT_PUBLIC_MATCHA_REF || "nounspace";
     params.append("ref", matchaRef);
     return `${matchaBaseUrl}?${params.toString()}`;
-  };
+  }, [defaultSellToken, defaultBuyToken, fromChain, toChain, optionalFeeRecipient, matchaRef]);
 
   React.useEffect(() => {
     setUrl(buildMatchaUrl());
-  }, [
-    defaultSellToken,
-    defaultBuyToken,
-    fromChain,
-    toChain,
-    optionalFeeRecipient,
-  ]);
+  }, [buildMatchaUrl]);
 
   const scaleValue = size;
 


### PR DESCRIPTION
## Summary
- Adds `ref` query parameter to Matcha trade URLs for referral tracking
- Creates `SystemConfigProvider` to expose community config to client components
- Swap fidget dynamically uses `brand.displayName` from the community config as the ref value
- Updates `getMatchaUrl` helper to accept optional ref parameter (defaults to "nounspace")

## Changes
- **New:** `src/common/providers/SystemConfigProvider.tsx` - React context provider with `useSystemConfig` hook
- **Updated:** `src/common/providers/index.tsx` - Wraps app with SystemConfigProvider
- **Updated:** `src/app/layout.tsx` - Passes systemConfig to Providers
- **Updated:** `src/fidgets/swap/Swap.tsx` - Uses `useSystemConfig()` to get brand.displayName for ref
- **Updated:** `src/common/lib/utils/links.ts` - `getMatchaUrl` accepts optional ref parameter

## Why this approach?
The system supports multiple communities per deployment via domain-based resolution. A static environment variable would not work since different domains serve different community configs. The SystemConfigProvider makes server-loaded config available to client components in an idiomatic React/Next.js way.

## Test plan
- [ ] Verify Swap fidget iframe URL includes `ref=[communityDisplayName]` parameter
- [ ] Test on different community domains to confirm ref changes per community
- [ ] Verify `getMatchaUrl` helper works with and without ref parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)