### PR TITLE
Update Top 8 fidget URL

### DIFF
--- a/src/fidgets/farcaster/Top8.tsx
+++ b/src/fidgets/farcaster/Top8.tsx
@@ -64,7 +64,7 @@ const Top8: React.FC<FidgetArgs<Top8FidgetSettings>> = ({
   } = settings;
 
   const trimmedUsername = username?.trim() || "nounspacetom";
-  const iframeUrl = `https://farcaster-top-8-frie-c060.bolt.host/${encodeURIComponent(trimmedUsername)}`;
+  const iframeUrl = `https://top8-pi.vercel.app/${encodeURIComponent(trimmedUsername)}`;
 
   return (
     <div


### PR DESCRIPTION
### Motivation
- Replace outdated Top 8 iframe host with the new endpoint to ensure the fidget loads from `https://top8-pi.vercel.app/`.

### Description
- Updated the iframe source in `src/fidgets/farcaster/Top8.tsx` to use `https://top8-pi.vercel.app/${encodeURIComponent(trimmedUsername)}` instead of the previous bolt.host URL.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972afac049883258ac0a2af546245d2)