### PR TITLE
Disable prefetch on directory profile links

### DIFF
--- a/src/fidgets/farcaster/components/CastRow.tsx
+++ b/src/fidgets/farcaster/components/CastRow.tsx
@@ -637,6 +637,7 @@ const CastReactions = ({ cast }: { cast: CastWithInteractions }) => {
             href={`/c/${encodeURIComponent((cast.channel.id || cast.channel.name).toString())}`}
             className="mt-1.5 flex items-center text-sm opacity-60 transition-colors hover:text-blue-500 focus:text-blue-500 py-1 px-1.5 rounded-md"
             onClick={(event) => event.stopPropagation()}
+            prefetch={false}
           >
             /{cast.channel.name}
           </Link>

--- a/src/fidgets/farcaster/components/linkify.tsx
+++ b/src/fidgets/farcaster/components/linkify.tsx
@@ -28,6 +28,7 @@ const renderMention = ({ content }: RenderFunctionArgs) => {
     <Link
       className="cursor-pointer text-blue-500 text-font-medium hover:underline hover:text-blue-500/70"
       href={`/s/${handleWithoutAt}`}
+      prefetch={false}
     >
       {content}
     </Link>

--- a/src/fidgets/token/ClankerManager.tsx
+++ b/src/fidgets/token/ClankerManager.tsx
@@ -780,6 +780,7 @@ const ClankerManagerFidget: React.FC<FidgetArgs<ClankerManagerSettings>> = ({
             >
               <Link
                 href={tokenSpaceHref}
+                prefetch={false}
                 className="group flex flex-col gap-3 rounded-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 sm:flex-row sm:items-center sm:justify-between"
                 style={{
                   color: "inherit",

--- a/src/fidgets/token/Directory/components/ProfileLink.tsx
+++ b/src/fidgets/token/Directory/components/ProfileLink.tsx
@@ -28,7 +28,7 @@ export const ProfileLink: React.FC<ProfileLinkProps> = ({
 
   if (username) {
     return (
-      <Link href={href} className={baseClassName}>
+      <Link href={href} prefetch={false} className={baseClassName}>
         {children}
       </Link>
     );


### PR DESCRIPTION
## Summary
Disable Next.js Link prefetching on directory profile links to reduce excessive server requests.

## Problem
When viewing a directory page with many members, Next.js automatically prefetches all `/s/[username]` profile pages when they enter the viewport. This caused hundreds of unnecessary requests visible in Vercel logs.

## Solution
Add `prefetch={false}` to the Next.js Link component in ProfileLink.tsx.

## Test plan
- [ ] Deploy and view a directory page with many members
- [ ] Check Vercel logs - should no longer see excessive `/s/[username]` requests
- [ ] Verify profile links still work correctly when clicked

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled automatic prefetching for profile, mention, and channel links to reduce background network activity and improve navigation predictability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->