### PR TITLE
Fix docs site redirect and README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Forked from [herocast](https://github.com/hellno/herocast/) in April 2024.
 
 # Docs
 
-📚 **[View Documentation](https://blankdotspace.github.io/space-system/)** - Full documentation site
+📚 **[View Full Documentation](https://blankdotspace.github.io/space-system/docs/)**
 
 Quick links:
-- [Getting Started](https://blankdotspace.github.io/space-system/docs/getting-started) - Local development setup
-- [Architecture](https://blankdotspace.github.io/space-system/docs/architecture/overview) - System design
-- [Contributing](https://blankdotspace.github.io/space-system/docs/contributing) - How to contribute
+- [Getting Started](docs/GETTING_STARTED.md) - Local development setup
+- [Architecture](docs/ARCHITECTURE/OVERVIEW.md) - System design
+- [Contributing](docs/CONTRIBUTING.MD) - How to contribute
 
-> Source files are in [`docs/`](docs/) and [`docs-site/`](docs-site/)
+> Documentation source: [`docs/`](docs/) • Docusaurus site: [`docs-site/`](docs-site/)
 
 ## What is Farcaster?
 a protocol for decentralized social apps: https://www.farcaster.xyz

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -2,6 +2,6 @@ import React from 'react';
 import {Redirect} from '@docusaurus/router';
 
 export default function Home(): React.JSX.Element {
-  // Redirect to the docs README which serves as the landing page
-  return <Redirect to="/README" />;
+  // Redirect to the docs landing page
+  return <Redirect to="/docs/" />;
 }


### PR DESCRIPTION
- Redirect landing page to /docs/ instead of /README
- Use local doc links in README (more reliable for GitHub viewing)
- Keep hosted docs link pointing to /docs/ path