### PR TITLE
Reuse shared web3.bio socials helper

### DIFF
--- a/src/common/data/api/token/enrichEns.ts
+++ b/src/common/data/api/token/enrichEns.ts
@@ -10,7 +10,7 @@ const ENSTATE_BATCH_SIZE = 50;
 /**
  * Extracts social handles from web3.bio links array
  */
-function extractWeb3BioSocials(links: Record<string, any> | undefined): {
+export function extractWeb3BioSocials(links: Record<string, any> | undefined): {
   twitterHandle: string | null;
   twitterUrl: string | null;
   githubHandle: string | null;

--- a/src/pages/api/token/directory.ts
+++ b/src/pages/api/token/directory.ts
@@ -7,6 +7,7 @@ import requestHandler, {
   type BlankspaceResponse,
 } from "@/common/data/api/requestHandler";
 import neynar from "@/common/data/api/neynar";
+import { extractWeb3BioSocials } from "@/common/data/api/token/enrichEns";
 import { fetchTokenData } from "@/common/lib/utils/fetchTokenData";
 import type { EtherScanChainName } from "@/constants/etherscanChainIds";
 import { ALCHEMY_API } from "@/constants/urls";
@@ -552,46 +553,6 @@ async function fetchMoralisTokenHolders(
 const WEB3BIO_BATCH_SIZE = 30;
 // enstate.rs supports up to 50 addresses per batch (used as fallback)
 const ENSTATE_BATCH_SIZE = 50;
-
-/**
- * Extracts social handles from web3.bio links array
- */
-function extractWeb3BioSocials(links: Record<string, any> | undefined): {
-  twitterHandle: string | null;
-  twitterUrl: string | null;
-  githubHandle: string | null;
-  githubUrl: string | null;
-} {
-  let twitterHandle: string | null = null;
-  let twitterUrl: string | null = null;
-  let githubHandle: string | null = null;
-  let githubUrl: string | null = null;
-
-  if (!links || typeof links !== "object") {
-    return { twitterHandle, twitterUrl, githubHandle, githubUrl };
-  }
-
-  // web3.bio returns links as an object with platform keys
-  const twitter = links.twitter || links.x;
-  if (twitter && typeof twitter === "object") {
-    const handle = twitter.handle || twitter.identity;
-    if (typeof handle === "string" && handle) {
-      twitterHandle = handle.replace(/^@/, "");
-      twitterUrl = twitter.link || `https://twitter.com/${twitterHandle}`;
-    }
-  }
-
-  const github = links.github;
-  if (github && typeof github === "object") {
-    const handle = github.handle || github.identity;
-    if (typeof handle === "string" && handle) {
-      githubHandle = handle.replace(/^@/, "");
-      githubUrl = github.link || `https://github.com/${githubHandle}`;
-    }
-  }
-
-  return { twitterHandle, twitterUrl, githubHandle, githubUrl };
-}
 
 /**
  * Fetches profile metadata for addresses using web3.bio API (primary)

--- a/tests/tokenDirectory.api.test.ts
+++ b/tests/tokenDirectory.api.test.ts
@@ -222,7 +222,7 @@ describe("token directory API", () => {
     expect((alchemyCalls[1][0] as string).toLowerCase()).toContain("pagekey=next-page");
 
     expect(result.members).toHaveLength(2);
-    // ENS data comes from enstate.rs only now (no wagmi fallback)
+    // ENS data comes from web3.bio mock; enstate.rs fallback returns empty
     expect(result.members[0]).toMatchObject({
       address: "0x000000000000000000000000000000000000aaaa",
       balanceRaw: "2",


### PR DESCRIPTION
### Motivation
- Centralize the `web3.bio` socials extraction logic to avoid duplicated implementations and keep parsing behavior consistent across ENS enrichment and the token directory API.
- Clarify a misleading test comment so the test accurately documents that ENS data in that scenario is provided by the `web3.bio` mock.

### Description
- Exported the helper `extractWeb3BioSocials` from `src/common/data/api/token/enrichEns.ts` by changing its declaration to `export function extractWeb3BioSocials(...)`.
- Removed the duplicate `extractWeb3BioSocials` implementation from `src/pages/api/token/directory.ts` and imported it with `import { extractWeb3BioSocials } from "@/common/data/api/token/enrichEns"`.
- Updated the comment near the assertion in `tests/tokenDirectory.api.test.ts` to state that ENS data in the test comes from the `web3.bio` mock and that the `enstate.rs` fallback returns empty.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69793e934a188325a15fc931f736d029)