### PR TITLE
Fix default channel not being set when Home channel is active

### DIFF
--- a/src/fidgets/farcaster/components/CreateCast.tsx
+++ b/src/fidgets/farcaster/components/CreateCast.tsx
@@ -503,9 +503,10 @@ const CreateCast: React.FC<CreateCastProps> = ({
     const communityChannel = systemConfig?.community?.social?.farcaster;
     if (!communityChannel || !setChannel) return;
 
-    // Only set default if no channel is currently selected
+    // Only set default if no real channel is currently selected
+    // The "Home" channel has id: '' which means posting to followers, not a real channel
     const currentChannel = getChannel();
-    if (currentChannel) return;
+    if (currentChannel?.id) return;
 
     const setDefaultChannel = async () => {
       const channels = await fetchChannelsByName(communityChannel);


### PR DESCRIPTION
## Summary
- The Home channel (posting to followers) has an empty `id: ''`
- The previous check `if (currentChannel)` exited early because the object exists, even though no real Farcaster channel was selected
- Changed to `if (currentChannel?.id)` to only skip when an actual channel with an ID is selected

## Test plan
- [ ] Open a community with a farcaster channel configured (e.g., nouns)
- [ ] Open the cast modal
- [ ] Verify the channel is automatically set to the community's channel (e.g., /nouns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel selection behavior when creating a cast—the app now properly defaults to a community channel even when "Home" is the current selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->