### PR TITLE
build: strip console.log statements in production

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -71,6 +71,12 @@ const cspHeader = `
 const nextConfig = {
   // output: 'export', // Outputs a Single-Page Application (SPA).
   // distDir: './dist', // Changes the build output directory to `./dist/`.
+  compiler: {
+    // Remove console.log in production builds (keep console.error and console.warn)
+    removeConsole: process.env.NODE_ENV === 'production' ? {
+      exclude: ['error', 'warn'],
+    } : false,
+  },
   transpilePackages: [
     "react-tweet", 
     "react-best-gradient-color-picker",


### PR DESCRIPTION
## Summary
- Configure Next.js SWC compiler to remove console statements in production builds
- Removes: `console.log`, `console.debug`, `console.info`
- Keeps: `console.error`, `console.warn` (useful for production debugging)

## Why
There are 571 console statements across 143 files. Rather than manually updating each one, this build-time solution automatically strips them in production.

## Test plan
- [ ] Verify console.logs appear in development (`npm run dev`)
- [ ] Verify console.logs are stripped in production build (`npm run build && npm run start`)
- [ ] Verify console.error and console.warn still work in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to optimize console logging in production environments. Error and warning messages are preserved for debugging while other console output is suppressed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->