### PR TITLE
Use UI font name instead of stylesheet URL and resolve to supported font families

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,40 +7,10 @@ import { loadSystemConfig, SystemConfig } from "@/config";
 import ClientMobileHeaderWrapper from "@/common/components/organisms/ClientMobileHeaderWrapper";
 import ClientSidebarWrapper from "@/common/components/organisms/ClientSidebarWrapper";
 import type { Metadata } from 'next' // Migrating next/head
-import { extractFontFamilyFromUrl } from "@/common/lib/utils/fontUtils";
 import { resolveBaseUrl } from "@/common/lib/utils/resolveBaseUrl";
 import { resolveAssetUrl } from "@/common/lib/utils/resolveAssetUrl";
 import { buildMiniAppEmbed } from "@/common/lib/utils/miniAppEmbed";
 import { resolveMiniAppDomain } from "@/common/lib/utils/miniAppDomain";
-
-const TRUSTED_STYLESHEET_HOSTS = new Set(["fonts.googleapis.com"]);
-
-function validateStylesheetUrl(stylesheetUrl?: string | null): string | null {
-  if (!stylesheetUrl) {
-    return null;
-  }
-
-  try {
-    const parsedUrl = new URL(stylesheetUrl);
-    if (parsedUrl.protocol !== "https:") {
-      console.warn("Rejected non-https UI stylesheet URL", { stylesheetUrl });
-      return null;
-    }
-
-    if (!TRUSTED_STYLESHEET_HOSTS.has(parsedUrl.hostname)) {
-      console.warn("Rejected untrusted UI stylesheet URL", {
-        stylesheetUrl,
-        hostname: parsedUrl.hostname,
-      });
-      return null;
-    }
-
-    return parsedUrl.toString();
-  } catch (error) {
-    console.warn("Failed to parse UI stylesheet URL", { stylesheetUrl, error });
-    return null;
-  }
-}
 
 // Force dynamic rendering so metadata is generated at request time (not build time)
 // This ensures metadata matches the actual domain/community config at runtime
@@ -140,12 +110,9 @@ export default async function RootLayout({
   children: React.ReactNode;
 }) {
   const systemConfig = await loadSystemConfig();
-  const validatedUiStylesheet = validateStylesheetUrl(systemConfig.ui?.url);
-  const navFontFamily = extractFontFamilyFromUrl(validatedUiStylesheet ?? undefined);
-  const navFontStack =
-    navFontFamily
-      ? `${navFontFamily}, var(--font-sans, Inter, system-ui, -apple-system, sans-serif)`
-      : "var(--font-sans, Inter, system-ui, -apple-system, sans-serif)";
+  const navFontStack = systemConfig.ui?.font
+    ? `${systemConfig.ui.font}, var(--font-sans, Inter, system-ui, -apple-system, sans-serif)`
+    : "var(--font-sans, Inter, system-ui, -apple-system, sans-serif)";
   const navFontColor = systemConfig.ui?.fontColor || "#0f172a";
   const castButtonFontColor =
     systemConfig.ui?.castButton?.fontColor ||
@@ -167,11 +134,7 @@ export default async function RootLayout({
   
   return (
     <html lang="en" suppressHydrationWarning>
-      <head>
-        {validatedUiStylesheet && (
-          <link rel="stylesheet" href={validatedUiStylesheet} />
-        )}
-      </head>
+      <head />
       <body
         style={
           {

--- a/src/common/lib/hooks/useUIColors.ts
+++ b/src/common/lib/hooks/useUIColors.ts
@@ -1,6 +1,6 @@
 import { SystemConfig } from "@/config";
 import { useMemo } from "react";
-import { extractFontFamilyFromUrl } from "../utils/fontUtils";
+import { resolveUiFontFamily } from "../utils/fontUtils";
 
 type UseUIColorsProps = {
   systemConfig?: SystemConfig;
@@ -39,7 +39,7 @@ export const useUIColors = ({ systemConfig }: UseUIColorsProps = {}) => {
         styles.getPropertyValue("--ns-background-color")?.trim() || undefined;
     }
 
-    const parsedFontFamily = extractFontFamilyFromUrl(ui?.url);
+    const resolvedFontFamily = resolveUiFontFamily(ui?.font);
     const castButton = {
       ...(ui?.castButton || {}),
       backgroundColor:
@@ -66,10 +66,9 @@ export const useUIColors = ({ systemConfig }: UseUIColorsProps = {}) => {
         ui?.castButtonFontColor ||
         cssCastButtonFontColor ||
         "#ffffff",
-      fontFamily: parsedFontFamily
-        ? `${parsedFontFamily}, var(--font-sans, sans-serif)`
+      fontFamily: resolvedFontFamily
+        ? `${resolvedFontFamily}, var(--font-sans, sans-serif)`
         : cssFontFamily || "var(--font-sans, Inter, system-ui, -apple-system, sans-serif)",
-      fontUrl: ui?.url,
       backgroundColor: ui?.backgroundColor || cssBackgroundColor || "#ffffff",
       primaryColor: ui?.primaryColor || "rgb(37, 99, 235)",
       primaryHoverColor: ui?.primaryHoverColor || "rgb(29, 78, 216)",

--- a/src/common/lib/utils/fontUtils.ts
+++ b/src/common/lib/utils/fontUtils.ts
@@ -1,11 +1,10 @@
-export function extractFontFamilyFromUrl(fontUrl?: string): string | undefined {
-  if (!fontUrl) return undefined;
+import type { FontFamily } from "@/common/lib/theme";
+import { FONT_FAMILY_OPTIONS_BY_NAME } from "@/common/lib/theme/fonts";
 
-  const familyParam = fontUrl.split("family=")[1];
-  if (!familyParam) return undefined;
+export function resolveUiFontFamily(fontName?: FontFamily): string | undefined {
+  if (!fontName) return undefined;
 
-  const family = decodeURIComponent(familyParam.split("&")[0]).replace(/\+/g, " ");
-  const familyName = family.split(":")[0];
-
-  return familyName || undefined;
+  return (
+    FONT_FAMILY_OPTIONS_BY_NAME[fontName]?.config?.style?.fontFamily ?? fontName
+  );
 }

--- a/src/config/systemConfig.ts
+++ b/src/config/systemConfig.ts
@@ -37,7 +37,7 @@ export interface SystemConfig {
 }
 
 export interface UIConfig {
-  url?: string;
+  font?: string;
   fontColor?: string;
   castButtonFontColor?: string;
   backgroundColor?: string;


### PR DESCRIPTION
### Motivation
- Community configs now provide a font name (e.g. `"Inter"`) instead of an external stylesheet `url`, so UI code must consume font names and map them to the app's supported font families.
- Remove legacy handling for loading and validating external Google Fonts stylesheets for UI fonts and instead use the app's built-in font registry.

### Description
- Replaced `ui.url` handling with `ui.font` in the SystemConfig `UIConfig` type (`src/config/systemConfig.ts`).
- Added `resolveUiFontFamily` to map a UI font name to a resolved CSS font-family using `FONT_FAMILY_OPTIONS_BY_NAME` (`src/common/lib/utils/fontUtils.ts`).
- Updated the `useUIColors` hook to use the resolved font family from `ui.font` and removed the legacy `fontUrl` output (`src/common/lib/hooks/useUIColors.ts`).
- Simplified root layout to use `systemConfig.ui.font` for the navigation font stack and removed stylesheet URL validation and link injection (`src/app/layout.tsx`).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972a7194de883259a166efbb2a9e677)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated font configuration to use direct font family values instead of URL-based stylesheet injection.
  * Removed stylesheet URL validation and trust-host checks for streamlined font handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->