### PR TITLE
Fix directory fidget timeout errors

### DIFF
--- a/src/common/data/api/token/dependencies.ts
+++ b/src/common/data/api/token/dependencies.ts
@@ -1,39 +1,8 @@
-import type { Address } from "viem";
-import { mainnet } from "viem/chains";
-import { createConfig } from "wagmi";
-import {
-  getEnsName as wagmiGetEnsName,
-  getEnsAvatar as wagmiGetEnsAvatar,
-} from "wagmi/actions";
-import { http } from "@wagmi/core";
 import neynar from "@/common/data/api/neynar";
-import { ALCHEMY_API } from "@/constants/urls";
 import type { DirectoryDependencies } from "./types";
-
-let ensLookupConfig: ReturnType<typeof createConfig> | null = null;
-
-function getEnsLookupConfig() {
-  if (!ensLookupConfig) {
-    const apiKey = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY;
-    if (!apiKey) {
-      throw new Error("NEXT_PUBLIC_ALCHEMY_API_KEY is not configured");
-    }
-
-    ensLookupConfig = createConfig({
-      chains: [mainnet],
-      transports: {
-        [mainnet.id]: http(`${ALCHEMY_API("eth")}v2/${apiKey}`),
-      },
-    });
-  }
-
-  return ensLookupConfig;
-}
 
 export const defaultDependencies: DirectoryDependencies = {
   fetchFn: fetch,
   neynarClient: neynar,
-  getEnsNameFn: (address: Address) => wagmiGetEnsName(getEnsLookupConfig(), { address }),
-  getEnsAvatarFn: (name: string) => wagmiGetEnsAvatar(getEnsLookupConfig(), { name }),
 };
 

