### PR TITLE
Directory theming

### DIFF
--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {Redirect} from '@docusaurus/router';
 
 export default function Home(): JSX.Element {

--- a/src/fidgets/snapshot/components/ProposalItem.tsx
+++ b/src/fidgets/snapshot/components/ProposalItem.tsx
@@ -12,7 +12,7 @@ import {
   renderSingleChoiceVotingUI,
   renderWeightedVotingUI,
 } from "../utils/renderVotingUI";
-import { Action, initialState, reducer, State } from "../utils/stateManagement";
+import { initialState, reducer } from "../utils/stateManagement";
 import voteOnProposal, { ProposalType } from "../utils/voteOnProposal";
 
 import { resolveIpfsUrl } from "@/common/lib/utils/url";

--- a/src/fidgets/token/Directory/Directory.tsx
+++ b/src/fidgets/token/Directory/Directory.tsx
@@ -1058,6 +1058,7 @@ const Directory: React.FC<
             settings={settings}
             tokenSymbol={directoryData.tokenSymbol}
             headingTextStyle={headingTextStyle}
+            secondaryFontFamily={secondaryFontFamily}
             network={network}
             includeFilter={includeFilter}
             viewerFid={viewerFid}
@@ -1070,6 +1071,7 @@ const Directory: React.FC<
             tokenSymbol={directoryData.tokenSymbol}
             headingTextStyle={headingTextStyle}
             headingFontFamilyStyle={headingFontFamilyStyle}
+            secondaryFontFamily={secondaryFontFamily}
             network={network}
             includeFilter={includeFilter}
             viewerFid={viewerFid}

--- a/src/fidgets/token/Directory/components/DirectoryCardView.tsx
+++ b/src/fidgets/token/Directory/components/DirectoryCardView.tsx
@@ -157,6 +157,8 @@ export const DirectoryCardView: React.FC<DirectoryCardViewProps> = ({
                 viewerFid={viewerFid}
                 signer={signer}
                 className="pointer-events-auto px-3 py-1 text-xs font-semibold"
+                buttonColor={settings.buttonColor}
+                buttonFontColor={settings.buttonFontColor}
               />
             </div>
           </div>

--- a/src/fidgets/token/Directory/components/DirectoryCardView.tsx
+++ b/src/fidgets/token/Directory/components/DirectoryCardView.tsx
@@ -33,6 +33,7 @@ export type DirectoryCardViewProps = {
   tokenSymbol?: string | null;
   headingTextStyle: React.CSSProperties;
   headingFontFamilyStyle: React.CSSProperties;
+  secondaryFontFamily: string;
   network: DirectoryNetwork;
   includeFilter: DirectoryIncludeOption;
   viewerFid: number;
@@ -45,6 +46,7 @@ export const DirectoryCardView: React.FC<DirectoryCardViewProps> = ({
   tokenSymbol,
   headingTextStyle,
   headingFontFamilyStyle,
+  secondaryFontFamily,
   network,
   includeFilter,
   viewerFid,
@@ -159,6 +161,7 @@ export const DirectoryCardView: React.FC<DirectoryCardViewProps> = ({
                 className="pointer-events-auto px-3 py-1 text-xs font-semibold"
                 buttonColor={settings.buttonColor}
                 buttonFontColor={settings.buttonFontColor}
+                buttonFontFamily={secondaryFontFamily}
               />
             </div>
           </div>

--- a/src/fidgets/token/Directory/components/DirectoryFollowButton.tsx
+++ b/src/fidgets/token/Directory/components/DirectoryFollowButton.tsx
@@ -11,6 +11,7 @@ export type DirectoryFollowButtonProps = {
   className?: string;
   buttonColor?: string;
   buttonFontColor?: string;
+  buttonFontFamily?: string;
 };
 
 export const DirectoryFollowButton: React.FC<DirectoryFollowButtonProps> = ({
@@ -20,6 +21,7 @@ export const DirectoryFollowButton: React.FC<DirectoryFollowButtonProps> = ({
   className,
   buttonColor,
   buttonFontColor,
+  buttonFontFamily,
 }) => {
   const { setModalOpen, getIsAccountReady } = useAppStore((state) => ({
     setModalOpen: state.setup.setModalOpen,
@@ -93,12 +95,15 @@ export const DirectoryFollowButton: React.FC<DirectoryFollowButtonProps> = ({
       : "Follow";
 
   const customStyle: React.CSSProperties | undefined =
-    !isFollowing && (buttonColor || buttonFontColor)
+    !isFollowing && (buttonColor || buttonFontColor || buttonFontFamily)
       ? {
           ...(buttonColor ? { backgroundColor: buttonColor } : {}),
           ...(buttonFontColor ? { color: buttonFontColor } : {}),
+          ...(buttonFontFamily ? { fontFamily: buttonFontFamily } : {}),
         }
-      : undefined;
+      : buttonFontFamily
+        ? { fontFamily: buttonFontFamily }
+        : undefined;
 
   return (
     <Button

--- a/src/fidgets/token/Directory/components/DirectoryFollowButton.tsx
+++ b/src/fidgets/token/Directory/components/DirectoryFollowButton.tsx
@@ -9,6 +9,8 @@ export type DirectoryFollowButtonProps = {
   viewerFid: number;
   signer: Parameters<typeof followUser>[2] | undefined;
   className?: string;
+  buttonColor?: string;
+  buttonFontColor?: string;
 };
 
 export const DirectoryFollowButton: React.FC<DirectoryFollowButtonProps> = ({
@@ -16,6 +18,8 @@ export const DirectoryFollowButton: React.FC<DirectoryFollowButtonProps> = ({
   viewerFid,
   signer,
   className,
+  buttonColor,
+  buttonFontColor,
 }) => {
   const { setModalOpen, getIsAccountReady } = useAppStore((state) => ({
     setModalOpen: state.setup.setModalOpen,
@@ -88,6 +92,14 @@ export const DirectoryFollowButton: React.FC<DirectoryFollowButtonProps> = ({
         : "Following"
       : "Follow";
 
+  const customStyle: React.CSSProperties | undefined =
+    !isFollowing && (buttonColor || buttonFontColor)
+      ? {
+          ...(buttonColor ? { backgroundColor: buttonColor } : {}),
+          ...(buttonFontColor ? { color: buttonFontColor } : {}),
+        }
+      : undefined;
+
   return (
     <Button
       type="button"
@@ -98,6 +110,7 @@ export const DirectoryFollowButton: React.FC<DirectoryFollowButtonProps> = ({
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
       className={className}
+      style={customStyle}
     >
       {label}
     </Button>

--- a/src/fidgets/token/Directory/components/DirectoryListView.tsx
+++ b/src/fidgets/token/Directory/components/DirectoryListView.tsx
@@ -126,6 +126,8 @@ export const DirectoryListView: React.FC<DirectoryListViewProps> = ({
                 viewerFid={viewerFid}
                 signer={signer}
                 className="px-3 py-1 text-xs font-semibold"
+                buttonColor={settings.buttonColor}
+                buttonFontColor={settings.buttonFontColor}
               />
               <div className="flex flex-col items-end gap-1 text-right text-xs text-muted-foreground">
                 {(settings.source ?? "tokenHolders") === "tokenHolders" && (

--- a/src/fidgets/token/Directory/components/DirectoryListView.tsx
+++ b/src/fidgets/token/Directory/components/DirectoryListView.tsx
@@ -32,6 +32,7 @@ export type DirectoryListViewProps = {
   settings: DirectoryFidgetSettings;
   tokenSymbol?: string | null;
   headingTextStyle: React.CSSProperties;
+  secondaryFontFamily: string;
   network: DirectoryNetwork;
   includeFilter: DirectoryIncludeOption;
   viewerFid: number;
@@ -43,6 +44,7 @@ export const DirectoryListView: React.FC<DirectoryListViewProps> = ({
   settings,
   tokenSymbol,
   headingTextStyle,
+  secondaryFontFamily,
   network,
   includeFilter,
   viewerFid,
@@ -128,6 +130,7 @@ export const DirectoryListView: React.FC<DirectoryListViewProps> = ({
                 className="px-3 py-1 text-xs font-semibold"
                 buttonColor={settings.buttonColor}
                 buttonFontColor={settings.buttonFontColor}
+                buttonFontFamily={secondaryFontFamily}
               />
               <div className="flex flex-col items-end gap-1 text-right text-xs text-muted-foreground">
                 {(settings.source ?? "tokenHolders") === "tokenHolders" && (

--- a/src/fidgets/token/Directory/properties.tsx
+++ b/src/fidgets/token/Directory/properties.tsx
@@ -404,6 +404,42 @@ export const directoryProperties: FidgetProperties<DirectoryFidgetSettings> = {
       ),
       group: "style",
     },
+    {
+      fieldName: "buttonColor",
+      displayName: "Button Color",
+      displayNameHint: "Background color for the Follow button.",
+      default: "",
+      required: false,
+      inputSelector: (props) => (
+        <WithMargin>
+          <ThemeColorSelector
+            {...props}
+            themeVariable=""
+            defaultColor="#3b82f6"
+            colorType="background"
+          />
+        </WithMargin>
+      ),
+      group: "style",
+    },
+    {
+      fieldName: "buttonFontColor",
+      displayName: "Button Font Color",
+      displayNameHint: "Text color for the Follow button.",
+      default: "",
+      required: false,
+      inputSelector: (props) => (
+        <WithMargin>
+          <ThemeColorSelector
+            {...props}
+            themeVariable=""
+            defaultColor="#ffffff"
+            colorType="font color"
+          />
+        </WithMargin>
+      ),
+      group: "style",
+    },
     ...styleFields,
   ],
   size: {

--- a/src/fidgets/token/Directory/types.ts
+++ b/src/fidgets/token/Directory/types.ts
@@ -69,5 +69,7 @@ export type DirectoryFidgetSettings = FidgetSettings &
     primaryFontColor?: string;
     secondaryFontFamily?: string;
     secondaryFontColor?: string;
+    buttonColor?: string;
+    buttonFontColor?: string;
   };
 

--- a/supabase/functions/deploy-community-config/index.ts
+++ b/supabase/functions/deploy-community-config/index.ts
@@ -2161,7 +2161,6 @@ Deno.serve(async (req: Request) => {
     const communitySocial = isRecord(communityConfigObj.social)
       ? (communityConfigObj.social as JsonRecord)
       : {};
-    const website = getString(communityUrls.website);
     const discordUrl = getString(communityUrls.discord);
     const farcaster = getString(communitySocial.farcaster);
     const rawXHandle = getString(
@@ -2200,7 +2199,7 @@ Deno.serve(async (req: Request) => {
       const tabs: Array<{ name: string; config: JsonRecord }> = [];
       const tabOrder: string[] = [];
 
-      tabs.push({ name: "Home", config: buildHomeTabConfig(website, nowIso) });
+      tabs.push({ name: "Home", config: buildHomeTabConfig(existingWebsite, nowIso) });
       tabOrder.push("Home");
 
       if (farcaster) {

--- a/supabase/functions/deploy-community-config/index.ts
+++ b/supabase/functions/deploy-community-config/index.ts
@@ -1028,7 +1028,7 @@ function buildExploreTabConfig(
   // Merge UI styling into directory settings
   const enhancedSettings: JsonRecord = {
     ...settings,
-    ...(uiFont ? { primaryFontFamily: uiFont, secondaryFontFamily: uiFont } : {}),
+    ...(uiFont ? { primaryFontFamily: uiFont } : {}),
     ...(buttonColor ? { buttonColor } : {}),
     ...(buttonFontColor ? { buttonFontColor } : {}),
   };
@@ -2044,10 +2044,8 @@ Deno.serve(async (req: Request) => {
     const urls = isRecord(updatedCommunityConfig.urls)
       ? { ...updatedCommunityConfig.urls }
       : {};
-    const existingWebsite = getString(urls.website);
-    if (!existingWebsite) {
-      urls.website = `https://${resolvedCustomDomain || resolvedBlankSubdomain}`;
-    }
+    // Don't default urls.website to the space's own domain - if no website is provided,
+    // the home tab should be empty rather than embedding the space's domain in an iframe
     updatedCommunityConfig.urls = urls;
 
     if (resolvedCustomDomain) {
@@ -2161,6 +2159,7 @@ Deno.serve(async (req: Request) => {
     const communitySocial = isRecord(communityConfigObj.social)
       ? (communityConfigObj.social as JsonRecord)
       : {};
+    const website = getString(communityUrls.website);
     const discordUrl = getString(communityUrls.discord);
     const farcaster = getString(communitySocial.farcaster);
     const rawXHandle = getString(
@@ -2199,7 +2198,7 @@ Deno.serve(async (req: Request) => {
       const tabs: Array<{ name: string; config: JsonRecord }> = [];
       const tabOrder: string[] = [];
 
-      tabs.push({ name: "Home", config: buildHomeTabConfig(existingWebsite, nowIso) });
+      tabs.push({ name: "Home", config: buildHomeTabConfig(website, nowIso) });
       tabOrder.push("Home");
 
       if (farcaster) {

--- a/supabase/functions/deploy-community-config/index.ts
+++ b/supabase/functions/deploy-community-config/index.ts
@@ -1028,7 +1028,7 @@ function buildExploreTabConfig(
   // Merge UI styling into directory settings
   const enhancedSettings: JsonRecord = {
     ...settings,
-    ...(uiFont ? { primaryFontFamily: uiFont } : {}),
+    ...(uiFont ? { primaryFontFamily: uiFont, secondaryFontFamily: uiFont } : {}),
     ...(buttonColor ? { buttonColor } : {}),
     ...(buttonFontColor ? { buttonFontColor } : {}),
   };

--- a/supabase/functions/deploy-community-config/index.ts
+++ b/supabase/functions/deploy-community-config/index.ts
@@ -32,6 +32,7 @@ interface SignedFile {
 interface DeployRequest {
   walletAddress: string;
   communityId?: string;
+  signedTargetCommunityId?: string | null;
   walletSignature: string;
   nonce: string;
   timestamp: string;
@@ -1014,15 +1015,31 @@ function buildExploreTabConfig(
   settings: JsonRecord,
   timestamp: string,
   data: JsonRecord,
+  uiConfig?: JsonRecord,
 ): JsonRecord {
   const fidgetId = `Directory:${idSuffix}`;
+
+  // Extract UI styling from uiConfig
+  const uiFont = uiConfig ? getString(uiConfig.font) : null;
+  const castButton = uiConfig && isRecord(uiConfig.castButton) ? uiConfig.castButton : {};
+  const buttonColor = getString(castButton.backgroundColor);
+  const buttonFontColor = getString(castButton.fontColor);
+
+  // Merge UI styling into directory settings
+  const enhancedSettings: JsonRecord = {
+    ...settings,
+    ...(uiFont ? { primaryFontFamily: uiFont } : {}),
+    ...(buttonColor ? { buttonColor } : {}),
+    ...(buttonFontColor ? { buttonFontColor } : {}),
+  };
+
   return {
     fidgetInstanceDatums: {
       [fidgetId]: {
         config: {
           data,
           editable: false,
-          settings,
+          settings: enhancedSettings,
         },
         fidgetType: "Directory",
         id: fidgetId,
@@ -1612,6 +1629,7 @@ Deno.serve(async (req: Request) => {
     const {
       walletAddress,
       communityId,
+      signedTargetCommunityId,
       walletSignature,
       nonce,
       timestamp,
@@ -1684,13 +1702,16 @@ Deno.serve(async (req: Request) => {
     // Verify wallet signature cryptographically before any DB operations
     // The signature must be bound to the specific deploy payload (communityId + timestamp + nonce)
     // The target community ID should match what the client signed (blank subdomain, custom domain, or null for new)
-    const signedTargetCommunityId = blankSubdomain || communityId || customDomain || null;
+    // Use explicit undefined check so null remains a valid "new-community" target.
+    const verificationTarget = signedTargetCommunityId === undefined
+      ? blankSubdomain || communityId || customDomain || null
+      : signedTargetCommunityId;
     const signatureResult = await verifyWalletSignature(supabase, {
       walletAddress,
       signature: walletSignature,
       nonce,
       timestamp,
-      communityId: signedTargetCommunityId,
+      communityId: verificationTarget,
     });
 
     if (!signatureResult.valid) {
@@ -2356,9 +2377,17 @@ Deno.serve(async (req: Request) => {
         : candidate.baseName;
       const tabName = uniqueTabName(baseName, usedExploreTabNames);
       const idSuffix = slugify(tabName, candidate.idFallback);
+      const uiConfigRecord = isRecord(uiConfig) ? (uiConfig as JsonRecord) : undefined;
       exploreTabs.push({
         name: tabName,
-        config: buildExploreTabConfig(tabName, idSuffix, candidate.settings, nowIso, candidate.data),
+        config: buildExploreTabConfig(
+          tabName,
+          idSuffix,
+          candidate.settings,
+          nowIso,
+          candidate.data,
+          uiConfigRecord,
+        ),
       });
       exploreTabOrder.push(tabName);
     });


### PR DESCRIPTION
When a space system is deployed, pass theme settings from the community config into the directory fidgets generated on the Explore page (for communities with a token or farcaster channel)

<img width="1628" height="823" alt="image" src="https://github.com/user-attachments/assets/6f7c2073-0508-471a-b884-5d707808920a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added button styling customization options for directory components, including background color, text color, and font family settings.
  * Introduced UI configuration support for community deployments, enabling custom styling on a per-tab basis.

* **Refactor**
  * Updated internal imports for improved code organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->