### PR TITLE
Set default channel from community config in cast modal

### DIFF
--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -498,6 +498,29 @@ const CreateCast: React.FC<CreateCastProps> = ({
     },
   });
 
+  // Set default channel from community config if available
+  useEffect(() => {
+    const communityChannel = systemConfig?.community?.social?.farcaster;
+    if (!communityChannel || !setChannel) return;
+
+    // Only set default if no channel is currently selected
+    const currentChannel = getChannel();
+    if (currentChannel) return;
+
+    const setDefaultChannel = async () => {
+      const channels = await fetchChannelsByName(communityChannel);
+      // Find exact match for the community channel
+      const matchingChannel = channels.find(
+        (ch) => ch.id?.toLowerCase() === communityChannel.toLowerCase()
+      );
+      if (matchingChannel) {
+        setChannel(matchingChannel);
+      }
+    };
+
+    setDefaultChannel();
+  }, [systemConfig, setChannel, getChannel]);
+
   const debouncedPasteUpload = useMemo(
     () =>
       debounce(


### PR DESCRIPTION
When opening the cast modal, if the community has a Farcaster channel configured (community.social.farcaster), automatically select it as the default channel. Only sets the default if no channel is already selected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default Farcaster channel is now automatically initialized from system configuration when creating a new cast, eliminating the need for manual selection on startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->