### PR TITLE
Make PWA manifest dynamic based on community config

### DIFF
--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,22 +1,39 @@
 import type { MetadataRoute } from 'next'
+import { loadSystemConfig } from '@/config'
+import { resolveBaseUrl } from '@/common/lib/utils/resolveBaseUrl'
+import { resolveAssetUrl } from '@/common/lib/utils/resolveAssetUrl'
 
-export default function manifest(): MetadataRoute.Manifest {
+// Force dynamic rendering so manifest is generated at request time (not build time)
+// This ensures the PWA name and icons match the actual domain/community config
+export const dynamic = 'force-dynamic'
+
+export default async function manifest(): Promise<MetadataRoute.Manifest> {
+  const config = await loadSystemConfig()
+  const baseUrl = await resolveBaseUrl({ systemConfig: config })
+
+  // Resolve the community icon URL, falling back to default if not available
+  const iconUrl = resolveAssetUrl(config.assets.logos.icon, baseUrl) ?? config.assets.logos.icon
+
+  // Get theme color from UI config if available
+  const themeColor = config.ui?.primaryColor ?? '#000000'
+  const backgroundColor = config.ui?.backgroundColor ?? '#ffffff'
+
   return {
-    name: 'Nounspace',
-    short_name: 'Nounspace',
-    description: 'The customizable web3 social app built on Farcaster',
+    name: config.brand.displayName,
+    short_name: config.brand.displayName,
+    description: config.brand.description,
     start_url: '/',
     display: 'standalone',
-    background_color: '#ffffff',
-    theme_color: '#000000',
+    background_color: backgroundColor,
+    theme_color: themeColor,
     icons: [
       {
-        src: '/app/icon-192x192.png',
+        src: iconUrl,
         sizes: '192x192',
         type: 'image/png',
       },
       {
-        src: '/app/icon-512x512.png',
+        src: iconUrl,
         sizes: '512x512',
         type: 'image/png',
       },


### PR DESCRIPTION
## Summary
- PWA manifest now loads community config at request time
- Sets name/short_name from `brand.displayName` instead of hardcoded "Nounspace"
- Sets description from `brand.description`
- Uses community icon from `assets.logos.icon`
- Applies theme colors from UI config (`primaryColor`, `backgroundColor`)

This allows each community to have its own branded PWA installation experience with the correct name and icon.

## Test plan
- [ ] Visit a community site and check the manifest at `/manifest.webmanifest`
- [ ] Verify the name matches the community's displayName
- [ ] Verify the icon URL points to the community's icon
- [ ] Test PWA installation to confirm the app name and icon are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)