### PR TITLE
Use transparent colors for highlights and warnings

### DIFF
--- a/src/common/components/organisms/FidgetPickerModal.tsx
+++ b/src/common/components/organisms/FidgetPickerModal.tsx
@@ -350,8 +350,8 @@ export const FidgetPickerModal: React.FC<FidgetPickerModalProps> = ({
           onClick={() => handleFidgetSelect(option)}
         >
           <Card className={`w-full h-full flex items-center p-3 rounded-lg border-0 ${
-            isUnverifiedMiniApp 
-              ? 'bg-amber-50' 
+            isUnverifiedMiniApp
+              ? 'bg-[rgba(245,158,11,0.15)]'
               : 'bg-[rgba(128,128,128,0.2)]'
           }`}>
             <CardContent

--- a/src/common/components/organisms/navigation/NavigationEditor.tsx
+++ b/src/common/components/organisms/navigation/NavigationEditor.tsx
@@ -428,7 +428,7 @@ const NavigationEditorComponent: React.FC<NavigationEditorProps> = ({
                           toast.success("Navigation item deleted");
                         }
                       }}
-                      className="p-1 hover:bg-red-100 rounded opacity-0 group-hover:opacity-100 transition-opacity ml-auto"
+                      className="p-1 hover:bg-[rgba(239,68,68,0.2)] rounded opacity-0 group-hover:opacity-100 transition-opacity ml-auto"
                       aria-label={`Delete ${item.label}`}
                       title={`Delete ${item.label}`}
                     >

--- a/src/common/components/organisms/navigation/NavigationItem.tsx
+++ b/src/common/components/organisms/navigation/NavigationItem.tsx
@@ -118,7 +118,7 @@ const NavigationItemComponent: React.FC<NavigationItemProps> = ({
       <Link
         href={disable ? "#" : href}
         className={mergeClasses(
-          "flex relative items-center p-0 text-inherit rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 w-full group min-h-[40px]",
+          "flex relative items-center p-0 text-inherit rounded-lg dark:text-white hover:bg-[rgba(128,128,128,0.15)] w-full group min-h-[40px]",
           isSelected ? "bg-[rgba(128,128,128,0.2)]" : "",
           disable ? "opacity-50 cursor-not-allowed pointer-events-none" : ""
         )}
@@ -224,7 +224,7 @@ const NavigationButtonComponent: React.FC<NavigationButtonProps> = ({
         disabled={disable}
         className={mergeClasses(
           "flex relative items-center p-0 text-inherit rounded-lg dark:text-white w-full group min-h-[40px]",
-          "hover:bg-gray-100 dark:hover:bg-gray-700",
+          "hover:bg-[rgba(128,128,128,0.15)]",
           disable ? "opacity-50 cursor-not-allowed pointer-events-none" : ""
         )}
         onClick={onClick}


### PR DESCRIPTION
Replace absolute background colors with transparent rgba values so they work correctly on any background color:

- Navigation hover: gray-100/gray-700 → rgba(128,128,128,0.15)
- Delete button hover: red-100 → rgba(239,68,68,0.2)
- Unverified mini-app warning: amber-50 → rgba(245,158,11,0.15)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated background colors for unverified mini-app options with a subtle orange tint
  * Refined hover effects on navigation and delete button elements for improved visual consistency throughout the interface

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->