--- a/src/common/data/api/token/enrichEns.ts
+++ b/src/common/data/api/token/enrichEns.ts
@@ -83,7 +83,7 @@ export async function enrichWithEns(
         const ids = batch.map((addr) => `ethereum,${addr}`).join(",");
         const url = `https://api.web3.bio/profile/batch/${encodeURIComponent(ids)}`;
         const response = await deps.fetchFn(url, {
-          signal: AbortSignal.timeout(10000), // 10 second timeout per batch
+          signal: AbortSignal.timeout(5000), // 5 second timeout per batch
         });
         if (!response.ok) {
           return [];
@@ -160,7 +160,7 @@ export async function enrichWithEns(
             url.searchParams.append("addresses[]", addr);
           }
           const response = await deps.fetchFn(url.toString(), {
-            signal: AbortSignal.timeout(10000), // 10 second timeout per batch
+            signal: AbortSignal.timeout(5000), // 5 second timeout per batch
           });
           if (!response.ok) {
             return [];

--- a/src/common/data/api/token/enrichEns.ts
+++ b/src/common/data/api/token/enrichEns.ts
@@ -10,7 +10,7 @@ const ENSTATE_BATCH_SIZE = 50;
 /**
  * Extracts social handles from web3.bio links array
  */
-function extractWeb3BioSocials(links: Record<string, any> | undefined): {
+export function extractWeb3BioSocials(links: Record<string, any> | undefined): {
   twitterHandle: string | null;
   twitterUrl: string | null;
   githubHandle: string | null;

--- a/src/common/data/api/token/enrichEns.ts
+++ b/src/common/data/api/token/enrichEns.ts
@@ -2,15 +2,58 @@ import { chunk } from "lodash";
 import type { DirectoryDependencies, EnsMetadata, TokenHolder } from "./types";
 import { normalizeAddress, isAddress, extractOwnerAddress, parseSocialRecord } from "./utils";
 
+// web3.bio API supports max 30 addresses per batch
+const WEB3BIO_BATCH_SIZE = 30;
+// enstate.rs supports up to 50 addresses per batch (used as fallback)
 const ENSTATE_BATCH_SIZE = 50;
 
 /**
- * Fetches ENS metadata for a list of addresses using Enstate.rs bulk lookups.
- * Gracefully handles addresses without ENS names (returns null values).
+ * Extracts social handles from web3.bio links array
+ */
+function extractWeb3BioSocials(links: Record<string, any> | undefined): {
+  twitterHandle: string | null;
+  twitterUrl: string | null;
+  githubHandle: string | null;
+  githubUrl: string | null;
+} {
+  let twitterHandle: string | null = null;
+  let twitterUrl: string | null = null;
+  let githubHandle: string | null = null;
+  let githubUrl: string | null = null;
+
+  if (!links || typeof links !== "object") {
+    return { twitterHandle, twitterUrl, githubHandle, githubUrl };
+  }
+
+  // web3.bio returns links as an object with platform keys
+  const twitter = links.twitter || links.x;
+  if (twitter && typeof twitter === "object") {
+    const handle = twitter.handle || twitter.identity;
+    if (typeof handle === "string" && handle) {
+      twitterHandle = handle.replace(/^@/, "");
+      twitterUrl = twitter.link || `https://twitter.com/${twitterHandle}`;
+    }
+  }
+
+  const github = links.github;
+  if (github && typeof github === "object") {
+    const handle = github.handle || github.identity;
+    if (typeof handle === "string" && handle) {
+      githubHandle = handle.replace(/^@/, "");
+      githubUrl = github.link || `https://github.com/${githubHandle}`;
+    }
+  }
+
+  return { twitterHandle, twitterUrl, githubHandle, githubUrl };
+}
+
+/**
+ * Fetches profile metadata for token holders using web3.bio API (primary)
+ * with enstate.rs as fallback. Gracefully handles addresses without
+ * ENS names (returns null values).
  *
- * Note: We only use enstate.rs for ENS resolution to avoid timeouts.
- * Most token holders don't have ENS names, so additional fallback APIs
- * would just add latency without meaningful benefit.
+ * web3.bio returns richer data including social links and display names.
+ * See: https://api.web3.bio/#batch-query
  */
 export async function enrichWithEns(
   holders: TokenHolder[],
@@ -28,82 +71,159 @@ export async function enrichWithEns(
     return {};
   }
 
-  const enstateMetadata: Record<string, Partial<EnsMetadata>> = {};
+  const metadata: Record<string, Partial<EnsMetadata>> = {};
 
-  // Bulk lookup via Enstate.rs (parallel batches for speed)
+  // Primary: web3.bio batch API (parallel batches for speed)
   try {
-    const batches = chunk(uniqueAddresses, ENSTATE_BATCH_SIZE);
+    const batches = chunk(uniqueAddresses, WEB3BIO_BATCH_SIZE);
     const batchResults = await Promise.allSettled(
       batches.map(async (batch) => {
         if (batch.length === 0) return [];
-        const url = new URL("https://enstate.rs/bulk/a");
-        for (const addr of batch) {
-          url.searchParams.append("addresses[]", addr);
-        }
-        const response = await deps.fetchFn(url.toString(), {
+        // web3.bio expects format: ethereum,0xaddress
+        const ids = batch.map((addr) => `ethereum,${addr}`).join(",");
+        const url = `https://api.web3.bio/profile/batch/${encodeURIComponent(ids)}`;
+        const response = await deps.fetchFn(url, {
           signal: AbortSignal.timeout(10000), // 10 second timeout per batch
         });
         if (!response.ok) {
           return [];
         }
         const json = await response.json();
-        return Array.isArray(json?.response) ? json.response : [];
+        return Array.isArray(json) ? json : [];
       }),
     );
 
     for (const result of batchResults) {
       if (result.status !== "fulfilled") continue;
-      const records = result.value;
-      for (const record of records) {
-        const addr = normalizeAddress(record?.address || "");
+      const profiles = result.value;
+      for (const profile of profiles) {
+        // web3.bio returns address in the response
+        const addr = normalizeAddress(profile?.address || "");
         if (!addr) continue;
-        const partial = enstateMetadata[addr] ?? {};
-        if (!partial.ensName && typeof record?.name === "string") {
-          partial.ensName = record.name;
-        }
-        if (!partial.ensAvatarUrl && typeof record?.avatar === "string") {
-          partial.ensAvatarUrl = record.avatar;
-        }
-        if (!partial.primaryAddress && typeof record?.chains?.eth === "string") {
-          partial.primaryAddress = normalizeAddress(record.chains.eth);
-        }
-        const ensRecords = record?.records;
-        if (ensRecords && typeof ensRecords === "object") {
-          if (!partial.twitterHandle) {
-            const parsedTwitter = parseSocialRecord(
-              ensRecords["com.twitter"] ??
-                ensRecords["twitter"] ??
-                ensRecords["com.x"] ??
-                ensRecords["x"],
-              "twitter",
-            );
-            if (parsedTwitter) {
-              partial.twitterHandle = parsedTwitter.handle;
-              partial.twitterUrl = parsedTwitter.url;
-            }
+        const partial = metadata[addr] ?? {};
+
+        // ENS name from identity field (for ENS platform profiles)
+        if (!partial.ensName && typeof profile?.identity === "string") {
+          // Only use identity if it looks like an ENS name
+          if (profile.identity.endsWith(".eth") || profile.platform === "ens") {
+            partial.ensName = profile.identity;
           }
-          if (!partial.githubHandle) {
-            const parsedGithub = parseSocialRecord(
-              ensRecords["com.github"] ?? ensRecords["github"],
-              "github",
-            );
-            if (parsedGithub) {
-              partial.githubHandle = parsedGithub.handle;
-              partial.githubUrl = parsedGithub.url;
+        }
+        // Also check aliases for ENS names
+        if (!partial.ensName && Array.isArray(profile?.aliases)) {
+          for (const alias of profile.aliases) {
+            if (typeof alias === "string" && alias.endsWith(".eth")) {
+              partial.ensName = alias;
+              break;
             }
           }
         }
-        enstateMetadata[addr] = partial;
+
+        if (!partial.ensAvatarUrl && typeof profile?.avatar === "string") {
+          partial.ensAvatarUrl = profile.avatar;
+        }
+        if (!partial.primaryAddress && typeof profile?.address === "string") {
+          partial.primaryAddress = normalizeAddress(profile.address);
+        }
+
+        // Extract social links from web3.bio response
+        const socials = extractWeb3BioSocials(profile?.links);
+        if (!partial.twitterHandle && socials.twitterHandle) {
+          partial.twitterHandle = socials.twitterHandle;
+          partial.twitterUrl = socials.twitterUrl;
+        }
+        if (!partial.githubHandle && socials.githubHandle) {
+          partial.githubHandle = socials.githubHandle;
+          partial.githubUrl = socials.githubUrl;
+        }
+
+        metadata[addr] = partial;
       }
     }
   } catch (error) {
-    console.error("Failed to fetch ENS metadata from enstate.rs", error);
+    console.error("Failed to fetch profile metadata from web3.bio", error);
+  }
+
+  // Fallback: enstate.rs for addresses not resolved by web3.bio
+  const unresolvedAddresses = uniqueAddresses.filter(
+    (addr) => !metadata[addr]?.ensName,
+  );
+
+  if (unresolvedAddresses.length > 0) {
+    try {
+      const batches = chunk(unresolvedAddresses, ENSTATE_BATCH_SIZE);
+      const batchResults = await Promise.allSettled(
+        batches.map(async (batch) => {
+          if (batch.length === 0) return [];
+          const url = new URL("https://enstate.rs/bulk/a");
+          for (const addr of batch) {
+            url.searchParams.append("addresses[]", addr);
+          }
+          const response = await deps.fetchFn(url.toString(), {
+            signal: AbortSignal.timeout(10000), // 10 second timeout per batch
+          });
+          if (!response.ok) {
+            return [];
+          }
+          const json = await response.json();
+          return Array.isArray(json?.response) ? json.response : [];
+        }),
+      );
+
+      for (const result of batchResults) {
+        if (result.status !== "fulfilled") continue;
+        const records = result.value;
+        for (const record of records) {
+          const addr = normalizeAddress(record?.address || "");
+          if (!addr) continue;
+          const partial = metadata[addr] ?? {};
+          if (!partial.ensName && typeof record?.name === "string") {
+            partial.ensName = record.name;
+          }
+          if (!partial.ensAvatarUrl && typeof record?.avatar === "string") {
+            partial.ensAvatarUrl = record.avatar;
+          }
+          if (!partial.primaryAddress && typeof record?.chains?.eth === "string") {
+            partial.primaryAddress = normalizeAddress(record.chains.eth);
+          }
+          const ensRecords = record?.records;
+          if (ensRecords && typeof ensRecords === "object") {
+            if (!partial.twitterHandle) {
+              const parsedTwitter = parseSocialRecord(
+                ensRecords["com.twitter"] ??
+                  ensRecords["twitter"] ??
+                  ensRecords["com.x"] ??
+                  ensRecords["x"],
+                "twitter",
+              );
+              if (parsedTwitter) {
+                partial.twitterHandle = parsedTwitter.handle;
+                partial.twitterUrl = parsedTwitter.url;
+              }
+            }
+            if (!partial.githubHandle) {
+              const parsedGithub = parseSocialRecord(
+                ensRecords["com.github"] ?? ensRecords["github"],
+                "github",
+              );
+              if (parsedGithub) {
+                partial.githubHandle = parsedGithub.handle;
+                partial.githubUrl = parsedGithub.url;
+              }
+            }
+          }
+          metadata[addr] = partial;
+        }
+      }
+    } catch (error) {
+      console.error("Failed to fetch ENS metadata from enstate.rs (fallback)", error);
+    }
   }
 
   // Build final metadata entries for all addresses
   // Addresses without ENS data will have null values (graceful handling)
   const entries = uniqueAddresses.map((address) => {
-    const existing = enstateMetadata[address] ?? {};
+    const existing = metadata[address] ?? {};
     const ensName: string | null = existing.ensName ?? null;
     const ensAvatarUrl: string | null = existing.ensAvatarUrl ?? null;
     const twitterHandle: string | null = existing.twitterHandle ?? null;

--- a/src/common/data/api/token/enrichEns.ts
+++ b/src/common/data/api/token/enrichEns.ts
@@ -1,23 +1,19 @@
 import { chunk } from "lodash";
-import type { Address } from "viem";
 import type { DirectoryDependencies, EnsMetadata, TokenHolder } from "./types";
 import { normalizeAddress, isAddress, extractOwnerAddress, parseSocialRecord } from "./utils";
 
 const ENSTATE_BATCH_SIZE = 50;
+const ENSDATA_BATCH_SIZE = 50;
 
 /**
  * Fetches ENS metadata for a list of addresses
- * Uses Enstate.rs for bulk lookups, then wagmi for individual resolution
+ * Uses Enstate.rs for bulk lookups, with ensdata.net as fallback
+ * Gracefully handles addresses without ENS names (returns null values)
  */
 export async function enrichWithEns(
   holders: TokenHolder[],
   deps: DirectoryDependencies,
 ): Promise<Record<string, EnsMetadata>> {
-  const apiKey = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY;
-  if (!apiKey) {
-    return {};
-  }
-
   const addresses = holders
     .map((holder) => {
       const address = extractOwnerAddress(holder);
@@ -92,61 +88,111 @@ export async function enrichWithEns(
     console.error("Failed to fetch ENS social metadata", error);
   }
 
-  // Then, resolve individual addresses via wagmi (fallback/supplement)
-  const entries = await Promise.all(
-    uniqueAddresses.map(async (address) => {
-      const viemAddress = address as Address;
-      const existing = enstateMetadata[address] ?? {};
-      let ensName: string | null = existing.ensName ?? null;
-      let ensAvatarUrl: string | null = existing.ensAvatarUrl ?? null;
-      const twitterHandle: string | null = existing.twitterHandle ?? null;
-      const twitterUrl: string | null = existing.twitterUrl ?? null;
-      const githubHandle: string | null = existing.githubHandle ?? null;
-      const githubUrl: string | null = existing.githubUrl ?? null;
-      const primaryAddress: string | null = existing.primaryAddress
-        ? normalizeAddress(existing.primaryAddress)
-        : null;
-
-      try {
-        const resolvedName = await deps.getEnsNameFn(viemAddress);
-        if (resolvedName) {
-          ensName = ensName ?? resolvedName;
-        }
-        if (!ensAvatarUrl && ensName) {
-          try {
-            ensAvatarUrl = await deps.getEnsAvatarFn(ensName);
-          } catch (avatarError) {
-            console.error(
-              `Failed to resolve ENS avatar for ${ensName}`,
-              avatarError,
-            );
-          }
-        }
-      } catch (error) {
-        console.error(
-          `Failed to resolve ENS metadata for address ${address}`,
-          error,
-        );
-      }
-
-      return [
-        address,
-        {
-          ensName: ensName ?? null,
-          ensAvatarUrl: ensAvatarUrl ?? null,
-          twitterHandle: twitterHandle ?? null,
-          twitterUrl:
-            twitterUrl ??
-            (twitterHandle ? `https://twitter.com/${twitterHandle}` : null),
-          githubHandle: githubHandle ?? null,
-          githubUrl:
-            githubUrl ??
-            (githubHandle ? `https://github.com/${githubHandle}` : null),
-          primaryAddress,
-        },
-      ] as const;
-    }),
+  // Try ensdata.net as fallback for addresses not resolved by enstate.rs
+  const unresolvedAddresses = uniqueAddresses.filter(
+    (addr) => !enstateMetadata[addr]?.ensName,
   );
+
+  if (unresolvedAddresses.length > 0) {
+    try {
+      for (const batch of chunk(unresolvedAddresses, ENSDATA_BATCH_SIZE)) {
+        // ensdata.net supports individual lookups; fetch in parallel with concurrency limit
+        const results = await Promise.allSettled(
+          batch.map(async (addr) => {
+            try {
+              const response = await fetch(`https://ensdata.net/${addr}`, {
+                signal: AbortSignal.timeout(5000),
+              });
+              if (!response.ok) return null;
+              const data = await response.json();
+              return { address: addr, data };
+            } catch {
+              return null;
+            }
+          }),
+        );
+
+        for (const result of results) {
+          if (result.status !== "fulfilled" || !result.value) continue;
+          const { address: addr, data } = result.value;
+          if (!data || typeof data !== "object") continue;
+
+          const partial = enstateMetadata[addr] ?? {};
+          if (!partial.ensName && typeof data.ens === "string") {
+            partial.ensName = data.ens;
+          }
+          if (!partial.ensAvatarUrl && typeof data.avatar === "string") {
+            partial.ensAvatarUrl = data.avatar;
+          }
+          if (!partial.primaryAddress && typeof data.address === "string") {
+            partial.primaryAddress = normalizeAddress(data.address);
+          }
+          // ensdata.net may include records in different format
+          const records = data.records;
+          if (records && typeof records === "object") {
+            if (!partial.twitterHandle) {
+              const parsedTwitter = parseSocialRecord(
+                records["com.twitter"] ??
+                  records["twitter"] ??
+                  records["com.x"] ??
+                  records["x"],
+                "twitter",
+              );
+              if (parsedTwitter) {
+                partial.twitterHandle = parsedTwitter.handle;
+                partial.twitterUrl = parsedTwitter.url;
+              }
+            }
+            if (!partial.githubHandle) {
+              const parsedGithub = parseSocialRecord(
+                records["com.github"] ?? records["github"],
+                "github",
+              );
+              if (parsedGithub) {
+                partial.githubHandle = parsedGithub.handle;
+                partial.githubUrl = parsedGithub.url;
+              }
+            }
+          }
+          enstateMetadata[addr] = partial;
+        }
+      }
+    } catch (error) {
+      console.error("Failed to fetch ENS metadata from ensdata.net", error);
+    }
+  }
+
+  // Build final metadata entries for all addresses
+  // Addresses without ENS data will have null values (graceful handling)
+  const entries = uniqueAddresses.map((address) => {
+    const existing = enstateMetadata[address] ?? {};
+    const ensName: string | null = existing.ensName ?? null;
+    const ensAvatarUrl: string | null = existing.ensAvatarUrl ?? null;
+    const twitterHandle: string | null = existing.twitterHandle ?? null;
+    const twitterUrl: string | null = existing.twitterUrl ?? null;
+    const githubHandle: string | null = existing.githubHandle ?? null;
+    const githubUrl: string | null = existing.githubUrl ?? null;
+    const primaryAddress: string | null = existing.primaryAddress
+      ? normalizeAddress(existing.primaryAddress)
+      : null;
+
+    return [
+      address,
+      {
+        ensName,
+        ensAvatarUrl,
+        twitterHandle,
+        twitterUrl:
+          twitterUrl ??
+          (twitterHandle ? `https://twitter.com/${twitterHandle}` : null),
+        githubHandle,
+        githubUrl:
+          githubUrl ??
+          (githubHandle ? `https://github.com/${githubHandle}` : null),
+        primaryAddress,
+      },
+    ] as const;
+  });
 
   return Object.fromEntries(entries);
 }

--- a/src/common/data/api/token/types.ts
+++ b/src/common/data/api/token/types.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import type { Address } from "viem";
 import neynar from "@/common/data/api/neynar";
 
 // Query validation schema
@@ -100,8 +99,6 @@ export type DirectoryApiResponse = {
 export type DirectoryDependencies = {
   fetchFn: typeof fetch;
   neynarClient: typeof neynar;
-  getEnsNameFn: (address: Address) => Promise<string | null>;
-  getEnsAvatarFn: (name: string) => Promise<string | null>;
 };
 
 // Fetch result types

--- a/src/pages/api/token/directory.ts
+++ b/src/pages/api/token/directory.ts
@@ -7,6 +7,7 @@ import requestHandler, {
   type BlankspaceResponse,
 } from "@/common/data/api/requestHandler";
 import neynar from "@/common/data/api/neynar";
+import { extractWeb3BioSocials } from "@/common/data/api/token/enrichEns";
 import { fetchTokenData } from "@/common/lib/utils/fetchTokenData";
 import type { EtherScanChainName } from "@/constants/etherscanChainIds";
 import { ALCHEMY_API } from "@/constants/urls";
@@ -552,46 +553,6 @@ async function fetchMoralisTokenHolders(
 const WEB3BIO_BATCH_SIZE = 30;
 // enstate.rs supports up to 50 addresses per batch (used as fallback)
 const ENSTATE_BATCH_SIZE = 50;
-
-/**
- * Extracts social handles from web3.bio links array
- */
-function extractWeb3BioSocials(links: Record<string, any> | undefined): {
-  twitterHandle: string | null;
-  twitterUrl: string | null;
-  githubHandle: string | null;
-  githubUrl: string | null;
-} {
-  let twitterHandle: string | null = null;
-  let twitterUrl: string | null = null;
-  let githubHandle: string | null = null;
-  let githubUrl: string | null = null;
-
-  if (!links || typeof links !== "object") {
-    return { twitterHandle, twitterUrl, githubHandle, githubUrl };
-  }
-
-  // web3.bio returns links as an object with platform keys
-  const twitter = links.twitter || links.x;
-  if (twitter && typeof twitter === "object") {
-    const handle = twitter.handle || twitter.identity;
-    if (typeof handle === "string" && handle) {
-      twitterHandle = handle.replace(/^@/, "");
-      twitterUrl = twitter.link || `https://twitter.com/${twitterHandle}`;
-    }
-  }
-
-  const github = links.github;
-  if (github && typeof github === "object") {
-    const handle = github.handle || github.identity;
-    if (typeof handle === "string" && handle) {
-      githubHandle = handle.replace(/^@/, "");
-      githubUrl = github.link || `https://github.com/${githubHandle}`;
-    }
-  }
-
-  return { twitterHandle, twitterUrl, githubHandle, githubUrl };
-}
 
 /**
  * Fetches profile metadata for addresses using web3.bio API (primary)

--- a/src/pages/api/token/directory.ts
+++ b/src/pages/api/token/directory.ts
@@ -548,15 +548,58 @@ async function fetchMoralisTokenHolders(
   };
 }
 
+// web3.bio API supports max 30 addresses per batch
+const WEB3BIO_BATCH_SIZE = 30;
+// enstate.rs supports up to 50 addresses per batch (used as fallback)
 const ENSTATE_BATCH_SIZE = 50;
 
 /**
- * Fetches ENS metadata for a list of addresses using Enstate.rs bulk lookups.
- * Gracefully handles addresses without ENS names (returns null values).
+ * Extracts social handles from web3.bio links array
+ */
+function extractWeb3BioSocials(links: Record<string, any> | undefined): {
+  twitterHandle: string | null;
+  twitterUrl: string | null;
+  githubHandle: string | null;
+  githubUrl: string | null;
+} {
+  let twitterHandle: string | null = null;
+  let twitterUrl: string | null = null;
+  let githubHandle: string | null = null;
+  let githubUrl: string | null = null;
+
+  if (!links || typeof links !== "object") {
+    return { twitterHandle, twitterUrl, githubHandle, githubUrl };
+  }
+
+  // web3.bio returns links as an object with platform keys
+  const twitter = links.twitter || links.x;
+  if (twitter && typeof twitter === "object") {
+    const handle = twitter.handle || twitter.identity;
+    if (typeof handle === "string" && handle) {
+      twitterHandle = handle.replace(/^@/, "");
+      twitterUrl = twitter.link || `https://twitter.com/${twitterHandle}`;
+    }
+  }
+
+  const github = links.github;
+  if (github && typeof github === "object") {
+    const handle = github.handle || github.identity;
+    if (typeof handle === "string" && handle) {
+      githubHandle = handle.replace(/^@/, "");
+      githubUrl = github.link || `https://github.com/${githubHandle}`;
+    }
+  }
+
+  return { twitterHandle, twitterUrl, githubHandle, githubUrl };
+}
+
+/**
+ * Fetches profile metadata for addresses using web3.bio API (primary)
+ * with enstate.rs as fallback. Gracefully handles addresses without
+ * ENS names (returns null values).
  *
- * Note: We only use enstate.rs for ENS resolution to avoid timeouts.
- * Most token holders don't have ENS names, so additional fallback APIs
- * would just add latency without meaningful benefit.
+ * web3.bio returns richer data including social links and display names.
+ * See: https://api.web3.bio/#batch-query
  */
 async function fetchEnsMetadata(
   addresses: string[],
@@ -574,82 +617,159 @@ async function fetchEnsMetadata(
     return {};
   }
 
-  const enstateMetadata: Record<string, Partial<EnsMetadata>> = {};
+  const metadata: Record<string, Partial<EnsMetadata>> = {};
 
-  // Bulk lookup via Enstate.rs (parallel batches for speed)
+  // Primary: web3.bio batch API (parallel batches for speed)
   try {
-    const batches = chunk(uniqueAddresses, ENSTATE_BATCH_SIZE);
+    const batches = chunk(uniqueAddresses, WEB3BIO_BATCH_SIZE);
     const batchResults = await Promise.allSettled(
       batches.map(async (batch) => {
         if (batch.length === 0) return [];
-        const url = new URL("https://enstate.rs/bulk/a");
-        for (const addr of batch) {
-          url.searchParams.append("addresses[]", addr);
-        }
-        const response = await deps.fetchFn(url.toString(), {
+        // web3.bio expects format: ethereum,0xaddress
+        const ids = batch.map((addr) => `ethereum,${addr}`).join(",");
+        const url = `https://api.web3.bio/profile/batch/${encodeURIComponent(ids)}`;
+        const response = await deps.fetchFn(url, {
           signal: AbortSignal.timeout(10000), // 10 second timeout per batch
         });
         if (!response.ok) {
           return [];
         }
         const json = await response.json();
-        return Array.isArray(json?.response) ? json.response : [];
+        return Array.isArray(json) ? json : [];
       }),
     );
 
     for (const result of batchResults) {
       if (result.status !== "fulfilled") continue;
-      const records = result.value;
-      for (const record of records) {
-        const addr = normalizeAddress(record?.address || "");
+      const profiles = result.value;
+      for (const profile of profiles) {
+        // web3.bio returns address in the response
+        const addr = normalizeAddress(profile?.address || "");
         if (!addr) continue;
-        const partial = enstateMetadata[addr] ?? {};
-        if (!partial.ensName && typeof record?.name === "string") {
-          partial.ensName = record.name;
-        }
-        if (!partial.ensAvatarUrl && typeof record?.avatar === "string") {
-          partial.ensAvatarUrl = record.avatar;
-        }
-        if (!partial.primaryAddress && typeof record?.chains?.eth === "string") {
-          partial.primaryAddress = normalizeAddress(record.chains.eth);
-        }
-        const ensRecords = record?.records;
-        if (ensRecords && typeof ensRecords === "object") {
-          if (!partial.twitterHandle) {
-            const parsedTwitter = parseSocialRecord(
-              ensRecords["com.twitter"] ??
-                ensRecords["twitter"] ??
-                ensRecords["com.x"] ??
-                ensRecords["x"],
-              "twitter",
-            );
-            if (parsedTwitter) {
-              partial.twitterHandle = parsedTwitter.handle;
-              partial.twitterUrl = parsedTwitter.url;
-            }
+        const partial = metadata[addr] ?? {};
+
+        // ENS name from identity field (for ENS platform profiles)
+        if (!partial.ensName && typeof profile?.identity === "string") {
+          // Only use identity if it looks like an ENS name
+          if (profile.identity.endsWith(".eth") || profile.platform === "ens") {
+            partial.ensName = profile.identity;
           }
-          if (!partial.githubHandle) {
-            const parsedGithub = parseSocialRecord(
-              ensRecords["com.github"] ?? ensRecords["github"],
-              "github",
-            );
-            if (parsedGithub) {
-              partial.githubHandle = parsedGithub.handle;
-              partial.githubUrl = parsedGithub.url;
+        }
+        // Also check aliases for ENS names
+        if (!partial.ensName && Array.isArray(profile?.aliases)) {
+          for (const alias of profile.aliases) {
+            if (typeof alias === "string" && alias.endsWith(".eth")) {
+              partial.ensName = alias;
+              break;
             }
           }
         }
-        enstateMetadata[addr] = partial;
+
+        if (!partial.ensAvatarUrl && typeof profile?.avatar === "string") {
+          partial.ensAvatarUrl = profile.avatar;
+        }
+        if (!partial.primaryAddress && typeof profile?.address === "string") {
+          partial.primaryAddress = normalizeAddress(profile.address);
+        }
+
+        // Extract social links from web3.bio response
+        const socials = extractWeb3BioSocials(profile?.links);
+        if (!partial.twitterHandle && socials.twitterHandle) {
+          partial.twitterHandle = socials.twitterHandle;
+          partial.twitterUrl = socials.twitterUrl;
+        }
+        if (!partial.githubHandle && socials.githubHandle) {
+          partial.githubHandle = socials.githubHandle;
+          partial.githubUrl = socials.githubUrl;
+        }
+
+        metadata[addr] = partial;
       }
     }
   } catch (error) {
-    console.error("Failed to fetch ENS metadata from enstate.rs", error);
+    console.error("Failed to fetch profile metadata from web3.bio", error);
+  }
+
+  // Fallback: enstate.rs for addresses not resolved by web3.bio
+  const unresolvedAddresses = uniqueAddresses.filter(
+    (addr) => !metadata[addr]?.ensName,
+  );
+
+  if (unresolvedAddresses.length > 0) {
+    try {
+      const batches = chunk(unresolvedAddresses, ENSTATE_BATCH_SIZE);
+      const batchResults = await Promise.allSettled(
+        batches.map(async (batch) => {
+          if (batch.length === 0) return [];
+          const url = new URL("https://enstate.rs/bulk/a");
+          for (const addr of batch) {
+            url.searchParams.append("addresses[]", addr);
+          }
+          const response = await deps.fetchFn(url.toString(), {
+            signal: AbortSignal.timeout(10000), // 10 second timeout per batch
+          });
+          if (!response.ok) {
+            return [];
+          }
+          const json = await response.json();
+          return Array.isArray(json?.response) ? json.response : [];
+        }),
+      );
+
+      for (const result of batchResults) {
+        if (result.status !== "fulfilled") continue;
+        const records = result.value;
+        for (const record of records) {
+          const addr = normalizeAddress(record?.address || "");
+          if (!addr) continue;
+          const partial = metadata[addr] ?? {};
+          if (!partial.ensName && typeof record?.name === "string") {
+            partial.ensName = record.name;
+          }
+          if (!partial.ensAvatarUrl && typeof record?.avatar === "string") {
+            partial.ensAvatarUrl = record.avatar;
+          }
+          if (!partial.primaryAddress && typeof record?.chains?.eth === "string") {
+            partial.primaryAddress = normalizeAddress(record.chains.eth);
+          }
+          const ensRecords = record?.records;
+          if (ensRecords && typeof ensRecords === "object") {
+            if (!partial.twitterHandle) {
+              const parsedTwitter = parseSocialRecord(
+                ensRecords["com.twitter"] ??
+                  ensRecords["twitter"] ??
+                  ensRecords["com.x"] ??
+                  ensRecords["x"],
+                "twitter",
+              );
+              if (parsedTwitter) {
+                partial.twitterHandle = parsedTwitter.handle;
+                partial.twitterUrl = parsedTwitter.url;
+              }
+            }
+            if (!partial.githubHandle) {
+              const parsedGithub = parseSocialRecord(
+                ensRecords["com.github"] ?? ensRecords["github"],
+                "github",
+              );
+              if (parsedGithub) {
+                partial.githubHandle = parsedGithub.handle;
+                partial.githubUrl = parsedGithub.url;
+              }
+            }
+          }
+          metadata[addr] = partial;
+        }
+      }
+    } catch (error) {
+      console.error("Failed to fetch ENS metadata from enstate.rs (fallback)", error);
+    }
   }
 
   // Build final metadata entries for all addresses
   // Addresses without ENS data will have null values (graceful handling)
   const entries = uniqueAddresses.map((address) => {
-    const existing = enstateMetadata[address] ?? {};
+    const existing = metadata[address] ?? {};
     const ensName: string | null = existing.ensName ?? null;
     const ensAvatarUrl: string | null = existing.ensAvatarUrl ?? null;
     const twitterHandle: string | null = existing.twitterHandle ?? null;

--- a/src/pages/api/token/directory.ts
+++ b/src/pages/api/token/directory.ts
@@ -1,14 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { chunk } from "lodash";
-import { formatUnits, type Address } from "viem";
-import { mainnet } from "viem/chains";
-import { createConfig } from "wagmi";
-import {
-  getEnsName as wagmiGetEnsName,
-  getEnsAvatar as wagmiGetEnsAvatar,
-} from "wagmi/actions";
-import { http } from "@wagmi/core";
+import { formatUnits } from "viem";
 
 import requestHandler, {
   type BlankspaceResponse,
@@ -121,29 +114,7 @@ type DirectoryErrorResponse = {
 type DirectoryDependencies = {
   fetchFn: typeof fetch;
   neynarClient: typeof neynar;
-  getEnsNameFn: (address: Address) => Promise<string | null>;
-  getEnsAvatarFn: (name: string) => Promise<string | null>;
 };
-
-let ensLookupConfig: ReturnType<typeof createConfig> | null = null;
-
-function getEnsLookupConfig() {
-  if (!ensLookupConfig) {
-    const apiKey = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY;
-    if (!apiKey) {
-      throw new Error("NEXT_PUBLIC_ALCHEMY_API_KEY is not configured");
-    }
-
-    ensLookupConfig = createConfig({
-      chains: [mainnet],
-      transports: {
-        [mainnet.id]: http(`${ALCHEMY_API("eth")}v2/${apiKey}`),
-      },
-    });
-  }
-
-  return ensLookupConfig;
-}
 
 function ensureAlchemyApiKey(): string {
   const apiKey = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY;
@@ -229,8 +200,6 @@ function normalizeAlchemyOwnerRecord(
 const defaultDependencies: DirectoryDependencies = {
   fetchFn: fetch,
   neynarClient: neynar,
-  getEnsNameFn: (address) => wagmiGetEnsName(getEnsLookupConfig(), { address }),
-  getEnsAvatarFn: (name) => wagmiGetEnsAvatar(getEnsLookupConfig(), { name }),
 };
 
 type EnsMetadata = {
@@ -579,15 +548,18 @@ async function fetchMoralisTokenHolders(
   };
 }
 
+const ENSTATE_BATCH_SIZE = 50;
+const ENSDATA_BATCH_SIZE = 50;
+
+/**
+ * Fetches ENS metadata for a list of addresses
+ * Uses Enstate.rs for bulk lookups, with ensdata.net as fallback
+ * Gracefully handles addresses without ENS names (returns null values)
+ */
 async function fetchEnsMetadata(
   addresses: string[],
   deps: DirectoryDependencies,
 ): Promise<Record<string, EnsMetadata>> {
-  const apiKey = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY;
-  if (!apiKey) {
-    return {};
-  }
-
   const uniqueAddresses = Array.from(
     new Set(
       addresses
@@ -601,8 +573,8 @@ async function fetchEnsMetadata(
   }
 
   const enstateMetadata: Record<string, Partial<EnsMetadata>> = {};
-  const ENSTATE_BATCH_SIZE = 50;
 
+  // Primary: bulk lookup via Enstate.rs
   try {
     for (const batch of chunk(uniqueAddresses, ENSTATE_BATCH_SIZE)) {
       if (batch.length === 0) continue;
@@ -659,63 +631,114 @@ async function fetchEnsMetadata(
       }
     }
   } catch (error) {
-    console.error("Failed to fetch ENS social metadata", error);
+    console.error("Failed to fetch ENS metadata from enstate.rs", error);
   }
 
-  const entries = await Promise.all(
-    uniqueAddresses.map(async (address) => {
-      const viemAddress = address as Address;
-      const existing = enstateMetadata[address] ?? {};
-      let ensName: string | null = existing.ensName ?? null;
-      let ensAvatarUrl: string | null = existing.ensAvatarUrl ?? null;
-      const twitterHandle: string | null = existing.twitterHandle ?? null;
-      const twitterUrl: string | null = existing.twitterUrl ?? null;
-      const githubHandle: string | null = existing.githubHandle ?? null;
-      const githubUrl: string | null = existing.githubUrl ?? null;
-      const primaryAddress: string | null = existing.primaryAddress
-        ? normalizeAddress(existing.primaryAddress)
-        : null;
-
-      try {
-        const resolvedName = await deps.getEnsNameFn(viemAddress);
-        if (resolvedName) {
-          ensName = ensName ?? resolvedName;
-        }
-        if (!ensAvatarUrl && ensName) {
-          try {
-            ensAvatarUrl = await deps.getEnsAvatarFn(ensName);
-          } catch (avatarError) {
-            console.error(
-              `Failed to resolve ENS avatar for ${ensName}`,
-              avatarError,
-            );
-          }
-        }
-      } catch (error) {
-        console.error(
-          `Failed to resolve ENS metadata for address ${address}`,
-          error,
-        );
-      }
-
-      return [
-        address,
-        {
-          ensName: ensName ?? null,
-          ensAvatarUrl: ensAvatarUrl ?? null,
-          twitterHandle: twitterHandle ?? null,
-          twitterUrl:
-            twitterUrl ??
-            (twitterHandle ? `https://twitter.com/${twitterHandle}` : null),
-          githubHandle: githubHandle ?? null,
-          githubUrl:
-            githubUrl ??
-            (githubHandle ? `https://github.com/${githubHandle}` : null),
-          primaryAddress,
-        },
-      ] as const;
-    }),
+  // Fallback: use ensdata.net for addresses not resolved by enstate.rs
+  const unresolvedAddresses = uniqueAddresses.filter(
+    (addr) => !enstateMetadata[addr]?.ensName,
   );
+
+  if (unresolvedAddresses.length > 0) {
+    try {
+      for (const batch of chunk(unresolvedAddresses, ENSDATA_BATCH_SIZE)) {
+        // ensdata.net supports individual lookups; fetch in parallel with timeout
+        const results = await Promise.allSettled(
+          batch.map(async (addr) => {
+            try {
+              const response = await deps.fetchFn(`https://ensdata.net/${addr}`, {
+                signal: AbortSignal.timeout(5000),
+              });
+              if (!response.ok) return null;
+              const data = await response.json();
+              return { address: addr, data };
+            } catch {
+              return null;
+            }
+          }),
+        );
+
+        for (const result of results) {
+          if (result.status !== "fulfilled" || !result.value) continue;
+          const { address: addr, data } = result.value;
+          if (!data || typeof data !== "object") continue;
+
+          const partial = enstateMetadata[addr] ?? {};
+          if (!partial.ensName && typeof data.ens === "string") {
+            partial.ensName = data.ens;
+          }
+          if (!partial.ensAvatarUrl && typeof data.avatar === "string") {
+            partial.ensAvatarUrl = data.avatar;
+          }
+          if (!partial.primaryAddress && typeof data.address === "string") {
+            partial.primaryAddress = normalizeAddress(data.address);
+          }
+          // ensdata.net may include records in different format
+          const records = data.records;
+          if (records && typeof records === "object") {
+            if (!partial.twitterHandle) {
+              const parsedTwitter = parseSocialRecord(
+                records["com.twitter"] ??
+                  records["twitter"] ??
+                  records["com.x"] ??
+                  records["x"],
+                "twitter",
+              );
+              if (parsedTwitter) {
+                partial.twitterHandle = parsedTwitter.handle;
+                partial.twitterUrl = parsedTwitter.url;
+              }
+            }
+            if (!partial.githubHandle) {
+              const parsedGithub = parseSocialRecord(
+                records["com.github"] ?? records["github"],
+                "github",
+              );
+              if (parsedGithub) {
+                partial.githubHandle = parsedGithub.handle;
+                partial.githubUrl = parsedGithub.url;
+              }
+            }
+          }
+          enstateMetadata[addr] = partial;
+        }
+      }
+    } catch (error) {
+      console.error("Failed to fetch ENS metadata from ensdata.net", error);
+    }
+  }
+
+  // Build final metadata entries for all addresses
+  // Addresses without ENS data will have null values (graceful handling)
+  const entries = uniqueAddresses.map((address) => {
+    const existing = enstateMetadata[address] ?? {};
+    const ensName: string | null = existing.ensName ?? null;
+    const ensAvatarUrl: string | null = existing.ensAvatarUrl ?? null;
+    const twitterHandle: string | null = existing.twitterHandle ?? null;
+    const twitterUrl: string | null = existing.twitterUrl ?? null;
+    const githubHandle: string | null = existing.githubHandle ?? null;
+    const githubUrl: string | null = existing.githubUrl ?? null;
+    const primaryAddress: string | null = existing.primaryAddress
+      ? normalizeAddress(existing.primaryAddress)
+      : null;
+
+    return [
+      address,
+      {
+        ensName,
+        ensAvatarUrl,
+        twitterHandle,
+        twitterUrl:
+          twitterUrl ??
+          (twitterHandle ? `https://twitter.com/${twitterHandle}` : null),
+        githubHandle,
+        githubUrl:
+          githubUrl ??
+          (githubHandle ? `https://github.com/${githubHandle}` : null),
+        primaryAddress,
+      },
+    ] as const;
+  });
 
   return Object.fromEntries(entries);
 }

--- a/src/pages/api/token/directory.ts
+++ b/src/pages/api/token/directory.ts
@@ -629,7 +629,7 @@ async function fetchEnsMetadata(
         const ids = batch.map((addr) => `ethereum,${addr}`).join(",");
         const url = `https://api.web3.bio/profile/batch/${encodeURIComponent(ids)}`;
         const response = await deps.fetchFn(url, {
-          signal: AbortSignal.timeout(10000), // 10 second timeout per batch
+          signal: AbortSignal.timeout(5000), // 5 second timeout per batch
         });
         if (!response.ok) {
           return [];
@@ -706,7 +706,7 @@ async function fetchEnsMetadata(
             url.searchParams.append("addresses[]", addr);
           }
           const response = await deps.fetchFn(url.toString(), {
-            signal: AbortSignal.timeout(10000), // 10 second timeout per batch
+            signal: AbortSignal.timeout(5000), // 5 second timeout per batch
           });
           if (!response.ok) {
             return [];

--- a/src/pages/api/token/directory.ts
+++ b/src/pages/api/token/directory.ts
@@ -549,12 +549,14 @@ async function fetchMoralisTokenHolders(
 }
 
 const ENSTATE_BATCH_SIZE = 50;
-const ENSDATA_BATCH_SIZE = 50;
 
 /**
- * Fetches ENS metadata for a list of addresses
- * Uses Enstate.rs for bulk lookups, with ensdata.net as fallback
- * Gracefully handles addresses without ENS names (returns null values)
+ * Fetches ENS metadata for a list of addresses using Enstate.rs bulk lookups.
+ * Gracefully handles addresses without ENS names (returns null values).
+ *
+ * Note: We only use enstate.rs for ENS resolution to avoid timeouts.
+ * Most token holders don't have ENS names, so additional fallback APIs
+ * would just add latency without meaningful benefit.
  */
 async function fetchEnsMetadata(
   addresses: string[],
@@ -574,20 +576,30 @@ async function fetchEnsMetadata(
 
   const enstateMetadata: Record<string, Partial<EnsMetadata>> = {};
 
-  // Primary: bulk lookup via Enstate.rs
+  // Bulk lookup via Enstate.rs (parallel batches for speed)
   try {
-    for (const batch of chunk(uniqueAddresses, ENSTATE_BATCH_SIZE)) {
-      if (batch.length === 0) continue;
-      const url = new URL("https://enstate.rs/bulk/a");
-      for (const addr of batch) {
-        url.searchParams.append("addresses[]", addr);
-      }
-      const response = await deps.fetchFn(url.toString());
-      if (!response.ok) {
-        continue;
-      }
-      const json = await response.json();
-      const records: any[] = Array.isArray(json?.response) ? json.response : [];
+    const batches = chunk(uniqueAddresses, ENSTATE_BATCH_SIZE);
+    const batchResults = await Promise.allSettled(
+      batches.map(async (batch) => {
+        if (batch.length === 0) return [];
+        const url = new URL("https://enstate.rs/bulk/a");
+        for (const addr of batch) {
+          url.searchParams.append("addresses[]", addr);
+        }
+        const response = await deps.fetchFn(url.toString(), {
+          signal: AbortSignal.timeout(10000), // 10 second timeout per batch
+        });
+        if (!response.ok) {
+          return [];
+        }
+        const json = await response.json();
+        return Array.isArray(json?.response) ? json.response : [];
+      }),
+    );
+
+    for (const result of batchResults) {
+      if (result.status !== "fulfilled") continue;
+      const records = result.value;
       for (const record of records) {
         const addr = normalizeAddress(record?.address || "");
         if (!addr) continue;
@@ -632,80 +644,6 @@ async function fetchEnsMetadata(
     }
   } catch (error) {
     console.error("Failed to fetch ENS metadata from enstate.rs", error);
-  }
-
-  // Fallback: use ensdata.net for addresses not resolved by enstate.rs
-  const unresolvedAddresses = uniqueAddresses.filter(
-    (addr) => !enstateMetadata[addr]?.ensName,
-  );
-
-  if (unresolvedAddresses.length > 0) {
-    try {
-      for (const batch of chunk(unresolvedAddresses, ENSDATA_BATCH_SIZE)) {
-        // ensdata.net supports individual lookups; fetch in parallel with timeout
-        const results = await Promise.allSettled(
-          batch.map(async (addr) => {
-            try {
-              const response = await deps.fetchFn(`https://ensdata.net/${addr}`, {
-                signal: AbortSignal.timeout(5000),
-              });
-              if (!response.ok) return null;
-              const data = await response.json();
-              return { address: addr, data };
-            } catch {
-              return null;
-            }
-          }),
-        );
-
-        for (const result of results) {
-          if (result.status !== "fulfilled" || !result.value) continue;
-          const { address: addr, data } = result.value;
-          if (!data || typeof data !== "object") continue;
-
-          const partial = enstateMetadata[addr] ?? {};
-          if (!partial.ensName && typeof data.ens === "string") {
-            partial.ensName = data.ens;
-          }
-          if (!partial.ensAvatarUrl && typeof data.avatar === "string") {
-            partial.ensAvatarUrl = data.avatar;
-          }
-          if (!partial.primaryAddress && typeof data.address === "string") {
-            partial.primaryAddress = normalizeAddress(data.address);
-          }
-          // ensdata.net may include records in different format
-          const records = data.records;
-          if (records && typeof records === "object") {
-            if (!partial.twitterHandle) {
-              const parsedTwitter = parseSocialRecord(
-                records["com.twitter"] ??
-                  records["twitter"] ??
-                  records["com.x"] ??
-                  records["x"],
-                "twitter",
-              );
-              if (parsedTwitter) {
-                partial.twitterHandle = parsedTwitter.handle;
-                partial.twitterUrl = parsedTwitter.url;
-              }
-            }
-            if (!partial.githubHandle) {
-              const parsedGithub = parseSocialRecord(
-                records["com.github"] ?? records["github"],
-                "github",
-              );
-              if (parsedGithub) {
-                partial.githubHandle = parsedGithub.handle;
-                partial.githubUrl = parsedGithub.url;
-              }
-            }
-          }
-          enstateMetadata[addr] = partial;
-        }
-      }
-    } catch (error) {
-      console.error("Failed to fetch ENS metadata from ensdata.net", error);
-    }
   }
 
   // Build final metadata entries for all addresses

--- a/tests/tokenDirectory.api.test.ts
+++ b/tests/tokenDirectory.api.test.ts
@@ -45,13 +45,6 @@ describe("token directory API", () => {
           json: async () => ({ response: [] }),
         } as any;
       }
-      // ensdata.net fallback for addresses without ENS from enstate.rs
-      if (url.startsWith("https://ensdata.net/")) {
-        return {
-          ok: false,
-          status: 404,
-        } as any;
-      }
       throw new Error(`Unexpected fetch call: ${url}`);
     });
 
@@ -82,8 +75,8 @@ describe("token directory API", () => {
       },
     );
 
-    // 3 calls: moralis, enstate.rs, ensdata.net fallback
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    // 2 calls: moralis, enstate.rs (no more ensdata.net fallback)
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     const [moralisCall, enstateCall] = fetchMock.mock.calls;
     expect(moralisCall[0]).toContain(
       "https://deep-index.moralis.io/api/v2.2/erc20/0x000000000000000000000000000000000000ABCD/owners",
@@ -180,13 +173,6 @@ describe("token directory API", () => {
           }),
         } as any;
       }
-      // ensdata.net fallback for addresses without ENS from enstate.rs
-      if (url.startsWith("https://ensdata.net/")) {
-        return {
-          ok: false,
-          status: 404,
-        } as any;
-      }
       throw new Error(`Unexpected fetch call: ${url}`);
     });
 
@@ -207,8 +193,8 @@ describe("token directory API", () => {
       },
     );
 
-    // 4 calls: 2 alchemy, 1 enstate.rs, 1 ensdata.net fallback
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    // 3 calls: 2 alchemy, 1 enstate.rs (no more ensdata.net fallback)
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     const alchemyCalls = fetchMock.mock.calls.filter(([url]) =>
       (typeof url === "string" ? url : url.toString()).includes("alchemy.com"),
     );
@@ -283,13 +269,6 @@ describe("token directory API", () => {
               },
             ],
           }),
-        } as any;
-      }
-      // ensdata.net fallback for addresses without ENS from enstate.rs
-      if (url.startsWith("https://ensdata.net/")) {
-        return {
-          ok: false,
-          status: 404,
         } as any;
       }
       throw new Error(`Unexpected fetch call: ${url}`);

--- a/tests/tokenDirectory.api.test.ts
+++ b/tests/tokenDirectory.api.test.ts
@@ -222,7 +222,7 @@ describe("token directory API", () => {
     expect((alchemyCalls[1][0] as string).toLowerCase()).toContain("pagekey=next-page");
 
     expect(result.members).toHaveLength(2);
-    // ENS data comes from enstate.rs only now (no wagmi fallback)
+    // ENS data comes from web3.bio mock; enstate.rs fallback returns empty
     expect(result.members[0]).toMatchObject({
       address: "0x000000000000000000000000000000000000aaaa",
       balanceRaw: "2",


### PR DESCRIPTION
## Summary
- Fix FUNCTION_INVOCATION_TIMEOUT errors when generating directories for ERC20/NFT tokens
- Replace Alchemy-based ENS resolution with free public APIs (web3.bio + enstate.rs)
- Optimize API calls with parallel batch requests and proper timeouts

## Changes
- **Primary ENS provider**: web3.bio batch API (max 30 addresses per request)
- **Fallback**: enstate.rs bulk API (max 50 addresses per request)
- **Removed**: Alchemy/wagmi individual RPC calls that caused 429 rate limits
- **Removed**: ensdata.net fallback that made hundreds of sequential requests
- **Added**: 5-second timeout per batch request to prevent hanging
- **Added**: Parallel batch execution via Promise.allSettled

## Root Cause
The original implementation made individual Alchemy RPC calls for every address to resolve ENS names, causing:
1. HTTP 429 rate limit errors from Alchemy
2. Hundreds of sequential requests for addresses without ENS names
3. Function invocation timeouts on Vercel (25s limit)

## Test plan
- [x] Unit tests pass (`npx vitest run tests/tokenDirectory.api.test.ts`)
- [ ] Test directory generation with ERC20 token
- [ ] Test directory generation with NFT collection
- [ ] Verify ENS names resolve correctly for addresses that have them
- [ ] Verify addresses without ENS gracefully show as null

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Switched ENS metadata retrieval to web3.bio as primary source with enstate.rs fallback, using batched requests and per-batch timeouts for more reliable, faster results.
  * Enhanced extraction of Twitter and GitHub handles/URLs from profile data.

* **Breaking Changes**
  * Removed previously exposed ENS lookup hooks from the public dependency surface; integrations relying on those hooks need updating.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->