### PR TITLE
fix: add missing commitAllSpaceChanges calls for initial space tabs

### DIFF
--- a/src/app/api/opengraph/route.ts
+++ b/src/app/api/opengraph/route.ts
@@ -153,13 +153,13 @@ export async function GET(request: NextRequest) {
       }
     };
 
-    let rawImage = getMetaContent("og:image") || 
+    const rawImage = getMetaContent("og:image") || 
                    getMetaContent("twitter:image") || 
                    null;
 
     let image = makeAbsoluteUrl(rawImage);
 
-    let rawVideo = getMetaContent("og:video") || 
+    const rawVideo = getMetaContent("og:video") || 
                    getMetaContent("twitter:player") || 
                    null;
 

--- a/src/common/data/stores/app/space/spaceStore.ts
+++ b/src/common/data/stores/app/space/spaceStore.ts
@@ -1008,6 +1008,10 @@ export const createSpaceStoreFunc = (
         "Profile",
         createInitialProfileSpaceConfigForFid(fid),
       );
+      
+      // Commit the staged tab to storage (required after staged commit pattern refactor)
+      await get().space.commitAllSpaceChanges(newSpaceId);
+      
       analytics.track(AnalyticsEvent.SPACE_REGISTERED, {
         type: "user",
         spaceId: newSpaceId,
@@ -1121,6 +1125,9 @@ export const createSpaceStoreFunc = (
         "Channel",
         createInitialChannelSpaceConfig(channelId),
       );
+      
+      // Commit the staged tab to storage (required after staged commit pattern refactor)
+      await get().space.commitAllSpaceChanges(newSpaceId);
 
       analytics.track(AnalyticsEvent.SPACE_REGISTERED, {
         type: "channel",
@@ -1277,6 +1284,9 @@ export const createSpaceStoreFunc = (
           initialConfig,
           network,
         );
+        
+        // Commit the staged tab to storage (required after staged commit pattern refactor)
+        await get().space.commitAllSpaceChanges(newSpaceId, network);
 
         analytics.track(AnalyticsEvent.SPACE_REGISTERED, {
         type: "token",
@@ -1376,8 +1386,12 @@ export const createSpaceStoreFunc = (
           initialConfig
         );
         console.log("[registerProposalSpace] Overview tab created successfully");
+        
+        // Commit the staged tab to storage (required after staged commit pattern refactor)
+        await get().space.commitAllSpaceChanges(newSpaceId);
+        console.log("[registerProposalSpace] Overview tab committed to storage");
       } catch (tabError) {
-        console.error("[registerProposalSpace] Tab creation failed:", tabError);
+        console.error("[registerProposalSpace] Tab creation/commit failed:", tabError);
         throw new Error(`Failed to create Overview tab: ${tabError instanceof Error ? tabError.message : String(tabError)}`);
       }
 

--- a/src/fidgets/zora/TradeModal.tsx
+++ b/src/fidgets/zora/TradeModal.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from "react";
 import { BsCoin } from "react-icons/bs";
-import { parseEther, formatEther } from "viem";
+import { parseEther } from "viem";
 import { useAccount, useWalletClient, usePublicClient } from "wagmi";
 import Modal from "@/common/components/molecules/Modal";
 import { useEthUsdPrice } from "@/fidgets/nouns-home/price";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1301,6 +1301,11 @@
   resolved "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz"
   integrity sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==
 
+"@hey-api/client-fetch@^0.8.3":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@hey-api/client-fetch/-/client-fetch-0.8.4.tgz#2dc2d368b4dd2137789f46adcae68ccd04ea2adb"
+  integrity sha512-SWtUjVEFIUdiJGR2NiuF0njsSrSdTe7WHWkp3BLH3DEl2bRhiflOnBo29NSDdrY90hjtTQiTQkBxUgGOF29Xzg==
+
 "@humanfs/core@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.1.tgz#17c55ca7d426733fe3c561906b8173c336b40a77"
@@ -7143,6 +7148,19 @@
     protobufjs "^7.0.0"
     rxjs "^7.8.0"
     undici "^5.8.1"
+
+"@zoralabs/coins-sdk@^0.3.0":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@zoralabs/coins-sdk/-/coins-sdk-0.3.3.tgz#7877dcbc4383c2b91d85c87c8022ded6fc25ff01"
+  integrity sha512-C6rHMgZnK5dfUs4/i6OCJhBzF6Uj4KsuYpfoIyFSvgj2iZbZ7SIICGhS0lKbLdxvb8xbSwv2Fn7Xnqylf/BuEg==
+  dependencies:
+    "@hey-api/client-fetch" "^0.8.3"
+    "@zoralabs/protocol-deployments" "^0.6.4"
+
+"@zoralabs/protocol-deployments@^0.6.4":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@zoralabs/protocol-deployments/-/protocol-deployments-0.6.5.tgz#4d04fa555b718b95b0865fee6290e4fdb6097ef9"
+  integrity sha512-4SrsNAQaCFvphV3lH8eAaM2yqKIitQcOnVTCLQPrcydVmtWPuP4H8RP4xJRL3i52oCDyiDhwFR8uLkzXaI3oIw==
 
 abi-wan-kanabi@^2.2.3:
   version "2.2.4"


### PR DESCRIPTION
After the staged commit pattern refactor (beae80d1), createSpaceTab only stages tabs in local state and requires commitAllSpaceChanges to persist them to storage. This was missing in all space registration functions, causing new spaces to be created without their initial tabs being saved.

Fixed in:
- registerSpaceFid (profile spaces)
- registerChannelSpace (channel spaces)
- registerSpaceContract (token spaces)
- registerProposalSpace (proposal spaces)

This ensures initial tabs are properly committed to Supabase Storage and tab order files are saved when spaces are first created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure staged space/tab changes are immediately persisted to storage for more reliable configuration saves.
  * Clarified error messaging to reflect combined failures during tab creation and commit.

* **Style / Refactor**
  * Enforced immutability for OpenGraph metadata variables.
  * Removed an unused import to clean up the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->