### PR TITLE
Fix tab name edit mode causing underline to jump

### DIFF
--- a/src/common/components/atoms/editable-text.tsx
+++ b/src/common/components/atoms/editable-text.tsx
@@ -54,7 +54,8 @@ const EditableText = ({
   return isEditing ? (
     <input
       value={text}
-      className="bg-transparent border-none outline-none w-full min-w-0"
+      className="bg-transparent border-none outline-none text-center"
+      style={{ width: `${Math.max(text.length, 1)}ch` }}
       maxLength={maxLength}
       onKeyDown={(event) => {
         if (isEnterOrEscapeKeyEvent(event)) {


### PR DESCRIPTION
## Summary
- Changed input from `w-full` to auto-sized width using `ch` units
- Added `text-center` to keep text centered within the input
- Prevents the tab from expanding when switching to edit mode, which was causing the underline to shift

## Test plan
- [ ] Double-click on a tab name to enter edit mode
- [ ] Verify the underline stays in place and doesn't jump
- [ ] Verify text remains centered while editing
- [ ] Test with various tab name lengths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the input field to dynamically adjust its width based on text content and centered alignment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->