### PR TITLE
Fix: Require user to be logged in for navigation edit button

### DIFF
--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -90,11 +90,15 @@ const Navigation = React.memo(
   const userTheme: UserTheme = useUserTheme();
   const uiColors = useUIColors({ systemConfig });
   
+  // Check if user is logged in
+  const isLoggedIn = getIsAccountReady();
+  
   // Check if user is admin (can edit navigation)
+  // Requires both: user must be logged in AND have admin identity public key
   const adminIdentityPublicKeys = systemConfig.adminIdentityPublicKeys || [];
-  const isNavigationEditable = currentUserIdentityPublicKey 
-    ? adminIdentityPublicKeys.includes(currentUserIdentityPublicKey)
-    : false;
+  const isNavigationEditable = isLoggedIn && 
+    currentUserIdentityPublicKey && 
+    adminIdentityPublicKeys.includes(currentUserIdentityPublicKey);
   
   // Use navigation hook for store access and handlers
   const {
@@ -281,7 +285,6 @@ const Navigation = React.memo(
     setShowCastDiscardPrompt(false);
   }, []);
   const { fid } = useFarcasterSigner("navigation");
-  const isLoggedIn = getIsAccountReady();
   const isInitializing = getIsInitializing();
   const { data } = useLoadFarcasterUser(fid);
   const user = useMemo(() => first(data?.users), [data]);


### PR DESCRIPTION
The edit button on the navigation panel was appearing regardless of whether the user was logged in. Now it only appears when:
- User is logged in (isLoggedIn)
- User has an identity public key
- User's identity public key is in the admin list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication and authorization checks for navigation editing to ensure only logged-in users with admin privileges can modify navigation settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->