### PR TITLE
chore: exclude docs-site build files from eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,18 @@ const compat = new FlatCompat({
 });
 
 export default defineConfig([
-    globalIgnores(["**/node_modules/", "**/dist/", "**/.next/", "src/assets", "**/*.config.js", "**/*.config.mjs", "**/next-env.d.ts", "**/public/sw.js"]),
+    globalIgnores([
+        "**/node_modules/",
+        "**/dist/",
+        "**/.next/",
+        "src/assets",
+        "**/*.config.js",
+        "**/*.config.mjs",
+        "**/next-env.d.ts",
+        "**/public/sw.js",
+        "docs-site/build/",
+        "docs-site/.docusaurus/",
+    ]),
     {
         extends: [
             ...compat.extends("eslint:recommended"),


### PR DESCRIPTION
## Summary
- Add `docs-site/build/` and `docs-site/.docusaurus/` to eslint's globalIgnores
- Prevents lint errors from compiled documentation files blocking commits

## Test plan
- [x] Pre-commit hook now passes without needing `--no-verify`
- [ ] Verify eslint still catches issues in source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint configuration to expand the global ignore list by including additional build and documentation directories. Reformatted configuration for improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->