### PR TITLE
Swap matcha for uniswap on token spaces

### DIFF
--- a/src/config/nouns/initialSpaces/initialTokenSpace.ts
+++ b/src/config/nouns/initialSpaces/initialTokenSpace.ts
@@ -19,20 +19,19 @@ export const createInitialTokenSpaceConfigForAddress = (
   const config = deepClone(INITIAL_SPACE_CONFIG_EMPTY);
 
   config.fidgetInstanceDatums = {
-    "iframe:f9e0259a-4524-4b37-a261-9f3be26d4af1": {
+    "Uniswap:f9e0259a-4524-4b37-a261-9f3be26d4af1": {
       config: {
         data: {},
         editable: true,
         settings: {
-          url: `https://app.uniswap.org/swap?chain=${network}&inputCurrency=NATIVE&outputCurrency=${address}`,
+          inputCurrency: "NATIVE",
+          outputCurrency: address,
+          chain: getNetworkWithId(network),
           size: 0.8,
-          cropOffsetX: 0,
-          cropOffsetY: 0,
-          isScrollable: true,
         },
       },
-      fidgetType: "iframe",
-      id: "iframe:f9e0259a-4524-4b37-a261-9f3be26d4af1",
+      fidgetType: "Uniswap",
+      id: "Uniswap:f9e0259a-4524-4b37-a261-9f3be26d4af1",
     },
     ...(isClankerToken &&
       castHash &&
@@ -196,7 +195,7 @@ export const createInitialTokenSpaceConfigForAddress = (
           },
           {
             h: 5,
-            i: "iframe:f9e0259a-4524-4b37-a261-9f3be26d4af1",
+            i: "Uniswap:f9e0259a-4524-4b37-a261-9f3be26d4af1",
             maxH: 36,
             maxW: 36,
             minH: 3,
@@ -310,7 +309,7 @@ export const createInitialTokenSpaceConfigForAddress = (
           },
           {
             h: 5,
-            i: "iframe:f9e0259a-4524-4b37-a261-9f3be26d4af1",
+            i: "Uniswap:f9e0259a-4524-4b37-a261-9f3be26d4af1",
             maxH: 36,
             maxW: 36,
             minH: 3,

--- a/src/config/nouns/initialSpaces/initialTokenSpace.ts
+++ b/src/config/nouns/initialSpaces/initialTokenSpace.ts
@@ -19,20 +19,20 @@ export const createInitialTokenSpaceConfigForAddress = (
   const config = deepClone(INITIAL_SPACE_CONFIG_EMPTY);
 
   config.fidgetInstanceDatums = {
-    "Swap:f9e0259a-4524-4b37-a261-9f3be26d4af1": {
+    "iframe:f9e0259a-4524-4b37-a261-9f3be26d4af1": {
       config: {
         data: {},
         editable: true,
         settings: {
-          defaultBuyToken: address,
-          defaultSellToken: "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-          fromChain: getNetworkWithId(network),
-          toChain: getNetworkWithId(network),
+          url: `https://app.uniswap.org/swap?chain=${network}&inputCurrency=NATIVE&outputCurrency=${address}`,
           size: 0.8,
+          cropOffsetX: 0,
+          cropOffsetY: 0,
+          isScrollable: true,
         },
       },
-      fidgetType: "Swap",
-      id: "Swap:f9e0259a-4524-4b37-a261-9f3be26d4af1",
+      fidgetType: "iframe",
+      id: "iframe:f9e0259a-4524-4b37-a261-9f3be26d4af1",
     },
     ...(isClankerToken &&
       castHash &&
@@ -196,7 +196,7 @@ export const createInitialTokenSpaceConfigForAddress = (
           },
           {
             h: 5,
-            i: "Swap:f9e0259a-4524-4b37-a261-9f3be26d4af1",
+            i: "iframe:f9e0259a-4524-4b37-a261-9f3be26d4af1",
             maxH: 36,
             maxW: 36,
             minH: 3,
@@ -310,7 +310,7 @@ export const createInitialTokenSpaceConfigForAddress = (
           },
           {
             h: 5,
-            i: "Swap:f9e0259a-4524-4b37-a261-9f3be26d4af1",
+            i: "iframe:f9e0259a-4524-4b37-a261-9f3be26d4af1",
             maxH: 36,
             maxW: 36,
             minH: 3,

--- a/src/config/nouns/initialSpaces/initialTokenSpace.ts
+++ b/src/config/nouns/initialSpaces/initialTokenSpace.ts
@@ -27,7 +27,6 @@ export const createInitialTokenSpaceConfigForAddress = (
           inputCurrency: "NATIVE",
           outputCurrency: address,
           chain: getNetworkWithId(network),
-          size: 0.8,
         },
       },
       fidgetType: "Uniswap",

--- a/src/config/nouns/nouns.fidgets.ts
+++ b/src/config/nouns/nouns.fidgets.ts
@@ -13,6 +13,7 @@ export const nounsFidgets = {
     'profile',
     'snapshot',
     'swap',
+    'uniswap',
     'rss',
     'market',
     'portfolio',

--- a/src/fidgets/index.ts
+++ b/src/fidgets/index.ts
@@ -15,6 +15,7 @@ import Top8 from "./farcaster/Top8";
 import Links from "./ui/Links";
 import snapShot from "./snapshot/SnapShot";
 import Swap from "./swap/Swap";
+import UniswapSwap from "./uniswap/UniswapSwap";
 import rss from "./ui/rss";
 import VideoFidget from "./ui/Video";
 import marketData from "./token/marketData";
@@ -56,6 +57,7 @@ export const CompleteFidgets = {
   zoraCoins: ZoraCoins,
   SnapShot: snapShot,
   Swap: Swap,
+  Uniswap: UniswapSwap,
   Rss: rss,
   Luma: Luma,
   Video: VideoFidget,

--- a/src/fidgets/uniswap/UniswapSwap.tsx
+++ b/src/fidgets/uniswap/UniswapSwap.tsx
@@ -100,6 +100,7 @@ const UniswapSwap: React.FC<FidgetArgs<UniswapFidgetSettings>> = ({
   },
 }) => {
   const uniswapBaseUrl = "https://app.uniswap.org/swap";
+  const uniswapOrigin = new URL(uniswapBaseUrl).origin;
   const [url, setUrl] = React.useState("");
 
   const buildUniswapUrl = () => {
@@ -120,7 +121,7 @@ const UniswapSwap: React.FC<FidgetArgs<UniswapFidgetSettings>> = ({
     setUrl(buildUniswapUrl());
   }, [inputCurrency, outputCurrency, chain]);
 
-  const scaleValue = size;
+  const scaleValue = Number.isFinite(size) && size > 0 ? size : 1;
 
   React.useEffect(() => {
     let currentScrollY = window.scrollY;
@@ -133,8 +134,17 @@ const UniswapSwap: React.FC<FidgetArgs<UniswapFidgetSettings>> = ({
     };
 
     const handleMessage = (event: MessageEvent) => {
-      if (event.data.action === "connectWallet") {
+      if (event.origin !== uniswapOrigin) {
+        return;
+      }
+
+      if (event.data?.action === "connectWallet") {
         preventScroll = true;
+        currentScrollY = window.scrollY;
+      }
+
+      if (event.data?.action === "unlock") {
+        preventScroll = false;
         currentScrollY = window.scrollY;
       }
     };
@@ -143,6 +153,7 @@ const UniswapSwap: React.FC<FidgetArgs<UniswapFidgetSettings>> = ({
     window.addEventListener("message", handleMessage);
 
     return () => {
+      preventScroll = false;
       window.removeEventListener("scroll", handleScroll);
       window.removeEventListener("message", handleMessage);
     };

--- a/src/fidgets/uniswap/UniswapSwap.tsx
+++ b/src/fidgets/uniswap/UniswapSwap.tsx
@@ -1,0 +1,180 @@
+import React from "react";
+import ChainSelector from "@/common/components/molecules/ChainSelector";
+import IFrameWidthSlider from "@/common/components/molecules/IframeScaleSlider";
+import TextInput from "@/common/components/molecules/TextInput";
+import {
+  FidgetArgs,
+  FidgetModule,
+  FidgetProperties,
+  type FidgetSettingsStyle,
+} from "@/common/fidgets";
+import { BsArrowLeftRight } from "react-icons/bs";
+import { mobileStyleSettings, WithMargin } from "../helpers";
+import ShadowSelector from "@/common/components/molecules/ShadowSelector";
+
+type UniswapFidgetSettings = {
+  inputCurrency: string;
+  outputCurrency: string;
+  chain: { id: string; name: string } | null;
+  size: number;
+} & FidgetSettingsStyle;
+
+const uniswapProperties: FidgetProperties = {
+  fidgetName: "Uniswap",
+  icon: 0x1f984, // Unicorn emoji
+  mobileIcon: <BsArrowLeftRight size={22} />,
+  fields: [
+    ...mobileStyleSettings,
+    {
+      fieldName: "inputCurrency",
+      displayName: "Input Currency",
+      displayNameHint: "Enter 'NATIVE' for the native token (ETH) or a token contract address",
+      default: "NATIVE",
+      required: true,
+      inputSelector: (props) => (
+        <WithMargin>
+          <TextInput {...props} />
+        </WithMargin>
+      ),
+      group: "settings",
+    },
+    {
+      fieldName: "outputCurrency",
+      displayName: "Output Currency",
+      displayNameHint: "Enter the token contract address you want to swap to",
+      default: "",
+      required: false,
+      inputSelector: (props) => (
+        <WithMargin>
+          <TextInput {...props} />
+        </WithMargin>
+      ),
+      group: "settings",
+    },
+    {
+      fieldName: "chain",
+      displayName: "Chain",
+      default: { id: "8453", name: "base" },
+      required: false,
+      inputSelector: (props) => (
+        <WithMargin>
+          <ChainSelector {...props} />
+        </WithMargin>
+      ),
+      group: "settings",
+    },
+    {
+      fieldName: "fidgetShadow",
+      displayName: "Fidget Shadow",
+      displayNameHint: "Shadow for the Fidget. Set to Theme Shadow to inherit the Fidget Shadow Settings from the Theme. Set to None to remove the shadow.",
+      default: "var(--user-theme-fidget-shadow)",
+      required: false,
+      inputSelector: (props) => (
+        <WithMargin>
+          <ShadowSelector {...props} hideGlobalSettings={false} />
+        </WithMargin>
+      ),
+      group: "style",
+    },
+    {
+      fieldName: "size",
+      required: false,
+      inputSelector: IFrameWidthSlider,
+      group: "style",
+    },
+  ],
+  size: {
+    minHeight: 3,
+    maxHeight: 36,
+    minWidth: 2,
+    maxWidth: 36,
+  },
+};
+
+const UniswapSwap: React.FC<FidgetArgs<UniswapFidgetSettings>> = ({
+  settings: {
+    inputCurrency = "NATIVE",
+    outputCurrency,
+    chain = { id: "8453", name: "base" },
+    size = 0.8,
+  },
+}) => {
+  const uniswapBaseUrl = "https://app.uniswap.org/swap";
+  const [url, setUrl] = React.useState("");
+
+  const buildUniswapUrl = () => {
+    const params = new URLSearchParams();
+    if (chain && chain.name) {
+      params.append("chain", chain.name.toLowerCase());
+    }
+    if (inputCurrency) {
+      params.append("inputCurrency", inputCurrency);
+    }
+    if (outputCurrency) {
+      params.append("outputCurrency", outputCurrency);
+    }
+    return `${uniswapBaseUrl}?${params.toString()}`;
+  };
+
+  React.useEffect(() => {
+    setUrl(buildUniswapUrl());
+  }, [inputCurrency, outputCurrency, chain]);
+
+  const scaleValue = size;
+
+  React.useEffect(() => {
+    let currentScrollY = window.scrollY;
+    let preventScroll = false;
+
+    const handleScroll = () => {
+      if (preventScroll && window.scrollY !== currentScrollY) {
+        window.scrollTo(0, currentScrollY);
+      }
+    };
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data.action === "connectWallet") {
+        preventScroll = true;
+        currentScrollY = window.scrollY;
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    window.addEventListener("message", handleMessage);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("message", handleMessage);
+    };
+  }, []);
+
+  if (!url || url.trim() === "") {
+    return (
+      <div className="h-[calc(100dvh-220px)] md:h-full flex items-center justify-center">
+        <p className="text-muted-foreground">Loading Uniswap...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ overflow: "hidden", width: "100%" }} className="h-[calc(100dvh-220px)] md:h-full">
+      <iframe
+        src={url}
+        sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+        style={{
+          transform: `scale(${scaleValue})`,
+          transformOrigin: "0 0",
+          width: `${100 / scaleValue}%`,
+          height: `${100 / scaleValue}%`,
+          overflow: "hidden",
+        }}
+        className="size-full"
+      />
+    </div>
+  );
+};
+
+export default {
+  fidget: UniswapSwap,
+  properties: uniswapProperties,
+} as FidgetModule<FidgetArgs<UniswapFidgetSettings>>;

--- a/src/fidgets/uniswap/UniswapSwap.tsx
+++ b/src/fidgets/uniswap/UniswapSwap.tsx
@@ -96,7 +96,7 @@ const UniswapSwap: React.FC<FidgetArgs<UniswapFidgetSettings>> = ({
     inputCurrency = "NATIVE",
     outputCurrency,
     chain = { id: "8453", name: "base" },
-    size = 0.8,
+    size = 1,
   },
 }) => {
   const uniswapBaseUrl = "https://app.uniswap.org/swap";


### PR DESCRIPTION
Currently matcha's app only allows a select few websites to embed them, including nounspace.com

As a result, the swap fidget fails to load on clanker.space and will fail to load on other space systems as well unless matcha whitelists each domain OR allows any domain to embed them.

I reached out to matcha on farcaster to see if they'd be willing to whitelist clanker.space or allow all domains to embed them.

If their answer is no (or until we hear yes from them), this replaces the matcha swap fidget used on initial token spaces with a uniswap swap fidget, which I confirmed works well.

<img width="1656" height="886" alt="image" src="https://github.com/user-attachments/assets/8ecbcf74-38cf-42fc-bf65-5f1765508ff3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uniswap swap widget available for direct token swaps: choose input/output currencies, select network, adjust widget size, and connect wallet to trade.
* **Updates**
  * Default spaces and layouts now include the Uniswap widget (replacing the previous swap entry).
* **Behavior**
  * Improved loading state and scroll-prevention during wallet connect for a smoother in-widget experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->