### PR TITLE
Fix navigation font color inheritance in sidebar items

### DIFF
--- a/src/common/components/organisms/FidgetPickerModal.tsx
+++ b/src/common/components/organisms/FidgetPickerModal.tsx
@@ -14,6 +14,7 @@ import { Input } from "../atoms/input";
 import Image from "next/image";
 
 import { Search, AlertTriangle, CheckCircle2 } from "lucide-react";
+import { useUIColors } from "@/common/lib/hooks/useUIColors";
 
 // Tag configuration for consistent styling - Core 8 categories
 const TAG_CONFIG: Record<string, { color: string; icon: string | any; displayName?: string }> = {
@@ -103,6 +104,7 @@ export const FidgetPickerModal: React.FC<FidgetPickerModalProps> = ({
   setCurrentlyDragging,
   generateFidgetInstance,
 }) => {
+  const uiColors = useUIColors();
   const [fidgetOptions, setFidgetOptions] = useState<FidgetOption[]>([]);
   // State for selected tags (single selection)
   const [selectedTag, setSelectedTag] = useState<string>('');
@@ -306,7 +308,7 @@ export const FidgetPickerModal: React.FC<FidgetPickerModalProps> = ({
       }
       return (
         <span
-          className="text-lg leading-none text-black group-hover:text-black"
+          className="text-lg leading-none text-inherit group-hover:text-inherit"
           role="img"
           aria-label={option.name}
         >
@@ -347,16 +349,19 @@ export const FidgetPickerModal: React.FC<FidgetPickerModalProps> = ({
           className="group w-full h-16 flex items-center gap-3 p-2 bg-transparent transform-gpu transition-transform will-change-transform hover:scale-[1.02]"
           onClick={() => handleFidgetSelect(option)}
         >
-          <Card className={`w-full h-full flex items-center p-3 rounded-lg ${
+          <Card className={`w-full h-full flex items-center p-3 rounded-lg border-0 ${
             isUnverifiedMiniApp 
-              ? 'bg-amber-50 border border-amber-200' 
+              ? 'bg-amber-50' 
               : 'bg-[rgba(128,128,128,0.2)]'
           }`}>
-            <CardContent className="overflow-hidden flex items-center gap-4 p-0 w-full">
+            <CardContent
+              className="overflow-hidden flex items-center gap-4 p-0 w-full"
+              style={{ color: uiColors.fontColor }}
+            >
               <div className="flex items-center justify-center w-8 h-8 flex-shrink-0 relative">
                 {renderIcon()}
                 <span
-                  className="text-lg leading-none text-black group-hover:text-black hidden"
+                  className="text-lg leading-none text-inherit group-hover:text-inherit hidden"
                   role="img"
                   aria-label={option.name}
                 >
@@ -365,7 +370,10 @@ export const FidgetPickerModal: React.FC<FidgetPickerModalProps> = ({
               </div>
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2 mb-1.5">
-                  <span className="text-sm font-medium text-black text-left leading-none group-hover:text-black truncate">
+                  <span
+                    className="text-sm font-medium text-inherit text-left leading-none group-hover:text-inherit truncate"
+                    style={{ color: uiColors.fontColor }}
+                  >
                     {option.name}
                   </span>
                   {/* Verification badge */}
@@ -380,7 +388,10 @@ export const FidgetPickerModal: React.FC<FidgetPickerModalProps> = ({
                     </span>
                   )}
                 </div>
-                <p className="text-xs text-gray-600 text-left leading-tight truncate">
+                <p
+                  className="text-xs text-inherit text-left leading-tight truncate opacity-50"
+                  style={{ color: uiColors.fontColor }}
+                >
                   {isUnverifiedMiniApp 
                     ? 'Third-party mini-app - may not work as expected'
                     : option.description

--- a/src/common/components/organisms/FidgetPickerModal.tsx
+++ b/src/common/components/organisms/FidgetPickerModal.tsx
@@ -350,7 +350,7 @@ export const FidgetPickerModal: React.FC<FidgetPickerModalProps> = ({
           <Card className={`w-full h-full flex items-center p-3 rounded-lg ${
             isUnverifiedMiniApp 
               ? 'bg-amber-50 border border-amber-200' 
-              : 'bg-[#F3F4F6]'
+              : 'bg-[rgba(128,128,128,0.2)]'
           }`}>
             <CardContent className="overflow-hidden flex items-center gap-4 p-0 w-full">
               <div className="flex items-center justify-center w-8 h-8 flex-shrink-0 relative">

--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -669,7 +669,7 @@ const Navigation = React.memo(
                     label={navEditMode ? "Exit Edit" : "Edit Nav"}
                     Icon={navEditMode ? LogoutIcon : () => (
                       <div className="w-6 h-6 flex items-center justify-center">
-                        <FaPencil className="w-4 h-4 text-gray-800 dark:text-white" />
+                        <FaPencil className="w-4 h-4" />
                       </div>
                     )}
                     onClick={() => {
@@ -808,7 +808,7 @@ const Navigation = React.memo(
                   <Link
                     href={discordUrl}
                     className={mergeClasses(
-                      "flex items-center p-2 text-gray-900 rounded-lg dark:text-white group w-full gap-2 text-lg font-medium",
+                      "flex items-center p-2 text-inherit rounded-lg dark:text-white group w-full gap-2 text-lg font-medium",
                       shrunk ? "justify-center gap-0" : ""
                     )}
                     style={navTextStyle}
@@ -820,7 +820,7 @@ const Navigation = React.memo(
                   </Link>
                 )}
                 <div
-                  className="flex flex-col items-center text-xs text-gray-500 mt-5"
+                  className="flex flex-col items-center text-xs text-inherit mt-5"
                   style={navTextStyle}
                 >
                   <Link href="/terms" className="hover:underline">

--- a/src/common/components/organisms/navigation/NavigationItem.tsx
+++ b/src/common/components/organisms/navigation/NavigationItem.tsx
@@ -114,7 +114,7 @@ const NavigationItemComponent: React.FC<NavigationItemProps> = ({
         href={disable ? "#" : href}
         className={mergeClasses(
           "flex relative items-center p-2 text-inherit rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 w-full group",
-          isSelected ? "bg-gray-100" : "",
+          isSelected ? "bg-[rgba(128,128,128,0.2)]" : "",
           shrunk ? "justify-center" : "",
           disable ? "opacity-50 cursor-not-allowed pointer-events-none" : ""
         )}

--- a/src/common/components/organisms/navigation/NavigationItem.tsx
+++ b/src/common/components/organisms/navigation/NavigationItem.tsx
@@ -113,7 +113,7 @@ const NavigationItemComponent: React.FC<NavigationItemProps> = ({
       <Link
         href={disable ? "#" : href}
         className={mergeClasses(
-          "flex relative items-center p-2 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 w-full group",
+          "flex relative items-center p-2 text-inherit rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 w-full group",
           isSelected ? "bg-gray-100" : "",
           shrunk ? "justify-center" : "",
           disable ? "opacity-50 cursor-not-allowed pointer-events-none" : ""
@@ -202,7 +202,7 @@ const NavigationButtonComponent: React.FC<NavigationButtonProps> = ({
       <button
         disabled={disable}
         className={mergeClasses(
-          "flex relative items-center p-2 text-gray-900 rounded-lg dark:text-white w-full group",
+          "flex relative items-center p-2 text-inherit rounded-lg dark:text-white w-full group",
           "hover:bg-gray-100 dark:hover:bg-gray-700",
           shrunk ? "justify-center" : "",
           disable ? "opacity-50 cursor-not-allowed pointer-events-none" : ""
@@ -241,4 +241,3 @@ export const NavigationButton = React.memo(
     );
   }
 );
-


### PR DESCRIPTION
### Motivation

- Navigation item text and icon colors were not inheriting the community `ui_config` `fontColor` because components contained hard-coded color classes that override the themed value.

### Description

- Replaced hard-coded Tailwind color classes on navigation links and buttons with `text-inherit` so they inherit the nav font color from `navTextStyle`/CSS variables (changed in `src/common/components/organisms/navigation/NavigationItem.tsx`).
- Removed explicit color classes from the edit pencil icon to avoid forcing a gray color (changed in `src/common/components/organisms/Navigation.tsx`).
- Adjusted footer/social link and small-footer text classes to `text-inherit` so those elements also respect the configured nav font color (changed in `src/common/components/organisms/Navigation.tsx`).

### Testing

- Started the dev server with `yarn dev`, which reported Next.js ready (server started successfully).  
- Attempted an automated visual check via Playwright screenshot, but the Playwright run timed out and did not complete.  
- No unit tests or snapshot tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697913d69e588325a1f24dccb0a970de)