### PR TITLE
Add BuilderScore and Top8 fidgets to initial profile space

### DIFF
--- a/src/config/nouns/initialSpaces/initialProfileSpace.ts
+++ b/src/config/nouns/initialSpaces/initialProfileSpace.ts
@@ -40,25 +40,47 @@ const createInitialProfileSpaceConfigForFid = (
       fidgetType: "Portfolio",
       id: "Portfolio:cd627e89-d661-4255-8c4c-2242a950e93e",
     },
+    "BuilderScore:profile": {
+      config: {
+        editable: false,
+        settings: {
+          fid: String(fid),
+        },
+        data: {},
+      },
+      fidgetType: "BuilderScore",
+      id: "BuilderScore:profile",
+    },
+    "Top8:profile": {
+      config: {
+        editable: false,
+        settings: {
+          username: username ?? "",
+        },
+        data: {},
+      },
+      fidgetType: "Top8",
+      id: "Top8:profile",
+    },
   };
   const layoutItems = [
     {
-      w: 6,
+      w: 4,
       h: 8,
       x: 0,
       y: 0,
       i: "feed:profile",
       minW: 4,
       maxW: 36,
-      minH: 6,
+      minH: 2,
       maxH: 36,
       moved: false,
       static: false,
     },
     {
-      w: 6,
+      w: 4,
       h: 8,
-      x: 7,
+      x: 4,
       y: 0,
       i: "Portfolio:cd627e89-d661-4255-8c4c-2242a950e93e",
       minW: 3,
@@ -67,7 +89,33 @@ const createInitialProfileSpaceConfigForFid = (
       maxH: 36,
       moved: false,
       static: false,
-      }
+    },
+    {
+      w: 4,
+      h: 3,
+      x: 8,
+      y: 0,
+      i: "BuilderScore:profile",
+      minW: 3,
+      maxW: 36,
+      minH: 2,
+      maxH: 36,
+      moved: false,
+      static: false,
+    },
+    {
+      w: 4,
+      h: 5,
+      x: 8,
+      y: 3,
+      i: "Top8:profile",
+      minW: 4,
+      maxW: 36,
+      minH: 5,
+      maxH: 36,
+      moved: false,
+      static: false,
+    },
   ];
 
   // Set the layout configuration

--- a/src/fidgets/farcaster/Top8.tsx
+++ b/src/fidgets/farcaster/Top8.tsx
@@ -64,7 +64,7 @@ const Top8: React.FC<FidgetArgs<Top8FidgetSettings>> = ({
   } = settings;
 
   const trimmedUsername = username?.trim() || "nounspacetom";
-  const iframeUrl = `https://farcaster-top-8-frie-c060.bolt.host/${encodeURIComponent(trimmedUsername)}`;
+  const iframeUrl = `https://top8-pi.vercel.app/${encodeURIComponent(trimmedUsername)}`;
 
   return (
     <div


### PR DESCRIPTION
## Summary
- Add BuilderScore fidget with user's FID as setting to default profile space
- Add Top8 fidget with user's Farcaster username as setting to default profile space
- Update layout to 3-column grid (feed, portfolio, and stacked BuilderScore/Top8)

<img width="3340" height="1808" alt="image" src="https://github.com/user-attachments/assets/98655e69-692e-4742-bfff-3442fda7d053" />


## Test plan
- [ ] Verify new Farcaster users see BuilderScore and Top8 fidgets on their initial profile
- [ ] Confirm BuilderScore displays correctly with user's FID
- [ ] Confirm Top8 displays correctly with user's username
- [ ] Verify layout renders properly with all 4 fidgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new profile widgets: BuilderScore and Top8, available on user profiles with custom configuration options.

* **Style**
  * Reorganized profile layout: adjusted widget sizes, positions and height constraints to accommodate the new widgets.

* **Bug Fixes**
  * Top8 widget now loads from an updated host to improve embed reliability and loading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->