### PR TITLE
Fix Uniswap fidget scale validation and message handling

### DIFF
--- a/src/fidgets/uniswap/UniswapSwap.tsx
+++ b/src/fidgets/uniswap/UniswapSwap.tsx
@@ -100,6 +100,7 @@ const UniswapSwap: React.FC<FidgetArgs<UniswapFidgetSettings>> = ({
   },
 }) => {
   const uniswapBaseUrl = "https://app.uniswap.org/swap";
+  const uniswapOrigin = new URL(uniswapBaseUrl).origin;
   const [url, setUrl] = React.useState("");
 
   const buildUniswapUrl = () => {
@@ -120,7 +121,7 @@ const UniswapSwap: React.FC<FidgetArgs<UniswapFidgetSettings>> = ({
     setUrl(buildUniswapUrl());
   }, [inputCurrency, outputCurrency, chain]);
 
-  const scaleValue = size;
+  const scaleValue = Number.isFinite(size) && size > 0 ? size : 1;
 
   React.useEffect(() => {
     let currentScrollY = window.scrollY;
@@ -133,8 +134,17 @@ const UniswapSwap: React.FC<FidgetArgs<UniswapFidgetSettings>> = ({
     };
 
     const handleMessage = (event: MessageEvent) => {
-      if (event.data.action === "connectWallet") {
+      if (event.origin !== uniswapOrigin) {
+        return;
+      }
+
+      if (event.data?.action === "connectWallet") {
         preventScroll = true;
+        currentScrollY = window.scrollY;
+      }
+
+      if (event.data?.action === "unlock") {
+        preventScroll = false;
         currentScrollY = window.scrollY;
       }
     };
@@ -143,6 +153,7 @@ const UniswapSwap: React.FC<FidgetArgs<UniswapFidgetSettings>> = ({
     window.addEventListener("message", handleMessage);
 
     return () => {
+      preventScroll = false;
       window.removeEventListener("scroll", handleScroll);
       window.removeEventListener("message", handleMessage);
     };


### PR DESCRIPTION
### Motivation
- Prevent unsafe iframe sizing when `size` is zero/NaN and avoid division-by-zero in downstream style calculations.
- Restrict postMessage handling to the Uniswap iframe origin and ensure scroll-locking set during wallet connect is properly released.

### Description
- Added `uniswapOrigin` derived from the Uniswap base URL and validated `event.origin` before processing messages.
- Replaced `const scaleValue = size` with a guarded `const scaleValue = Number.isFinite(size) && size > 0 ? size : 1` to ensure a finite non-zero scale.
- Updated `handleMessage` to use optional chaining, handle `connectWallet` to enable scroll prevention and `unlock` to disable it, and updated cleanup to reset `preventScroll` on unmount.

### Testing
- No automated tests were run as part of this change (no CI/lint/type checks executed in the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972a586e134832593f662a18371d4c7)