### PR TITLE
Update README to link to hosted documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,27 +7,14 @@ Forked from [herocast](https://github.com/hellno/herocast/) in April 2024.
 
 # Docs
 
-Full documentation is available in the [`docs/`](docs/) directory:
+📚 **[View Documentation](https://blankdotspace.github.io/space-system/)** - Full documentation site
 
-- **[Getting Started](docs/GETTING_STARTED.md)** - Quick start guide
-- **[Project Structure](docs/PROJECT_STRUCTURE.md)** - Codebase organization
-- **[Contributing](docs/CONTRIBUTING.MD)** - How to contribute
+Quick links:
+- [Getting Started](https://blankdotspace.github.io/space-system/docs/getting-started) - Local development setup
+- [Architecture](https://blankdotspace.github.io/space-system/docs/architecture/overview) - System design
+- [Contributing](https://blankdotspace.github.io/space-system/docs/contributing) - How to contribute
 
-### Architecture
-- [Overview](docs/ARCHITECTURE/OVERVIEW.md) - System architecture overview
-- [Authentication](docs/ARCHITECTURE/AUTHENTICATION.md) - Auth system design
-- [State Management](docs/ARCHITECTURE/STATE_MANAGEMENT.md) - Zustand stores
-
-### Systems
-- [Configuration](docs/SYSTEMS/CONFIGURATION/ARCHITECTURE_OVERVIEW.md) - Multi-tenant config system
-- [Spaces](docs/SYSTEMS/SPACES/OVERVIEW.md) - Space architecture (profile, token, channel, navPage)
-- [Fidgets](docs/SYSTEMS/FIDGETS/OVERVIEW.md) - Fidget system and registry
-- [Navigation](docs/SYSTEMS/NAVIGATION/OVERVIEW.md) - Navigation system
-- [Themes](docs/SYSTEMS/THEMES/OVERVIEW.md) - Theming system
-
-### Integrations
-- [Supabase](docs/INTEGRATIONS/SUPABASE.md) - Database schema and storage
-- [Farcaster](docs/INTEGRATIONS/FARCASTER.md) - Farcaster integration
+> Source files are in [`docs/`](docs/) and [`docs-site/`](docs-site/)
 
 ## What is Farcaster?
 a protocol for decentralized social apps: https://www.farcaster.xyz

--- a/docs-site/postcss.config.js
+++ b/docs-site/postcss.config.js
@@ -1,0 +1,7 @@
+// Override root postcss.config.js - Docusaurus doesn't need Tailwind
+module.exports = {
+  plugins: {
+    autoprefixer: {},
+  },
+};
+

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -1,6 +1,7 @@
+import React from 'react';
 import {Redirect} from '@docusaurus/router';
 
-export default function Home(): JSX.Element {
+export default function Home(): React.JSX.Element {
   // Redirect to the docs README which serves as the landing page
   return <Redirect to="/README" />;
 }


### PR DESCRIPTION
- Add prominent link to GitHub Pages docs site
- Simplify docs section with essential quick links
- Reference both docs/ source and docs-site/ for the Docusaurus site
- Fix React import in docs-site index page