### PR TITLE
Fix double-click on tab name in edit mode causing page reload

### DIFF
--- a/src/common/components/atoms/editable-text.tsx
+++ b/src/common/components/atoms/editable-text.tsx
@@ -71,9 +71,9 @@ const EditableText = ({
         e.stopPropagation();
       }}
       onDoubleClick={(e) => {
-        // Prevent navigation when double-clicking on input (select all text)
+        // Stop propagation to prevent navigation, but don't preventDefault
+        // so that the browser's native text selection on double-click works
         e.stopPropagation();
-        e.preventDefault();
       }}
       autoFocus
     />

--- a/src/common/components/atoms/reorderable-tab.tsx
+++ b/src/common/components/atoms/reorderable-tab.tsx
@@ -56,12 +56,24 @@ export const Tab = ({
       onTouchStart={() => preloadTabData && preloadTabData(tabName)}
     >
       <Link
-        href={getSpacePageUrl(tabName)}
+        href={inEditMode && isSelected ? "#" : getSpacePageUrl(tabName)}
         draggable={false}
         onClick={(e) => {
-          if (!inEditMode) {
+          // Prevent navigation for selected items in edit mode (matches NavigationEditor pattern)
+          // Allow normal Link navigation for non-selected items
+          if (inEditMode && isSelected) {
+            e.preventDefault();
+            e.stopPropagation();
+          } else {
             e.preventDefault();
             onClick(tabName, e);
+          }
+        }}
+        onDoubleClick={(e) => {
+          // Prevent navigation on double-click for selected items in edit mode
+          if (inEditMode && isSelected) {
+            e.preventDefault();
+            e.stopPropagation();
           }
         }}
         onDragStart={(e) => e.preventDefault()}


### PR DESCRIPTION
## Summary
- When editing a tab name, double-clicking to select text was triggering page navigation/reload
- Updated to match the NavigationEditor pattern for consistency

## Changes
- **reorderable-tab.tsx**: 
  - Change `href` to `"#"` when `inEditMode && isSelected` (prevents navigation)
  - Add `stopPropagation()` in addition to `preventDefault()` on click/doubleClick handlers
- **editable-text.tsx**: 
  - Keep `stopPropagation()` but remove `preventDefault()` on double-click so native text selection works

## Test plan
- [ ] Enter edit mode on a space by clicking the pencil icon
- [ ] Double-click a tab name to enter rename mode
- [ ] Double-click again on the text to select all - should select text, not reload page
- [ ] Verify normal tab clicking still works when not in edit mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)