### PR TITLE
Fix home navigation not loading after logout

### DIFF
--- a/src/common/components/organisms/Navigation.tsx
+++ b/src/common/components/organisms/Navigation.tsx
@@ -194,9 +194,10 @@ const Navigation = React.memo(
 
   const router = useRouter();
 
-  function handleLogout() {
-    router.push("/home");
-    logout();
+  async function handleLogout() {
+    await logout();
+    // Redirect to root, which will redirect to the first nav item
+    router.push("/");
   }
   
   // For backwards compatibility with code that uses configuredNavItems


### PR DESCRIPTION
Two issues fixed:
1. Call logout() BEFORE router.push() to avoid race condition where the new page tries to use state that gets cleared mid-render
2. Redirect to "/" instead of "/home" - the root page properly redirects to the first navigation item, which handles communities where "/home" might not be a valid nav item

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed logout flow to ensure the logout process completes before redirecting the user.
  * Updated the post-logout redirect destination.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->