### PR TITLE
feat: show loading skeleton only for grid while space loads

### DIFF
--- a/src/app/(spaces)/SpacePage.tsx
+++ b/src/app/(spaces)/SpacePage.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef, useEffect } from "react";
+import React, { ReactNode } from "react";
 import Space, { SpaceConfig, SpaceConfigSaveDetails } from "./Space";
 import { useSidebarContext } from "@/common/components/organisms/Sidebar";
 
@@ -24,37 +24,6 @@ export default function SpacePage({
   feed,
   showFeedOnMobile,
 }: SpacePageArgs) {
-  
-  // Create a stable deferred promise that won't change across renders
-  const deferredRef = useRef<{
-    promise: Promise<void>;
-    resolve: () => void;
-  } | null>(null);
-
-  // Initialize the deferred promise once
-  if (!deferredRef.current) {
-    let resolve: () => void;
-    const promise = new Promise<void>((res) => {
-      resolve = res;
-    });
-    deferredRef.current = {
-      promise,
-      resolve: resolve!,
-    };
-  }
-
-  // Watch for config becoming defined and resolve the deferred
-  useEffect(() => {
-    if (config && deferredRef.current) {
-      deferredRef.current.resolve();
-    }
-  }, [config]);
-
-  // If config is undefined, throw the stable promise to trigger Suspense fallback
-  if (!config) {
-    throw deferredRef.current.promise;
-  }
-  
   const { editMode, setEditMode, setSidebarEditable, portalRef } =
     useSidebarContext();
 


### PR DESCRIPTION
- Add loading state tracking to spaceStore (loadingTabs, checkedTabs)
- Track when tabs start loading and when database check completes
- Update Space component to accept undefined config
- Show SpaceLoading skeleton only for grid content while loading
- Keep profile header and tab bar visible during grid load
- Remove promise-throwing pattern from SpacePage

This improves UX by showing partial content immediately while the grid data loads from the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness when configuration data is unavailable with graceful fallbacks
  * Enhanced tracking of tab loading states and verification status for better user feedback

* **Refactor**
  * Optimized configuration resolution logic to account for loading and verification states
  * Simplified data flow for space and tab content rendering

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->