### PR TITLE
Fix Farcaster FID linking by reverting authenticator key to nounspace

### DIFF
--- a/src/authenticators/farcaster/signers/index.ts
+++ b/src/authenticators/farcaster/signers/index.ts
@@ -52,5 +52,5 @@ export interface FarcasterSignerAuthenticatorMethods<
 }
 
 export default {
-  blankspace: BlankspaceFarcasterAuthenticator,
+  nounspace: BlankspaceFarcasterAuthenticator,
 };

--- a/src/constants/requiredAuthenticators.ts
+++ b/src/constants/requiredAuthenticators.ts
@@ -1,1 +1,1 @@
-export default ["farcaster:blankspace"];
+export default ["farcaster:nounspace"];

--- a/src/fidgets/farcaster/index.tsx
+++ b/src/fidgets/farcaster/index.tsx
@@ -7,12 +7,12 @@ import { indexOf } from "lodash";
 import { err, ok } from "neverthrow";
 import { useEffect, useState } from "react";
 
-export const FARCASTER_AUTHENTICATOR_NAME = "farcaster:blankspace";
+export const FARCASTER_AUTHENTICATOR_NAME = "farcaster:nounspace";
 
 const createFarcasterSignerFromAuthenticatorManager = async (
   authenticatorManager: AuthenticatorManager,
   fidgetId: string,
-  authenticatorName: string = "farcaster:blankspace",
+  authenticatorName: string = "farcaster:nounspace",
 ): Promise<Signer> => {
   const schemeResult = await authenticatorManager.callMethod({
     requestingFidgetId: fidgetId,
@@ -58,7 +58,7 @@ const createFarcasterSignerFromAuthenticatorManager = async (
 
 export function useFarcasterSigner(
   fidgetId: string,
-  authenticatorName: string = "farcaster:blankspace",
+  authenticatorName: string = "farcaster:nounspace",
 ) {
   const authenticatorManager = useAuthenticatorManager();
   const [isLoadingSigner, setIsLoadingSigner] = useState(true);


### PR DESCRIPTION
The rebranding changed the authenticator name from "farcaster:nounspace" to "farcaster:blankspace". This key is used to store and retrieve user's signer data, so existing users' data was no longer found, causing them to be prompted to re-link their FID.

Reverts the authenticator key while keeping other rebranding changes (file renames, type names) intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated the default Farcaster authenticator from blankspace to nounspace. This change affects which authenticator is used by default for Farcaster operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->